### PR TITLE
fix(core): revert incorrect time zone fixes

### DIFF
--- a/packages/core/src/middlewares/request_model.ts
+++ b/packages/core/src/middlewares/request_model.ts
@@ -263,20 +263,9 @@ function getSystemPromptVariables(
     config: Config,
     room: ConversationRoom
 ) {
-    const baseDate = new Date()
-
-    const date = new Date(
-        // current time
-        Date.now() -
-            // remove offset, get utc + 0
-            baseDate.getTimezoneOffset() * Time.minute +
-            // set the offset
-            Time.getTimezoneOffset() * Time.minute
-    )
-
     return {
         name: config.botName,
-        date: date.toLocaleString(),
+        date: new Date().toLocaleString(),
         bot_id: session.bot.selfId,
         is_group: (!session.isDirect || session.guildId != null).toString(),
         is_private: session.isDirect?.toString(),
@@ -288,10 +277,9 @@ function getSystemPromptVariables(
             session.username
         ),
         noop: '',
-        time: date.toLocaleTimeString(),
+        time: new Date().toLocaleTimeString(),
         weekday: getCurrentWeekday(),
         idle_duration: getTimeDiffFormat(
-            // get raw date
             new Date().getTime(),
             room.updatedTime.getTime()
         )

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -54,7 +54,7 @@ export function getCurrentWeekday() {
 
 export const getTimeInUTC = (offset: number): string => {
     const date = new Date()
-    date.setMinutes(date.getMinutes() + date.getTimezoneOffset() + offset * 60)
+    date.setMinutes(date.getMinutes() + offset * 60)
     return date.toISOString().substring(11, 8)
 }
 


### PR DESCRIPTION
The previous fix was still wrong. This fix makes sure that all "local" datetimes use the environment (process.env.TZ) time zone, and that offsets are not applied twice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new middleware for processing incoming messages and formatting user prompts in the chat service.
  
- **Improvements**
	- Enhanced date and time calculations for better accuracy in various functions.
	- Streamlined message handling and error management in chat interactions.

- **Bug Fixes**
	- Corrected logic for UTC date calculations to ensure accurate time representation.

- **Documentation**
	- Updated function signatures to reflect changes in logic while maintaining compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->