### PR TITLE
[Fix] 修复 Zod 工具调用兼容性和消息延迟中间件问题

### DIFF
--- a/packages/claude-adapter/src/utils.ts
+++ b/packages/claude-adapter/src/utils.ts
@@ -19,7 +19,7 @@ import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { fetchImageUrl } from '@chatluna/v1-shared-adapter'
 import { isMessageContentImageUrl } from 'koishi-plugin-chatluna/utils/string'
 import { logger } from '.'
-import { ZodSchema } from 'zod'
+import { isZodSchemaV3 } from '@langchain/core/utils/types'
 
 export async function langchainMessageToClaudeMessage(
     messages: BaseMessage[],
@@ -219,10 +219,9 @@ export function formatToolsToClaudeTools(
 }
 
 export function formatToolToClaudeTool(tool: StructuredTool): CluadeTool {
-    const inputSchema =
-        tool.schema instanceof ZodSchema
-            ? zodToJsonSchema(tool.schema as never)
-            : tool.schema
+    const inputSchema = isZodSchemaV3(tool.schema)
+        ? zodToJsonSchema(tool.schema as never)
+        : tool.schema
 
     delete inputSchema['$schema']
     delete inputSchema['additionalProperties']

--- a/packages/core/src/middlewares/chat/message_delay.ts
+++ b/packages/core/src/middlewares/chat/message_delay.ts
@@ -17,6 +17,7 @@ interface MessageBatch {
     userName: string
     resolveWaiters: ((status?: ChainMiddlewareRunStatus) => void)[]
     timeout?: Disposable
+    processorResolve?: (status: ChainMiddlewareRunStatus) => void
 }
 
 const batches = new Map<string, MessageBatch>()
@@ -51,18 +52,23 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 batches.set(conversationId, newBatch)
 
                 if (config.messageQueueDelay > 0) {
-                    newBatch.timeout = ctx.setTimeout(() => {
-                        if (batches.get(conversationId) === newBatch) {
-                            logger.debug(
-                                `Delay timeout for ${conversationId}, processing batch with ${newBatch.messages.length} messages`
-                            )
-                            context.options.inputMessage = mergeMessages(
-                                newBatch.messages
-                            )
-                            batches.delete(conversationId)
+                    return await new Promise<ChainMiddlewareRunStatus>(
+                        (resolve) => {
+                            newBatch.processorResolve = resolve
+                            newBatch.timeout = ctx.setTimeout(() => {
+                                if (batches.get(conversationId) === newBatch) {
+                                    logger.debug(
+                                        // eslint-disable-next-line max-len
+                                        `Delay timeout (${config.messageQueueDelay}) for ${conversationId}, processing batch with ${newBatch.messages.length} messages`
+                                    )
+                                    context.options.inputMessage =
+                                        mergeMessages(newBatch.messages)
+                                    batches.delete(conversationId)
+                                    resolve(ChainMiddlewareRunStatus.CONTINUE)
+                                }
+                            }, config.messageQueueDelay * 1000)
                         }
-                    }, config.messageQueueDelay * 1000)
-                    return ChainMiddlewareRunStatus.STOP
+                    )
                 }
 
                 return ChainMiddlewareRunStatus.CONTINUE
@@ -72,7 +78,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 logger.debug(
                     `User mismatch for ${conversationId}, messageId: ${messageId}, waiting for batch completion`
                 )
-                return waitForBatchCompletion(
+                return await waitForBatchCompletion(
                     batch,
                     conversationId,
                     inputMessage,
@@ -87,17 +93,27 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 )
                 batch.messages.push(inputMessage)
 
-                if (config.messageQueueDelay > 0 && batch.timeout) {
+                if (
+                    config.messageQueueDelay > 0 &&
+                    batch.timeout &&
+                    batch.processorResolve
+                ) {
                     batch.timeout()
                     batch.timeout = ctx.setTimeout(() => {
-                        if (batches.get(conversationId) === batch) {
+                        if (
+                            batches.get(conversationId) === batch &&
+                            batch.processorResolve
+                        ) {
                             logger.debug(
-                                `Delay timeout for ${conversationId}, processing batch with ${batch.messages.length} messages`
+                                `Delay timeout (${config.messageQueueDelay}) for ${conversationId}, processing batch with ${batch.messages.length} messages`
                             )
                             context.options.inputMessage = mergeMessages(
                                 batch.messages
                             )
                             batches.delete(conversationId)
+                            batch.processorResolve(
+                                ChainMiddlewareRunStatus.CONTINUE
+                            )
                         }
                     }, config.messageQueueDelay * 1000)
                 }
@@ -108,7 +124,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             logger.debug(
                 `Interrupting and merging for ${conversationId}, messageId: ${messageId}`
             )
-            return interruptAndMerge(batch, inputMessage, context)
+            return await interruptAndMerge(batch, inputMessage, context)
         })
         .after('resolve_room')
         .after('read_chat_message')
@@ -125,11 +141,13 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             }
             batch.resolveWaiters.forEach((resolve) => resolve())
             batches.delete(conversationId)
-        } else {
-            logger.debug(`Cleaning up empty batch for ${conversationId}`)
-            const batch = batches.get(conversationId)
-            if (batch?.timeout) {
+        } else if (batch) {
+            logger.debug(`Cleaning up batch for ${conversationId}`)
+            if (batch.timeout) {
                 batch.timeout()
+            }
+            if (batch.processorResolve) {
+                batch.processorResolve(ChainMiddlewareRunStatus.STOP)
             }
             batches.delete(conversationId)
         }
@@ -147,6 +165,9 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             batch.resolveWaiters.forEach((resolve) =>
                 resolve(ChainMiddlewareRunStatus.STOP)
             )
+            if (batch.processorResolve) {
+                batch.processorResolve(ChainMiddlewareRunStatus.STOP)
+            }
             batches.delete(conversationId)
         }
     })
@@ -158,7 +179,10 @@ async function interruptAndMerge(
     context: ChainMiddlewareContext
 ): Promise<ChainMiddlewareRunStatus> {
     const oldWaiters = batch.resolveWaiters
+    const oldProcessor = batch.processorResolve
+
     batch.resolveWaiters = []
+    batch.processorResolve = undefined
     batch.messages.push(message)
 
     if (batch.timeout) {
@@ -167,6 +191,9 @@ async function interruptAndMerge(
     }
 
     oldWaiters.forEach((resolve) => resolve(ChainMiddlewareRunStatus.STOP))
+    if (oldProcessor) {
+        oldProcessor(ChainMiddlewareRunStatus.STOP)
+    }
 
     return new Promise((resolve) => {
         batch.resolveWaiters.push(() => {

--- a/packages/gemini-adapter/src/utils.ts
+++ b/packages/gemini-adapter/src/utils.ts
@@ -28,7 +28,7 @@ import {
     isMessageContentImageUrl,
     isMessageContentText
 } from 'koishi-plugin-chatluna/utils/string'
-import { ZodSchema } from 'zod'
+import { isZodSchemaV3 } from '@langchain/core/utils/types'
 
 export async function langchainMessageToGeminiMessage(
     messages: BaseMessage[],
@@ -326,7 +326,7 @@ export function formatToolToGeminiAITool(
     tool: StructuredTool
 ): ChatCompletionFunction {
     const parameters = removeAdditionalProperties(
-        tool.schema instanceof ZodSchema
+        isZodSchemaV3(tool.schema)
             ? zodToJsonSchema(tool.schema as never, {
                   allowedAdditionalProperties: undefined
               })

--- a/packages/hunyuan-adapter/src/utils.ts
+++ b/packages/hunyuan-adapter/src/utils.ts
@@ -17,7 +17,7 @@ import {
     ChatCompletionTool
 } from './types'
 import { removeAdditionalProperties } from '@chatluna/v1-shared-adapter'
-import { ZodSchema } from 'zod'
+import { isZodSchemaV3 } from '@langchain/core/utils/types'
 
 export function formatToolsToHunyuanTools(
     tools: StructuredTool[]
@@ -32,7 +32,7 @@ export function formatToolToHunyuanTool(
     tool: StructuredTool
 ): ChatCompletionTool {
     const parameters = removeAdditionalProperties(
-        tool.schema instanceof ZodSchema
+        isZodSchemaV3(tool.schema)
             ? zodToJsonSchema(tool.schema as never, {
                   allowedAdditionalProperties: undefined
               })

--- a/packages/qwen-adapter/src/utils.ts
+++ b/packages/qwen-adapter/src/utils.ts
@@ -22,7 +22,7 @@ import {
     removeAdditionalProperties
 } from '@chatluna/v1-shared-adapter'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
-import { ZodSchema } from 'zod'
+import { isZodSchemaV3 } from '@langchain/core/utils/types'
 
 export function formatToolsToQWenTools(
     tools: StructuredTool[]
@@ -35,7 +35,7 @@ export function formatToolsToQWenTools(
 
 export function formatToolToQWenTool(tool: StructuredTool): ChatCompletionTool {
     const parameters = removeAdditionalProperties(
-        tool.schema instanceof ZodSchema
+        isZodSchemaV3(tool.schema)
             ? zodToJsonSchema(tool.schema as never, {
                   allowedAdditionalProperties: undefined
               })

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -22,8 +22,8 @@ import {
     getImageMimeType,
     isMessageContentImageUrl
 } from 'koishi-plugin-chatluna/utils/string'
-import { ZodSchema } from 'zod'
 import { ToolCallChunk } from '@langchain/core/messages/tool'
+import { isZodSchemaV3 } from '@langchain/core/utils/types'
 
 export async function langchainMessageToOpenAIMessage(
     messages: BaseMessage[],
@@ -256,7 +256,7 @@ export function formatToolToOpenAITool(
     tool: StructuredTool
 ): ChatCompletionTool {
     const parameters = removeAdditionalProperties(
-        tool.schema instanceof ZodSchema
+        isZodSchemaV3(tool.schema)
             ? zodToJsonSchema(tool.schema as never, {
                   allowedAdditionalProperties: undefined
               })

--- a/packages/spark-adapter/src/utils.ts
+++ b/packages/spark-adapter/src/utils.ts
@@ -13,7 +13,7 @@ import {
     ChatCompletionMessageRoleEnum,
     ChatCompletionTool
 } from './types'
-import { ZodSchema } from 'zod'
+import { isZodSchemaV3 } from '@langchain/core/utils/types'
 
 export function langchainMessageToSparkMessage(
     messages: BaseMessage[],
@@ -147,7 +147,7 @@ export function formatToolToSparkTool(
     tool: StructuredTool
 ): ChatCompletionTool {
     const parameters = removeAdditionalProperties(
-        tool.schema instanceof ZodSchema
+        isZodSchemaV3(tool.schema)
             ? zodToJsonSchema(tool.schema as never, {
                   allowedAdditionalProperties: undefined
               })

--- a/packages/wenxin-adapter/src/utils.ts
+++ b/packages/wenxin-adapter/src/utils.ts
@@ -18,7 +18,7 @@ import {
 import { StructuredTool } from '@langchain/core/tools'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import { removeAdditionalProperties } from '@chatluna/v1-shared-adapter'
-import { ZodSchema } from 'zod'
+import { isZodSchemaV3 } from '@langchain/core/utils/types'
 
 export function langchainMessageToWenXinMessage(
     messages: BaseMessage[]
@@ -143,7 +143,7 @@ export function formatToolToWenxinTool(
     tool: StructuredTool
 ): ChatCompletionFunction {
     const parameters = removeAdditionalProperties(
-        tool.schema instanceof ZodSchema
+        isZodSchemaV3(tool.schema)
             ? zodToJsonSchema(tool.schema as never, {
                   allowedAdditionalProperties: undefined
               })

--- a/packages/zhipu-adapter/src/utils.ts
+++ b/packages/zhipu-adapter/src/utils.ts
@@ -24,7 +24,7 @@ import {
 } from '@chatluna/v1-shared-adapter'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { isMessageContentImageUrl } from 'koishi-plugin-chatluna/utils/string'
-import { ZodSchema } from 'zod'
+import { isZodSchemaV3 } from '@langchain/core/utils/types'
 
 export async function langchainMessageToZhipuMessage(
     messages: BaseMessage[],
@@ -303,7 +303,7 @@ export function formatToolToZhipuTool(
     tool: StructuredTool
 ): ChatCompletionTool {
     const parameters = removeAdditionalProperties(
-        tool.schema instanceof ZodSchema
+        isZodSchemaV3(tool.schema)
             ? zodToJsonSchema(tool.schema as never, {
                   allowedAdditionalProperties: undefined
               })


### PR DESCRIPTION
## 概要

修复所有适配器中的 Zod 架构类型检查，使用 `isZodSchemaV3` 替代 `instanceof ZodSchema`，并修复消息延迟中间件中的 timeout Promise 处理逻辑。

## Bug fixes

**修复 Zod 工具调用兼容性问题**
将所有适配器中的 `tool.schema instanceof ZodSchema` 检查替换为 `isZodSchemaV3(tool.schema)`，使用 `@langchain/core/utils/types` 提供的类型检查工具，提高 Zod 版本兼容性。

**修复消息延迟中间件 timeout 处理逻辑**
修复原有 timeout 回调无法继续执行中间件链的问题，将同步 timeout 回调改为基于 Promise 的异步执行流。

**修复批次处理逻辑不一致问题**
解决 timeout 后返回 CONTINUE 但下一行返回 STOP 的逻辑矛盾，引入 "批次处理者" 模式确保执行流一致性。

## Other Changes

**改进工具架构类型检查**
影响的适配器：claude, gemini, hunyuan, qwen, shared, spark, wenxin, zhipu

**增强消息批处理可靠性**
实现 `processorResolve` 机制，确保 timeout 后正确解析 Promise，在事件处理器和中断场景中正确清理 Promise resolver

**统一异步函数调用**
添加必要的 `await` 关键字，确保异步操作正确执行