### PR TITLE
[Fix] Improve error handling and migrate cache keys

### DIFF
--- a/packages/azure-openai-adapter/package.json
+++ b/packages/azure-openai-adapter/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/claude-adapter/package.json
+++ b/packages/claude-adapter/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.46",
+  "version": "1.3.0-alpha.47",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -138,7 +138,7 @@ class DatabaseCache {
         key: string,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         value: any,
-        maxAge: number = 1000 * 60 * 24
+        maxAge: number = 1000 * 60 * 60 * 24
     ) {
         const expire = maxAge ? new Date(Date.now() + maxAge) : null
         await this.ctx.database.upsert('cache', [

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -11,6 +11,11 @@ export class Cache<K extends keyof Tables, T extends Tables[K]> {
         public readonly tableName: K
     ) {
         this._cache = new DatabaseCache(ctx)
+        ctx.on('ready', async () => {
+            //  remove old data
+            await this._cache.clear('chathub/keys')
+            await this._cache.clear('chathub/chat_limit')
+        })
     }
 
     get<E extends keyof Tables>(tableName: E, id: string): Promise<Tables[E]>
@@ -66,7 +71,7 @@ export class Cache<K extends keyof Tables, T extends Tables[K]> {
 
 declare module '@koishijs/cache' {
     interface Tables {
-        'chathub/keys': string
+        'chatluna/keys': string
     }
 }
 
@@ -128,8 +133,13 @@ class DatabaseCache {
         return this.decode(entry.value)
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async set(table: string, key: string, value: any, maxAge?: number) {
+    async set(
+        table: string,
+        key: string,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        value: any,
+        maxAge: number = 1000 * 60 * 24
+    ) {
         const expire = maxAge ? new Date(Date.now() + maxAge) : null
         await this.ctx.database.upsert('cache', [
             {

--- a/packages/core/src/llm-core/chain/plugin_chat_chain.ts
+++ b/packages/core/src/llm-core/chain/plugin_chat_chain.ts
@@ -18,7 +18,7 @@ import {
     createReactAgent
 } from 'koishi-plugin-chatluna/llm-core/agent'
 import { BufferMemory } from 'koishi-plugin-chatluna/llm-core/memory/langchain'
-import { logger } from '../..'
+import { logger } from 'koishi-plugin-chatluna'
 import {
     ChatLunaError,
     ChatLunaErrorCode

--- a/packages/core/src/llm-core/utils/count_tokens.ts
+++ b/packages/core/src/llm-core/utils/count_tokens.ts
@@ -5,6 +5,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
+import { logger } from 'koishi-plugin-chatluna'
 
 // https://www.npmjs.com/package/js-tiktoken
 
@@ -192,8 +193,13 @@ export const getModelContextSize = (modelName: string): number => {
 }
 
 export function parseRawModelName(modelName: string): [string, string] {
-    if (modelName == null) {
-        throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
+    if (modelName == null || modelName.trim().length < 1) {
+        try {
+            throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
+        } catch (error) {
+            logger.error(error)
+        }
+        return [undefined, undefined]
     }
     return modelName.split(/(?<=^[^\/]+)\//) as [string, string]
 }

--- a/packages/core/src/middlewares/chat/chat_time_limit_check.ts
+++ b/packages/core/src/middlewares/chat/chat_time_limit_check.ts
@@ -1,9 +1,5 @@
 import { Context, Session } from 'koishi'
 import { parseRawModelName } from 'koishi-plugin-chatluna/llm-core/utils/count_tokens'
-import {
-    ChatLunaError,
-    ChatLunaErrorCode
-} from 'koishi-plugin-chatluna/utils/error'
 import { ChatHubAuthGroup } from '../../authorization/types'
 import { Cache } from '../../cache'
 import {
@@ -14,9 +10,10 @@ import {
 import crypto from 'crypto'
 import { Config } from '../../config'
 import { ModelType } from 'koishi-plugin-chatluna/llm-core/platform/types'
+import { logger } from 'koishi-plugin-chatluna'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
-    const chatLimitCache = new Cache(ctx, config, 'chathub/chat_limit')
+    const chatLimitCache = new Cache(ctx, config, 'chatluna/chat_limit')
 
     const authService = ctx.chatluna_auth
 
@@ -125,24 +122,27 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             return session.text('chatluna.not_available_model')
         }
 
-        const client = await ctx.chatluna.platform.getClient(
-            parseRawModelName(model)[0]
-        )
+        let platformClient: string
+
+        try {
+            ;[platformClient] = parseRawModelName(model)
+        } catch (e) {
+            logger.error(e)
+            return session.text('chatluna.not_available_model')
+        }
+
+        const client = await ctx.chatluna.platform.getClient(platformClient)
 
         if (!client.value) {
-            throw new ChatLunaError(
-                ChatLunaErrorCode.MODEL_ADAPTER_NOT_FOUND,
-                new Error(`Can't find model adapter for ${model}`)
-            )
+            logger.error(`Can't find model adapter for ${model}`)
+            return session.text('chatluna.not_available_model')
         }
 
         const clientConfig = client.value.configPool.getConfig(true)
 
         if (!clientConfig) {
-            throw new ChatLunaError(
-                ChatLunaErrorCode.MODEL_ADAPTER_NOT_FOUND,
-                new Error(`Can't find model adapter for ${model}`)
-            )
+            logger.error(`Can't find model adapter for ${model}`)
+            return session.text('chatluna.not_available_model')
         }
 
         const chatLimitRaw = clientConfig.value.chatLimit
@@ -207,7 +207,7 @@ declare module '../../chains/chain' {
     }
 
     interface ChainMiddlewareContextOptions {
-        chatLimitCache?: Cache<'chathub/chat_limit', ChatLimit>
+        chatLimitCache?: Cache<'chatluna/chat_limit', ChatLimit>
         chatLimit?: ChatLimit
         authGroup?: ChatHubAuthGroup
     }
@@ -215,7 +215,7 @@ declare module '../../chains/chain' {
 
 declare module '@koishijs/cache' {
     interface Tables {
-        'chathub/chat_limit': ChatLimit
+        'chatluna/chat_limit': ChatLimit
     }
 }
 

--- a/packages/core/src/middlewares/model/resolve_model.ts
+++ b/packages/core/src/middlewares/model/resolve_model.ts
@@ -30,8 +30,16 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 return ChainMiddlewareRunStatus.CONTINUE
             }
 
+            const modelName =
+                room?.model == null ||
+                room.model.trim().length < 1 ||
+                room.model === '无' ||
+                room.model === 'empty'
+                    ? 'empty'
+                    : room.model
+
             await context.send(
-                session.text('chatluna.room.unavailable', [room.model])
+                session.text('chatluna.room.unavailable', [modelName])
             )
 
             try {

--- a/packages/core/src/middlewares/system/wipe.ts
+++ b/packages/core/src/middlewares/system/wipe.ts
@@ -55,7 +55,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             // drop caches
 
             await ctx.chatluna.cache.clear('chatluna/chat_limit')
-            await ctx.chatluna.cache.clear('chathub/keys')
+            await ctx.chatluna.cache.clear('chatluna/keys')
 
             // delete local database and temps
 

--- a/packages/core/src/middlewares/system/wipe.ts
+++ b/packages/core/src/middlewares/system/wipe.ts
@@ -54,7 +54,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             // drop caches
 
-            await ctx.chatluna.cache.clear('chathub/chat_limit')
+            await ctx.chatluna.cache.clear('chatluna/chat_limit')
             await ctx.chatluna.cache.clear('chathub/keys')
 
             // delete local database and temps

--- a/packages/core/src/preset.ts
+++ b/packages/core/src/preset.ts
@@ -13,7 +13,6 @@ import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
 import { ObjectLock } from 'koishi-plugin-chatluna/utils/lock'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { Cache } from './cache'
 import { Config } from './config'
 import md5 from 'md5'
 
@@ -27,8 +26,7 @@ export class PresetService {
 
     constructor(
         private readonly ctx: Context,
-        private readonly config: Config,
-        private readonly cache: Cache<'chathub/keys', string>
+        private readonly config: Config
     ) {
         logger = createLogger(ctx)
         this._lock = new ObjectLock()
@@ -222,7 +220,6 @@ export class PresetService {
         )
 
         if (preset) {
-            // await this.cache.set('default-preset', 'chatgpt')
             return preset
         } else {
             await this._copyDefaultPresets()
@@ -289,8 +286,6 @@ export class PresetService {
     }
 
     async resetDefaultPreset(): Promise<void> {
-        await this.cache.delete('default-preset')
-
         await this._copyDefaultPresets()
     }
 

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -955,8 +955,8 @@ class ChatInterfaceWrapper {
 
             const chatInterface = await this.query(room, true)
             await chatInterface.clearChatHistory()
-            this._conversations.delete(conversationId)
         } finally {
+            this._conversations.delete(conversationId)
             await this._conversationQueue.remove(conversationId, requestId)
         }
     }

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -63,7 +63,7 @@ export class ChatLunaService extends Service {
     private _plugins: Record<string, ChatLunaPlugin> = {}
     private _chatInterfaceWrapper: ChatInterfaceWrapper
     private readonly _chain: ChatChain
-    private readonly _keysCache: Cache<'chathub/keys', string>
+    private readonly _keysCache: Cache<'chatluna/keys', string>
     private readonly _preset: PresetService
     private readonly _platformService: PlatformService
     private readonly _messageTransformer: MessageTransformer
@@ -76,8 +76,8 @@ export class ChatLunaService extends Service {
     ) {
         super(ctx, 'chatluna')
         this._chain = new ChatChain(ctx, config)
-        this._keysCache = new Cache(this.ctx, config, 'chathub/keys')
-        this._preset = new PresetService(ctx, config, this._keysCache)
+        this._keysCache = new Cache(this.ctx, config, 'chatluna/keys')
+        this._preset = new PresetService(ctx, config)
         this._platformService = new PlatformService(ctx)
         this._messageTransformer = new MessageTransformer(config)
         this._renderer = new DefaultRenderer(ctx, config)

--- a/packages/deepseek-adapter/package.json
+++ b/packages/deepseek-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/dify-adapter/package.json
+++ b/packages/dify-adapter/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/doubao-adapter/package.json
+++ b/packages/doubao-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/embeddings-service/package.json
+++ b/packages/embeddings-service/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/gemini-adapter/package.json
+++ b/packages/gemini-adapter/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/hunyuan-adapter/package.json
+++ b/packages/hunyuan-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/image-renderer/package.json
+++ b/packages/image-renderer/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/image-service/package.json
+++ b/packages/image-service/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/long-memory/package.json
+++ b/packages/long-memory/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/mcp-client/package.json
+++ b/packages/mcp-client/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/ollama-adapter/package.json
+++ b/packages/ollama-adapter/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/openai-adapter/package.json
+++ b/packages/openai-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/openai-like-adapter/package.json
+++ b/packages/openai-like-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/plugin-common/package.json
+++ b/packages/plugin-common/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47",
     "koishi-plugin-chatluna-knowledge-chat": "^1.0.23",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },

--- a/packages/qwen-adapter/package.json
+++ b/packages/qwen-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/rwkv-adapter/package.json
+++ b/packages/rwkv-adapter/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/search-service/package.json
+++ b/packages/search-service/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   }
 }

--- a/packages/spark-adapter/package.json
+++ b/packages/spark-adapter/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/variable-extension/package.json
+++ b/packages/variable-extension/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/vector-store-service/package.json
+++ b/packages/vector-store-service/package.json
@@ -46,7 +46,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/wenxin-adapter/package.json
+++ b/packages/wenxin-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {

--- a/packages/zhipu-adapter/package.json
+++ b/packages/zhipu-adapter/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.46"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
   },
   "koishi": {
     "description": {


### PR DESCRIPTION
This PR improves error handling in chat limit checks and migrates cache table names from the legacy 'chathub/*' namespace to the new 'chatluna/*' namespace.

### Bug Fixes

- Fixed crashes when model name is null or empty by adding proper validation in `parseRawModelName`
- Fixed unhandled errors in chat limit middleware that could crash the application
- Improved error messages when model adapter is not found
- Added proper handling for edge cases in model resolution (empty, null, '无', 'empty' values)

### Other Changes

- Migrated cache table names from 'chathub/keys' and 'chathub/chat_limit' to 'chatluna/keys' and 'chatluna/chat_limit'
- Added automatic cleanup of old cache keys on startup
- Set default maxAge for cache entries (24 minutes) to prevent memory bloat
- Replaced thrown errors with logger.error and graceful error returns for better UX
- Removed unused cache dependencies from PresetService