### PR TITLE
Fix: search-service typo and model reference issues

### DIFF
--- a/packages/search-service/package.json
+++ b/packages/search-service/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-search-service",
   "description": "search support for chatluna",
-  "version": "1.2.10",
+  "version": "1.3.0-alpha.0",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/search-service/src/index.ts
+++ b/packages/search-service/src/index.ts
@@ -66,7 +66,7 @@ export function apply(ctx: Context, config: Config) {
                     searchManager,
                     browserTool,
                     params.embeddings,
-                    keywordExtractModel?.value,
+                    browserModelRef,
                     summaryType
                 )
             },
@@ -77,9 +77,13 @@ export function apply(ctx: Context, config: Config) {
 
         plugin.registerTool('web_browser', {
             createTool(params) {
+                const summaryModel = computed(
+                    () => keywordExtractModel?.value ?? params.model
+                )
+
                 return new PuppeteerBrowserTool(
                     ctx,
-                    keywordExtractModel,
+                    summaryModel,
                     params.embeddings
                 )
             },
@@ -104,7 +108,7 @@ export function apply(ctx: Context, config: Config) {
                 )
 
                 const summaryModel = computed(
-                    () => keywordExtractModel.value ?? params.model
+                    () => keywordExtractModel?.value ?? params.model
                 )
 
                 const model = params.model
@@ -164,7 +168,7 @@ export interface Config extends ChatLunaPlugin.Config {
     topK: number
     summaryType: SummaryType
     summaryModel: string
-    mulitSourceMode: 'average' | 'total'
+    multiSourceMode: 'average' | 'total'
     searchFailedPrompt: string
 
     serperApiKey: string
@@ -221,10 +225,10 @@ export const Config: Schema<Config> = Schema.intersect([
             Schema.const('balanced'),
             Schema.const('quality')
         ]).default('speed') as Schema<Config['summaryType']>,
-        mulitSourceMode: Schema.union([
+        multiSourceMode: Schema.union([
             Schema.const('average'),
             Schema.const('total')
-        ]).default('average') as Schema<Config['mulitSourceMode']>,
+        ]).default('average') as Schema<Config['multiSourceMode']>,
         summaryModel: Schema.dynamic('model').default('empty'),
 
         searchThreshold: Schema.percent().step(0.01).default(0.25),

--- a/packages/search-service/src/provide.ts
+++ b/packages/search-service/src/provide.ts
@@ -81,7 +81,7 @@ export class SearchManager {
         const searchResults: SearchResult[] = []
 
         const signalLimit =
-            this.config.mulitSourceMode === 'average'
+            this.config.multiSourceMode === 'average'
                 ? Math.round(limit / providers.length)
                 : limit
 

--- a/packages/search-service/src/tools/search.ts
+++ b/packages/search-service/src/tools/search.ts
@@ -15,6 +15,7 @@ import { emptyEmbeddings } from 'koishi-plugin-chatluna/llm-core/model/in_memory
 import { logger } from '..'
 import { removeProperty } from '../utils/parse'
 import { ChatLunaToolRunnable } from 'koishi-plugin-chatluna/llm-core/platform/types'
+import { ComputedRef } from 'koishi-plugin-chatluna'
 
 export class SearchTool extends Tool {
     name = 'web_search'
@@ -27,13 +28,13 @@ export class SearchTool extends Tool {
         chunkOverlap: 100
     })
 
-    private llm: ChatLunaChatModel
+    private llm: ComputedRef<ChatLunaChatModel>
 
     constructor(
         private searchManager: SearchManager,
         private browserTool: PuppeteerBrowserTool,
         private embeddings: Embeddings,
-        llm: ChatLunaChatModel,
+        llm: ComputedRef<ChatLunaChatModel>,
         private summaryType: SummaryType
     ) {
         super({})
@@ -54,7 +55,7 @@ export class SearchTool extends Tool {
 
         const fakeSearchResult = await generateFakeSearchResult(
             arg,
-            this.llm ?? config.configurable.model
+            this.llm?.value ?? config.configurable.model
         )
 
         return JSON.stringify(


### PR DESCRIPTION
This PR fixes several issues in the search-service package that were causing errors in browser mode.

### Bug fixes

- Fix typo: `mulitSourceMode` → `multiSourceMode` in config schema and usage
- Fix model reference issues with proper null checking using optional chaining
- Update SearchTool to use `ComputedRef<ChatLunaChatModel>` for proper type safety
- Fix browserModelRef usage in web_search tool registration

### Other Changes

- Bump package version to 1.3.0-alpha.0 for next development cycle

Closes #561