### PR TITLE
[Fix] Fix room resolution and proxy configuration issues

### DIFF
--- a/packages/azure-openai-adapter/package.json
+++ b/packages/azure-openai-adapter/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/claude-adapter/package.json
+++ b/packages/claude-adapter/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.47",
+  "version": "1.3.0-alpha.48",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/chains/rooms.ts
+++ b/packages/core/src/chains/rooms.ts
@@ -430,8 +430,9 @@ export async function getAllJoinedConversationRoom(
                 (session.isDirect && room.visibility !== 'template_clone') ||
                 // 私有房间跨群
                 room.visibility === 'private' ||
+                // 模版克隆房间需要指定非群聊
                 (room.visibility === 'template_clone' &&
-                    session.isDirect &&
+                    !session.isDirect &&
                     !memberOfTheRoom) ||
                 queryAll === true
             ) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -97,7 +97,9 @@ export const Config: Schema<Config> = Schema.intersect([
     }),
 
     Schema.object({
-        blackList: Schema.computed(Schema.boolean()).default(false)
+        blackList: Schema.computed(Schema.boolean().default(false)).default(
+            false
+        )
     }),
 
     Schema.object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -143,13 +143,9 @@ function setupProxy(ctx: Context, config: Config) {
     if (config.isProxy) {
         request.setGlobalProxyAddress(
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            config.proxyAddress ?? (ctx.http.config as any)?.proxyAgent
+            config.proxyAddress || (ctx.http.config as any)?.proxyAgent
         )
-        logger.debug(
-            'global proxy %c',
-            config.proxyAddress,
-            request.globalProxyAddress
-        )
+        logger.debug('global proxy %c', config.proxyAddress)
     }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,9 +76,8 @@ function setupEntryPoint(
     const entryPointPlugin = (ctx: Context, config: Config) => {
         ctx.on('ready', async () => {
             await initializeComponents(ctx, config)
+            setupMiddleware(ctx)
         })
-
-        setupMiddleware(ctx)
     }
 
     const entryPointDisposable = forkScopeToDisposable(

--- a/packages/core/src/middlewares/chat/message_delay.ts
+++ b/packages/core/src/middlewares/chat/message_delay.ts
@@ -28,6 +28,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     chain
         .middleware('message_delay', async (session, context) => {
             if (!config.messageQueue || context.command?.length > 0) {
+                // 忽略命令执行或者不开启延时
                 return ChainMiddlewareRunStatus.CONTINUE
             }
 
@@ -126,7 +127,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             )
             return await interruptAndMerge(batch, inputMessage, context)
         })
-        .after('resolve_room')
+        .after('check_room')
         .after('read_chat_message')
         .before('lifecycle-handle_command')
 

--- a/packages/core/src/middlewares/room/check_room.ts
+++ b/packages/core/src/middlewares/room/check_room.ts
@@ -15,7 +15,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             const rooms = await getAllJoinedConversationRoom(ctx, session)
 
-            // 检查当前用户是否在当前房间
+            // 检查当前用户是否在房间
             if (room == null && rooms.length > 0) {
                 room = rooms[Math.floor(Math.random() * rooms.length)]
                 await switchConversationRoom(ctx, session, room.roomId)
@@ -24,7 +24,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 )
             } else if (room == null && rooms.length === 0) {
                 if ((context.command?.length ?? 0) > 1) {
-                    // 新群如果需要执行命令，则先继续。
+                    // 新群如果需要执行命令，则先继续
                     return ChainMiddlewareRunStatus.CONTINUE
                 }
 

--- a/packages/core/src/middlewares/room/resolve_room.ts
+++ b/packages/core/src/middlewares/room/resolve_room.ts
@@ -147,7 +147,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 if (
                     (config.defaultModel === '无' ||
                         config.defaultModel.trim().length < 1) &&
-                    ctx.chatluna.platform.listAllModels(ModelType.all).value
+                    ctx.chatluna.platform.listAllModels(ModelType.llm).value
                         .length < 1
                 ) {
                     return session.text('chatluna.not_available_model')
@@ -167,7 +167,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
                 cloneRoom.conversationId = uuidv4()
 
-                if (config.autoCreateRoomFromUser) {
+                // 私聊或者总是主动创建
+                if (config.autoCreateRoomFromUser || session.isDirect) {
                     // 如果是群聊的公共房间，那么就房主直接设置为聊天者，否则就是私聊
                     cloneRoom.roomMasterId = session.userId
 

--- a/packages/core/src/middlewares/system/wipe.ts
+++ b/packages/core/src/middlewares/system/wipe.ts
@@ -43,6 +43,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             await ctx.database.drop('chathub_auth_group')
             await ctx.database.drop('chathub_auth_joined_user')
             await ctx.database.drop('chathub_auth_user')
+            await ctx.database.drop('chatluna_docstore')
             // knowledge
 
             try {

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -77,13 +77,17 @@ function createProxyAgent(
 export let globalProxyAddress: string | null = global['globalProxyAddress']
 
 export function setGlobalProxyAddress(address: string) {
+    if (address == null || address.trim().length === 0) {
+        logger?.warn('Global proxy address is empty, using no proxy')
+        return
+    }
     if (address.match(/^socks/) || address.match(/^https?:\/\//)) {
         globalProxyAddress = address
         global['globalProxyAddress'] = address
     } else {
         throw new ChatLunaError(
             ChatLunaErrorCode.UNSUPPORTED_PROXY_PROTOCOL,
-            new Error('Unsupported proxy protocol')
+            new Error('Unsupported proxy protocol. Try add http:// or socks')
         )
     }
 }

--- a/packages/core/src/utils/request.ts
+++ b/packages/core/src/utils/request.ts
@@ -77,7 +77,7 @@ function createProxyAgent(
 export let globalProxyAddress: string | null = global['globalProxyAddress']
 
 export function setGlobalProxyAddress(address: string) {
-    if (address == null || address.trim().length === 0) {
+    if (!address?.trim()) {
         logger?.warn('Global proxy address is empty, using no proxy')
         return
     }

--- a/packages/deepseek-adapter/package.json
+++ b/packages/deepseek-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/dify-adapter/package.json
+++ b/packages/dify-adapter/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/doubao-adapter/package.json
+++ b/packages/doubao-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/embeddings-service/package.json
+++ b/packages/embeddings-service/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/gemini-adapter/package.json
+++ b/packages/gemini-adapter/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/hunyuan-adapter/package.json
+++ b/packages/hunyuan-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/image-renderer/package.json
+++ b/packages/image-renderer/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/image-service/package.json
+++ b/packages/image-service/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/long-memory/package.json
+++ b/packages/long-memory/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/mcp-client/package.json
+++ b/packages/mcp-client/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/ollama-adapter/package.json
+++ b/packages/ollama-adapter/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/openai-adapter/package.json
+++ b/packages/openai-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/openai-like-adapter/package.json
+++ b/packages/openai-like-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/plugin-common/package.json
+++ b/packages/plugin-common/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48",
     "koishi-plugin-chatluna-knowledge-chat": "^1.0.23",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },

--- a/packages/qwen-adapter/package.json
+++ b/packages/qwen-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/rwkv-adapter/package.json
+++ b/packages/rwkv-adapter/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/search-service/package.json
+++ b/packages/search-service/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   }
 }

--- a/packages/spark-adapter/package.json
+++ b/packages/spark-adapter/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/variable-extension/package.json
+++ b/packages/variable-extension/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/vector-store-service/package.json
+++ b/packages/vector-store-service/package.json
@@ -46,7 +46,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/wenxin-adapter/package.json
+++ b/packages/wenxin-adapter/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {

--- a/packages/zhipu-adapter/package.json
+++ b/packages/zhipu-adapter/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.47"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
   },
   "koishi": {
     "description": {


### PR DESCRIPTION
This PR fixes critical issues with room resolution logic, middleware initialization, and proxy configuration validation.

### Bug Fixes

- Fix template clone room visibility check to properly filter non-direct sessions
- Fix middleware initialization timing by moving setup to ready event
- Fix message_delay middleware dependency chain (now runs after check_room)
- Fix proxy configuration to validate empty addresses and prevent runtime errors
- Fix model type checking to use ModelType.llm instead of ModelType.all
- Auto-create rooms for direct messages regardless of autoCreateRoomFromUser setting

### Other Changes

- Add chatluna_docstore table cleanup in wipe middleware
- Improve proxy error messages with helpful hints
- Simplify proxy logging output
- Fix config schema for blackList default value
- Bump core version to 1.3.0-alpha.48 and update peer dependencies across all packages