### PR TITLE
fix: satori changed image to img

### DIFF
--- a/packages/core/src/middlewares/read_chat_message.ts
+++ b/packages/core/src/middlewares/read_chat_message.ts
@@ -51,7 +51,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     )
 
     ctx.chatluna.messageTransformer.intercept(
-        'image',
+        'img',
         async (session, element, message) => {
             const images: string[] = message.additional_kwargs.images ?? []
 


### PR DESCRIPTION
https://github.com/satorijs/satori/pull/223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- 修复了聊天消息中图片类型标识的错误，将 `'image'` 更改为 `'img'`。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->