### PR TITLE
bug fixed: corrected the embedding post data format in glmapi/requester.ts by fixing a typo

### DIFF
--- a/packages/chatglm-adapter/src/requester.ts
+++ b/packages/chatglm-adapter/src/requester.ts
@@ -129,7 +129,7 @@ export class OpenLLMRequester
 
         try {
             const response = await this._post('embeddings', {
-                inout: params.input,
+                input: params.input,
                 model: params.model
             })
 


### PR DESCRIPTION
Corrected the post data format in glmapi/requester.ts by fixing a typo

Changes: field "inout" change into "input"

```typescript
    async embeddings(params) {
        // eslint-disable-next-line @typescript-eslint/no-explicit-any
        let data;
        try {
            const response = await this._post('embeddings', {
                inout: params.input, // change into: input: params.input 
                model: params.model
            });
            data = await response.text();
            data = JSON.parse(data);
            if (data.data && data.data.length > 0) {
                return data.data.map((it) => it.embedding);
            }
            throw new Error();
        }
        catch (e) {
            const error = new Error('error when calling embeddings, Result: ' + JSON.stringify(data));
            error.stack = e.stack;
            error.cause = e.cause;
            throw new error_1.ChatHubError(error_1.ChatHubErrorCode.API_REQUEST_FAILED, error);
        }
    }
```