### PR TITLE
fix(core): satori changed "url" attributes to "src"

### DIFF
--- a/packages/core/src/middlewares/read_chat_message.ts
+++ b/packages/core/src/middlewares/read_chat_message.ts
@@ -55,7 +55,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         async (session, element, message) => {
             const images: string[] = message.additional_kwargs.images ?? []
 
-            const url = element.attrs['url'] as string
+            const url = (element.attrs.url ?? element.attrs.src) as string
 
             console.debug(`image url: ${url}`)
 


### PR DESCRIPTION
it's a compatibility motivated tiny change. no details.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 更新了聊天消息中URL值的获取方式，现在会检查`element.attrs.url`和`element.attrs.src`以获取URL值。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->