### PR TITLE
chore: bump package versions to alpha.42/alpha.4

### DIFF
--- a/packages/azure-openai-adapter/package.json
+++ b/packages/azure-openai-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-azure-openai-adapter",
   "description": "azure openai adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -46,7 +46,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/claude-adapter/package.json
+++ b/packages/claude-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-claude-adapter",
   "description": "claude adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -47,7 +47,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.41",
+  "version": "1.3.0-alpha.42",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/deepseek-adapter/package.json
+++ b/packages/deepseek-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-deepseek-adapter",
   "description": "deepseek adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/dify-adapter/package.json
+++ b/packages/dify-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-dify-adapter",
   "description": "dify adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/doubao-adapter/package.json
+++ b/packages/doubao-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/embeddings-service/package.json
+++ b/packages/embeddings-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-embeddings-service",
   "description": "embeddings service for chatluna",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/gemini-adapter/package.json
+++ b/packages/gemini-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.0-alpha.8",
+  "version": "1.3.0-alpha.9",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/hunyuan-adapter/package.json
+++ b/packages/hunyuan-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-hunyuan-adapter",
   "description": "hunyuan adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/image-renderer/package.json
+++ b/packages/image-renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-image-renderer",
   "description": "image renderer for chatluna",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/image-service/package.json
+++ b/packages/image-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-image-service",
   "description": "image service for chatluna",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/long-memory/package.json
+++ b/packages/long-memory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-long-memory",
   "description": "long memory for chatluna",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/mcp-client/package.json
+++ b/packages/mcp-client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-mcp-client",
   "description": "MCP Client for ChatLuna",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0-alpha.3",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/ollama-adapter/package.json
+++ b/packages/ollama-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-ollama-adapter",
   "description": "ollama adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62"
   },
   "devDependencies": {
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/openai-adapter/package.json
+++ b/packages/openai-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-adapter",
   "description": "openai adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/openai-like-adapter/package.json
+++ b/packages/openai-like-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-like-adapter",
   "description": "openai style api adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/plugin-common/package.json
+++ b/packages/plugin-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-plugin-common",
   "description": "plugin service for agent mode of chatluna",
-  "version": "1.3.0-alpha.13",
+  "version": "1.3.0-alpha.14",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42",
     "koishi-plugin-chatluna-knowledge-chat": "^1.0.23",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },

--- a/packages/qwen-adapter/package.json
+++ b/packages/qwen-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/rwkv-adapter/package.json
+++ b/packages/rwkv-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-rmkv-adapter",
   "description": "rwkv adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod-to-json-schema": "3.23.5"
   },
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/search-service/package.json
+++ b/packages/search-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-search-service",
   "description": "search support for chatluna",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chatluna/v1-shared-adapter",
   "description": "chatluna shared adapter",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   }
 }

--- a/packages/spark-adapter/package.json
+++ b/packages/spark-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-spark-adapter",
   "description": "spark adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/variable-extension/package.json
+++ b/packages/variable-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-variable-extension",
   "description": "variable extension for ChatLuna",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/vector-store-service/package.json
+++ b/packages/vector-store-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-vector-store-service",
   "description": "vector store service for chatluna",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -78,7 +78,7 @@
     "@zilliz/milvus2-sdk-node": "^2.5.7",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42",
     "mongodb": "^6.15.0",
     "neo4j-driver": "^5.28.1"
   },

--- a/packages/wenxin-adapter/package.json
+++ b/packages/wenxin-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-wenxin-adapter",
   "description": "wenxin adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.5"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {

--- a/packages/zhipu-adapter/package.json
+++ b/packages/zhipu-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-zhipu-adapter",
   "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.8",
+    "@chatluna/v1-shared-adapter": "^1.0.9",
     "@langchain/core": "0.3.62",
     "jsonwebtoken": "^9.0.2",
     "zod": "3.25.76",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.7",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.41"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.42"
   },
   "koishi": {
     "description": {


### PR DESCRIPTION
## Summary
• Update core package to v1.3.0-alpha.42
• Bump all adapter packages to alpha.4 versions

## Changes
This PR includes version updates across all packages in the monorepo for the new release cycle.