### PR TITLE
 fix(zhipu-adapter): fix messageChunk duplicated appending in another way 

### DIFF
--- a/packages/zhipu-adapter/src/requester.ts
+++ b/packages/zhipu-adapter/src/requester.ts
@@ -121,10 +121,9 @@ export class ZhipuRequester
                     defaultRole
                 )
 
-                messageChunk.content = content + messageChunk.content
-
                 if (!findTools) {
-                    content = messageChunk.content;
+                    content = (content + messageChunk.content)
+                    messageChunk.content = content
                 }
 
                 defaultRole = (delta.role ??

--- a/packages/zhipu-adapter/src/requester.ts
+++ b/packages/zhipu-adapter/src/requester.ts
@@ -124,8 +124,7 @@ export class ZhipuRequester
                 messageChunk.content = content + messageChunk.content
 
                 if (!findTools) {
-                    content = (content + messageChunk.content) as string
-                    messageChunk.content = content
+                    content = messageChunk.content;
                 }
 
                 defaultRole = (delta.role ??


### PR DESCRIPTION
fix issues refered in QQ group.

![f8c43b15063a696cc333886ae4516ed0](https://github.com/ChatLunaLab/chatluna/assets/19223209/833f138c-5f2a-48e3-ab65-14967c494b9a)
![d8be8ee260bbb660882c0d8a72a60c1f](https://github.com/ChatLunaLab/chatluna/assets/19223209/5b2cb40c-3f19-4fb3-8931-fde556e75871)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **功能更新**
	- 优化了内容更新逻辑，当不使用 `findTools` 时，直接将 `messageChunk.content` 赋值给 `content`。
	- 提升了用户体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->