### PR TITLE
feat(core): support `sender_id` in format_user_prompt for preset

### DIFF
--- a/packages/core/src/middlewares/request_model.ts
+++ b/packages/core/src/middlewares/request_model.ts
@@ -33,6 +33,10 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                     presetTemplate.formatUserPromptString,
                     {
                         sender: session.username,
+                        sender_id:
+                            session.author?.user?.id ??
+                            session.event?.user?.id ??
+                            '0',
                         prompt: context.message as string,
                         date: new Date().toLocaleString()
                     }


### PR DESCRIPTION
为预设中的 `format_user_prompt` 增加了 `sender_id` 变量占位符，
以便于用户可通过编写预设，让机器人能够通过用户ID区分用户。

一个例子：

```yml
format_user_prompt: '用户的名字是{sender}，他的用户ID是：{sender_id}，他对你说: {prompt}'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved request handling to include a `sender_id` field, enhancing user identification and session tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->