### PR TITLE
[Fix] MCP client configuration parsing and tool registration

### DIFF
--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-mcp-client",
   "description": "MCP Client for ChatLuna",
-  "version": "1.3.0-alpha.4",
+  "version": "1.3.0-alpha.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/extension-mcp/src/command.ts
+++ b/packages/extension-mcp/src/command.ts
@@ -123,6 +123,11 @@ export function apply(ctx: Context, config: Config) {
                 }, {})
             } else if (currentConfig['mcpServers']) {
                 mcpServers = { ...currentConfig['mcpServers'] }
+            } else if (
+                typeof currentConfig === 'object' &&
+                Object.keys(currentConfig)
+            ) {
+                mcpServers = currentConfig
             }
 
             let addedCount = 0
@@ -246,8 +251,8 @@ export function apply(ctx: Context, config: Config) {
                 return
             }
 
-            const tools = service['_globalTools']
-            const tool = tools[toolName]
+            const tools = service.globalTools
+            const tool = config.tools[toolName] || tools[toolName]
 
             if (!tool) {
                 await session.send(session.text('.tool_not_found', [toolName]))

--- a/packages/extension-mcp/src/index.ts
+++ b/packages/extension-mcp/src/index.ts
@@ -20,9 +20,7 @@ export function apply(ctx: Context, config: Config) {
 }
 
 export const Config: Schema<Config> = Schema.object({
-    servers: Schema.string()
-        .role('textarea')
-        .default('{\n\n\"mcpServers\": {\n\n\n\n}\n}'),
+    servers: Schema.string().role('textarea').default('{"mcpServers": {}}'),
     tools: Schema.dict(
         Schema.object({
             name: Schema.string().required(),

--- a/packages/extension-mcp/src/service.ts
+++ b/packages/extension-mcp/src/service.ts
@@ -54,7 +54,7 @@ export class ChatLunaMCPClientService extends Service {
 
             await this.registerClientToolsToSchema()
 
-            const toolLegth = await this.registerClientTools()
+            const toolLength = await this.registerClientTools()
             logger.info(`MCP client found ${toolLegth} tools`)
         })
     }

--- a/packages/extension-mcp/src/service.ts
+++ b/packages/extension-mcp/src/service.ts
@@ -54,10 +54,8 @@ export class ChatLunaMCPClientService extends Service {
 
             await this.registerClientToolsToSchema()
 
-            await this.registerClientTools()
-            logger.info(
-                `MCP client found ${Object.keys(this._globalTools).length} tools`
-            )
+            const toolLegth = await this.registerClientTools()
+            logger.info(`MCP client found ${toolLegth} tools`)
         })
     }
 
@@ -156,8 +154,8 @@ export class ChatLunaMCPClientService extends Service {
         for (const tool of mcpTools.tools) {
             schemaValueArray[tool.name] = {
                 name: tool.name,
-                enabled: true,
-                selector: []
+                enabled: this.config.tools[tool.name]?.enabled ?? true,
+                selector: this.config.tools[tool.name]?.selector ?? []
             }
         }
 
@@ -176,16 +174,13 @@ export class ChatLunaMCPClientService extends Service {
     }
 
     async registerClientTools() {
-        const tools = this.config.tools
         const mcpTools = await this._client.listTools()
 
-        // merge tools to global tools
-        for (const name in tools) {
-            this._globalTools[name] = tools[name]
-        }
+        const forkTools = { ...this._globalTools }
 
-        for (const name in this._globalTools) {
-            const toolConfig = this._globalTools[name]
+        let length = 0
+        for (const name in forkTools) {
+            const toolConfig = forkTools[name]
             const mcpTool = mcpTools.tools.find((t) => t.name === name)
 
             if (!mcpTool) {
@@ -194,7 +189,7 @@ export class ChatLunaMCPClientService extends Service {
             }
 
             // Skip if tool is explicitly disabled
-            if (toolConfig?.enabled === false) {
+            if (toolConfig.enabled === false) {
                 logger.debug(`Tool ${name} is disabled, skipping registration`)
                 continue
             }
@@ -233,7 +228,11 @@ export class ChatLunaMCPClientService extends Service {
                     )
                 }
             })
+
+            length++
         }
+
+        return length
     }
 
     async stop() {

--- a/packages/extension-mcp/src/service.ts
+++ b/packages/extension-mcp/src/service.ts
@@ -55,7 +55,7 @@ export class ChatLunaMCPClientService extends Service {
             await this.registerClientToolsToSchema()
 
             const toolLength = await this.registerClientTools()
-            logger.info(`MCP client found ${toolLegth} tools`)
+            logger.info(`MCP client found ${toolLength} tools`)
         })
     }
 


### PR DESCRIPTION
This PR fixes several issues in the MCP client extension related to configuration parsing and tool registration.

### Bug Fixes

- **Configuration parsing**: Added fallback logic to parse MCP server configurations when the `mcpServers` key is missing from the config object
- **Tool lookup**: Fixed tool resolution in commands to check both `config.tools` and `service.globalTools`, ensuring manually configured tools are found
- **Tool settings preservation**: Tool `enabled` and `selector` settings from user configuration are now properly preserved during schema registration instead of being reset to defaults
- **Tool count accuracy**: Fixed the reported tool count to reflect only registered/enabled tools instead of all global tools
- **Code quality**: Cleaned up default configuration formatting and removed unnecessary tool merging logic

### Other Changes

- Improved code clarity by using a forked copy of tools during registration
- Fixed access to `globalTools` to use public property instead of private `_globalTools`
- Simplified default server configuration to single-line JSON format