### PR TITLE
[Fix] Fix double brace escape sequence behavior

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.50",
+  "version": "1.3.0-alpha.51",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -221,7 +221,7 @@
     "langchain"
   ],
   "dependencies": {
-    "@chatluna/shared-prompt-renderer": "^1.0.0",
+    "@chatluna/shared-prompt-renderer": "^1.0.1",
     "@langchain/core": "0.3.62",
     "@vue/reactivity": "^3.6.0-alpha.2",
     "decimal.js": "^10.6.0",

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-plugin-common",
   "description": "plugin service for agent mode of chatluna",
-  "version": "1.3.0-alpha.14",
+  "version": "1.3.0-alpha.15",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51",
     "koishi-plugin-chatluna-knowledge-chat": "^1.0.23",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -59,7 +59,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.50"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.51"
   }
 }

--- a/packages/shared-prompt-renderer/README.md
+++ b/packages/shared-prompt-renderer/README.md
@@ -370,17 +370,22 @@ await renderer.render(
 
 ### 转义花括号
 
-使用双花括号输出字面花括号：
+使用双花括号作为转义序列输出单个花括号字符：
 
-```lua
-{{This will be rendered as {This will be rendered as}}}
-```
+- `{{` 输出字面字符 `{`
+- `}}` 输出字面字符 `}`
 
 **示例：**
 
 ```typescript
 await renderer.render('Use {{variable}} for interpolation')
 // 输出: "Use {variable} for interpolation"
+
+await renderer.render('{{if}} is a control structure')
+// 输出: "{if} is a control structure"
+
+await renderer.render('JSON object: {{ "key": "value" }}')
+// 输出: "JSON object: { "key": "value" }"
 ```
 
 ## API 参考

--- a/packages/shared-prompt-renderer/package.json
+++ b/packages/shared-prompt-renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chatluna/shared-prompt-renderer",
   "description": "chatluna prompt renderer",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/shared-prompt-renderer/src/lexer.ts
+++ b/packages/shared-prompt-renderer/src/lexer.ts
@@ -50,7 +50,8 @@ const tokenizeCache = new LRUCache<string, Token[]>(1000)
  * - {for item in list}...{/for} - Loop blocks for array iteration
  * - {while condition}...{/while} - While loop blocks (boolean condition only)
  * - {repeat count}...{/repeat} - Repeat blocks for count-based iteration
- * - {{...}} - Escaped braces (outputs as text)
+ * - {{ - Escape sequence for literal { character
+ * - }} - Escape sequence for literal } character
  */
 export function tokenize(input: string): Token[] {
     // Check cache
@@ -78,34 +79,42 @@ export function clearTokenizeCache(): void {
 function tokenizeInternal(input: string): Token[] {
     const tokens: Token[] = []
     let i = 0
+    let textBuffer = ''
 
     while (i < input.length) {
+        // Handle {{ escape sequence - outputs single {
+        if (i + 1 < input.length && input[i] === '{' && input[i + 1] === '{') {
+            textBuffer += '{'
+            i += 2
+            continue
+        }
+
+        // Handle }} escape sequence - outputs single }
+        if (i + 1 < input.length && input[i] === '}' && input[i + 1] === '}') {
+            textBuffer += '}'
+            i += 2
+            continue
+        }
+
         const braceStart = input.indexOf('{', i)
 
         if (braceStart === -1) {
             // No more braces, add remaining text
             if (i < input.length) {
-                tokens.push({ type: 'text', value: input.slice(i) })
+                textBuffer += input.slice(i)
             }
             break
         }
 
-        // Add text before brace
+        // Add text before brace to buffer
         if (braceStart > i) {
-            tokens.push({ type: 'text', value: input.slice(i, braceStart) })
+            textBuffer += input.slice(i, braceStart)
         }
 
-        // Handle escaped braces {{...}}
-        if (braceStart + 1 < input.length && input[braceStart + 1] === '{') {
-            const endBraces = input.indexOf('}}', braceStart + 2)
-            if (endBraces !== -1) {
-                tokens.push({
-                    type: 'text',
-                    value: input.slice(braceStart + 1, endBraces + 1)
-                })
-                i = endBraces + 2
-                continue
-            }
+        // Flush text buffer if we have accumulated text
+        if (textBuffer) {
+            tokens.push({ type: 'text', value: textBuffer })
+            textBuffer = ''
         }
 
         // Find matching closing brace
@@ -162,6 +171,11 @@ function tokenizeInternal(input: string): Token[] {
         }
 
         i = braceEnd + 1
+    }
+
+    // Flush any remaining text buffer
+    if (textBuffer) {
+        tokens.push({ type: 'text', value: textBuffer })
     }
 
     return tokens


### PR DESCRIPTION
This PR fixes the double brace escape sequence handling behavior in shared-prompt-renderer and updates related version numbers.

### Bug Fixes

- **shared-prompt-renderer**: Correct double brace escape sequence behavior
  - Previously `{{...}}` was treated as escaped content that would output the entire inner content as text
  - Now `{{` and `}}` are individual escape sequences that output single brace characters
  - `{{` outputs literal character `{`
  - `}}` outputs literal character `}`
  - Updated tokenizer to process escape sequences character-by-character using a text buffer
  - Improved documentation with clearer examples of escape sequence usage

### Other Changes

- **packages**: Bump versions to 1.3.0-alpha.51
  - Core package upgraded from 1.3.0-alpha.50 to 1.3.0-alpha.51
  - extension-tools upgraded from 1.3.0-alpha.14 to 1.3.0-alpha.15
  - shared-prompt-renderer upgraded from 1.0.0 to 1.0.1
  - Updated peer dependency references across all adapter, extension, service, and renderer packages