### PR TITLE
fix(core): typo in room visibility query

### DIFF
--- a/packages/core/src/chains/rooms.ts
+++ b/packages/core/src/chains/rooms.ts
@@ -59,7 +59,7 @@ export async function queryPublicConversationRoom(
             roomVisibility: {
                 // TODO: better type
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                $in: ['tempelate_clone', 'public'] as unknown as any
+                $in: ['template_clone', 'public'] as unknown as any
                 //    $in: ['template_clone', 'public']
             }
         }


### PR DESCRIPTION
一个单词拼写错误引起的bug

## 正常情况

当新用户在群组中首次触发对话，会检查群组中是否存在公开或模板克隆房间，并自动加入找到的房间。

## 异常情况

由于单词错误导致数据库查询找不到模板克隆房间，后续会导致每个新用户都会创建一个独立的对话房间。

## 影响范围

d1313f0b67aa5ebe1ba6a5c61459938a203f636d 后续提交均受影响，大约处于 v1.0.53 之后

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected a typographical error in a string value to ensure accurate functionality in the conversation room queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->