### PR TITLE
Fix: Bump adapter versions and fix shared utils initialization

### DIFF
--- a/packages/azure-openai-adapter/package.json
+++ b/packages/azure-openai-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-azure-openai-adapter",
   "description": "azure openai adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/claude-adapter/package.json
+++ b/packages/claude-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-claude-adapter",
   "description": "claude adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/deepseek-adapter/package.json
+++ b/packages/deepseek-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-deepseek-adapter",
   "description": "deepseek adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/dify-adapter/package.json
+++ b/packages/dify-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-dify-adapter",
   "description": "dify adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/doubao-adapter/package.json
+++ b/packages/doubao-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/gemini-adapter/package.json
+++ b/packages/gemini-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.0-alpha.10",
+  "version": "1.3.0-alpha.11",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/hunyuan-adapter/package.json
+++ b/packages/hunyuan-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-hunyuan-adapter",
   "description": "hunyuan adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/ollama-adapter/package.json
+++ b/packages/ollama-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-ollama-adapter",
   "description": "ollama adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/openai-adapter/package.json
+++ b/packages/openai-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-adapter",
   "description": "openai adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/openai-like-adapter/package.json
+++ b/packages/openai-like-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-like-adapter",
   "description": "openai style api adapter for chatluna",
-  "version": "1.3.0-alpha.6",
+  "version": "1.3.0-alpha.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/qwen-adapter/package.json
+++ b/packages/qwen-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.0-alpha.6",
+  "version": "1.3.0-alpha.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/rwkv-adapter/package.json
+++ b/packages/rwkv-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-rmkv-adapter",
   "description": "rwkv adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -322,13 +322,13 @@ export function convertMessageToMessageChunk(
         (message.role?.length ?? 0) > 0 ? message.role : 'assistant'
     ).toLowerCase()
 
-    let additionalKwargs: {
+    const additionalKwargs: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention
         function_call?: any
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention
         tool_calls?: any
         reasoning_content?: string
-    }
+    } = {}
 
     if (reasoningContent.length > 0) {
         additionalKwargs.reasoning_content = reasoningContent

--- a/packages/spark-adapter/package.json
+++ b/packages/spark-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-spark-adapter",
   "description": "spark adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/wenxin-adapter/package.json
+++ b/packages/wenxin-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-wenxin-adapter",
   "description": "wenxin adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/zhipu-adapter/package.json
+++ b/packages/zhipu-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-zhipu-adapter",
   "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.0-alpha.5",
+  "version": "1.3.0-alpha.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
This PR bumps adapter package versions and fixes a shared utility initialization issue.

### New Features

N/A

### Bug fixes

- Fix additionalKwargs initialization in shared utils to prevent undefined assignment (packages/shared/src/utils.ts)

### Other Changes

- Bump most adapter packages from alpha.5 to alpha.6
- Bump openai-like-adapter from alpha.6 to alpha.7  
- Bump qwen-adapter from alpha.6 to alpha.7
- Bump gemini-adapter from alpha.10 to alpha.11

This ensures all adapters are on consistent version numbers and resolves potential runtime issues with uninitialized object properties in the shared utilities.