### PR TITLE
[Feature] Add local file logging for debugging

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-azure-openai-adapter",
   "description": "azure openai adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-claude-adapter",
   "description": "claude adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-deepseek-adapter",
   "description": "deepseek adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-dify-adapter",
   "description": "dify adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -44,6 +44,7 @@ import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import type {} from 'koishi-plugin-chatluna-storage-service'
 import { ToolCallChunk } from '@langchain/core/messages/tool'
 import { RunnableConfig } from '@langchain/core/runnables'
+import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
 
 export class GeminiRequester
     extends ModelRequester
@@ -104,6 +105,13 @@ export class GeminiRequester
 
             yield* this._processResponseStream(response)
         } catch (e) {
+            if (this.ctx.chatluna.config.isLog) {
+                await trackLogToLocal(
+                    'Request',
+                    JSON.stringify(chatGenerationParams),
+                    logger
+                )
+            }
             if (e instanceof ChatLunaError) {
                 throw e
             } else {
@@ -117,15 +125,17 @@ export class GeminiRequester
     ): Promise<ChatGeneration> {
         const modelConfig = prepareModelConfig(params, this._pluginConfig)
 
+        const chatGenerationParams = await createChatGenerationParams(
+            params,
+            this._plugin,
+            modelConfig,
+            this._pluginConfig
+        )
+
         try {
             const response = await this._post(
                 `models/${modelConfig.model}:generateContent`,
-                await createChatGenerationParams(
-                    params,
-                    this._plugin,
-                    modelConfig,
-                    this._pluginConfig
-                ),
+                chatGenerationParams,
                 {
                     signal: params.signal
                 }
@@ -135,6 +145,13 @@ export class GeminiRequester
 
             return await this._processResponse(response)
         } catch (e) {
+            if (this.ctx.chatluna.config.isLog) {
+                await trackLogToLocal(
+                    'Request',
+                    JSON.stringify(chatGenerationParams),
+                    logger
+                )
+            }
             if (e instanceof ChatLunaError) {
                 throw e
             } else {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-hunyuan-adapter",
   "description": "hunyuan adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-ollama-adapter",
   "description": "ollama adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-like-adapter",
   "description": "openai style api adapter for chatluna",
-  "version": "1.3.0-alpha.8",
+  "version": "1.3.0-alpha.9",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-adapter",
   "description": "openai adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.0-alpha.8",
+  "version": "1.3.0-alpha.9",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/src/requester.ts
+++ b/packages/adapter-qwen/src/requester.ts
@@ -7,6 +7,7 @@ import {
 import { SSEEvent, sseIterable } from 'koishi-plugin-chatluna/utils/sse'
 import { Config } from '.'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
+import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
 import {
     ClientConfig,
     ClientConfigPool
@@ -47,42 +48,42 @@ export class QWenRequester
     async *completionStreamInternal(
         params: ModelRequestParams
     ): AsyncGenerator<ChatGenerationChunk> {
+        let model = params.model
+
+        let enabledThinking: boolean | undefined = null
+
+        if (model.includes('thinking')) {
+            enabledThinking = !model.includes('-non-thinking')
+            model = model.replace('-non-thinking', '').replace('-thinking', '')
+        } else if (model.includes('default')) {
+            enabledThinking = true
+            model = model.replace('-default', '-thinking')
+        }
+
+        const requestParams = {
+            model,
+            messages: await langchainMessageToQWenMessage(
+                params.input,
+                this._plugin,
+                model
+            ),
+            tools:
+                params.tools != null && !params.model.includes('vl')
+                    ? formatToolsToQWenTools(params.tools)
+                    : undefined,
+            stream: true,
+            top_p: params.topP,
+            temperature: params.temperature,
+            enable_search: params.model.includes('vl')
+                ? undefined
+                : this._pluginConfig.enableSearch,
+            enabled_thinking: enabledThinking
+        }
+
         try {
-            let model = params.model
-
-            let enabledThinking: boolean | undefined = null
-
-            if (model.includes('thinking')) {
-                enabledThinking = !model.includes('-non-thinking')
-                model = model
-                    .replace('-non-thinking', '')
-                    .replace('-thinking', '')
-            } else if (model.includes('default')) {
-                enabledThinking = true
-                model = model.replace('-default', '-thinking')
-            }
-
             const response = await this.post(
                 'chat/completions',
-                {
-                    model,
-                    messages: await langchainMessageToQWenMessage(
-                        params.input,
-                        this._plugin,
-                        model
-                    ),
-                    tools:
-                        params.tools != null && !params.model.includes('vl')
-                            ? formatToolsToQWenTools(params.tools)
-                            : undefined,
-                    stream: true,
-                    top_p: params.topP,
-                    temperature: params.temperature,
-                    enable_search: params.model.includes('vl')
-                        ? undefined
-                        : this._pluginConfig.enableSearch,
-                    enabled_thinking: enabledThinking
-                },
+                requestParams,
                 {
                     signal: params.signal
                 }
@@ -191,6 +192,13 @@ export class QWenRequester
                 )
             }
         } catch (e) {
+            if (this.ctx.chatluna.config.isLog) {
+                await trackLogToLocal(
+                    'Request',
+                    JSON.stringify(requestParams),
+                    this.logger
+                )
+            }
             if (e instanceof ChatLunaError) {
                 throw e
             } else {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-rmkv-adapter",
   "description": "rwkv adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-spark-adapter",
   "description": "spark adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-wenxin-adapter",
   "description": "wenxin adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-zhipu-adapter",
   "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.48",
+  "version": "1.3.0-alpha.49",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/chain/prompt.ts
+++ b/packages/core/src/llm-core/chain/prompt.ts
@@ -21,21 +21,10 @@ import {
 import { logger } from 'koishi-plugin-chatluna'
 import { SystemPrompts } from 'koishi-plugin-chatluna/llm-core/chain/base'
 import { Logger } from 'koishi'
-import {
-    getMessageContent,
-    isMessageContentImageUrl
-} from 'koishi-plugin-chatluna/utils/string'
+import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
+import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
 import type { ChatLunaPromptRenderService } from 'koishi-plugin-chatluna/services/chat'
 import { ComputedRef } from '@vue/reactivity'
-
-function escapeHtml(unsafe: string): string {
-    return unsafe
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;')
-        .replace(/'/g, '&#039;')
-}
 
 export interface ChatLunaChatPromptInput {
     messagesPlaceholder?: MessagesPlaceholder
@@ -281,44 +270,14 @@ Your goal is to craft an insightful, engaging response that seamlessly integrate
                     return msg
                 }
 
-                const dict = structuredClone(original)
-                if (dict.data == null) {
-                    return dict
-                }
-                delete dict.data.additional_kwargs['images']
-                delete dict.data.additional_kwargs['preset']
-
-                if (Array.isArray(dict.data.content)) {
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    dict.data.content = (dict.data.content as any[]).map(
-                        (content) => {
-                            if (isMessageContentImageUrl(content)) {
-                                content = {
-                                    type: 'image_url',
-                                    image_url: {
-                                        url:
-                                            typeof content.image_url ===
-                                            'string'
-                                                ? content.image_url
-                                                : content.image_url.url
-                                    }
-                                }
-
-                                if (content.image_url.url.length > 100) {
-                                    content.image_url.url =
-                                        content.image_url.url.slice(0, 20) +
-                                        '...'
-                                }
-                            }
-                            return content
-                        }
-                    ) as unknown as string
-                }
-
-                return dict
+                return original
             })
 
-            logger?.debug(`messages: ${JSON.stringify(mapMessages)})`)
+            await trackLogToLocal(
+                'ChatLunaPrompt',
+                JSON.stringify(mapMessages),
+                logger
+            )
         }
 
         return result
@@ -565,13 +524,10 @@ Your goal is to craft an insightful, engaging response that seamlessly integrate
             formatDocuments.length > 0
                 ? await this.conversationSummaryPrompt.format({
                       long_history: formatDocuments
-                          .map((document) => {
-                              const metadataJson = escapeHtml(
-                                  JSON.stringify(document.metadata)
-                              )
-                              const idEscaped = escapeHtml(String(document.id))
-                              return `<doc metadata="${metadataJson}" id="${idEscaped}">${document.pageContent}</doc>`
-                          })
+                          .map(
+                              (document) =>
+                                  `<doc metadata="${JSON.stringify(document.metadata)}" id="${document.id}">${document.pageContent}</doc>`
+                          )
                           .join(' '),
                       chat_history: chatHistory
                   })

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -35,7 +35,7 @@ export async function trackLogToLocal(
     output: string,
     logger: Logger
 ) {
-    const currentTime = new Date().toLocaleString()
+    const currentTime = new Date().toLocaleString().replace(/[/:]/g, '-')
     const tempDir = os.tmpdir()
     const logFile = `${tempDir}/chatluna/logs/chatluna-log-${currentTime}.log`
 

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,4 +1,6 @@
 import { Context, Logger } from 'koishi'
+import os from 'os'
+import fs from 'fs'
 
 let loggers: Record<string, Logger> = {}
 
@@ -26,4 +28,21 @@ export function setLoggerLevel(level: number) {
 
 export function clearLogger() {
     loggers = {}
+}
+
+export async function trackLogToLocal(
+    tag: string,
+    output: string,
+    logger: Logger
+) {
+    const currentTime = new Date().toLocaleString()
+    const tempDir = os.tmpdir()
+    const logFile = `${tempDir}/chatluna/logs/chatluna-log-${currentTime}.log`
+
+    if (!fs.existsSync(`${tempDir}/chatluna/logs`)) {
+        fs.mkdirSync(`${tempDir}/chatluna/logs`, { recursive: true })
+    }
+
+    await fs.promises.writeFile(logFile, output)
+    logger.info(`[${tag}] A local log file has been created at ${logFile}`)
 }

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-long-memory",
   "description": "long memory for chatluna",
-  "version": "1.3.0-alpha.0",
+  "version": "1.3.0-alpha.1",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49",
     "koishi-plugin-chatluna-knowledge-chat": "^1.0.23",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-search-service",
   "description": "search support for chatluna",
-  "version": "1.3.0-alpha.1",
+  "version": "1.3.0-alpha.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -59,7 +59,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.48"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.49"
   }
 }

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -27,6 +27,7 @@ import { AIMessageChunk } from '@langchain/core/messages'
 import { Response } from 'undici/types/fetch'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import { RunnableConfig } from '@langchain/core/runnables'
+import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
 
 interface RequestContext<
     T extends ClientConfig = ClientConfig,
@@ -280,15 +281,17 @@ export async function* completionStream<
 ): AsyncGenerator<ChatGenerationChunk> {
     const { modelRequester } = requestContext
 
+    const chatCompletionParams = await buildChatCompletionParams(
+        params,
+        requestContext.plugin,
+        enableGoogleSearch ?? false,
+        supportImageInput ?? true
+    )
+
     try {
         const response = await modelRequester.post(
             completionUrl,
-            await buildChatCompletionParams(
-                params,
-                requestContext.plugin,
-                enableGoogleSearch ?? false,
-                supportImageInput ?? true
-            ),
+            chatCompletionParams,
             {
                 signal: params.signal
             }
@@ -297,6 +300,13 @@ export async function* completionStream<
         const iterator = sseIterable(response)
         yield* processStreamResponse(requestContext, iterator)
     } catch (e) {
+        if (requestContext.ctx.chatluna.config.isLog) {
+            await trackLogToLocal(
+                'Request',
+                JSON.stringify(chatCompletionParams),
+                requestContext.ctx.logger('')
+            )
+        }
         if (e instanceof ChatLunaError) {
             throw e
         } else {
@@ -337,6 +347,13 @@ export async function completion<
 
         return await processResponse(requestContext, response)
     } catch (e) {
+        if (requestContext.ctx.chatluna.config.isLog) {
+            await trackLogToLocal(
+                'Request',
+                JSON.stringify(chatCompletionParams),
+                requestContext.ctx.logger('')
+            )
+        }
         if (e instanceof ChatLunaError) {
             throw e
         } else {


### PR DESCRIPTION
This PR adds local file logging capabilities to help debug request failures and prompt generation issues.

### New Features

- **Local File Logging System**: Added `trackLogToLocal` utility function that writes debug logs to OS temp directory under `chatluna/logs/`
- **Request Parameter Logging**: Automatically logs request parameters on errors in gemini, qwen, and shared-adapter requesters
- **Prompt Logging**: Logs formatted prompts and messages in ChatLunaPrompt for debugging
- **Conditional Logging**: Only writes logs when `isLog` config option is enabled to avoid unnecessary file I/O

### Bug Fixes

- Fixed timestamp formatting in log filenames to be filesystem-safe (replaced `/` and `:` with `-`)

### Other Changes

- Simplified ChatLunaPrompt logging by removing HTML escaping and content filtering
- Cleaned up message serialization for better readability in logs
- Bumped all package versions to alpha.49 for this release
- Updated peer dependencies across all adapter and extension packages

This feature significantly improves debugging capabilities by capturing the exact state of requests and prompts without cluttering console output.