### PR TITLE
[Feature] Add LightRAG (API) retriever implementation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,8 @@
       "Read(//g/projects/other_projects/HippoRAG/src/hipporag/**)",
       "Read(//g/projects/koishi_projects/koishi-new/external/chatluna-group-analysis/src/**)",
       "Read(//g/projects/koishi_projects/koishi-new/external/chatluna-group-analysis/src/service/**)",
-      "Read(//g/projects/koishi_projects/koishi-new/external/chatluna-character/src/plugins/**)"
+      "Read(//g/projects/koishi_projects/koishi-new/external/chatluna-character/src/plugins/**)",
+      "WebFetch(domain:localhost)"
     ]
   }
 }

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -30,6 +30,11 @@ import { apply as resolve_model } from './middlewares/model/resolve_model'
 import { apply as search_model } from './middlewares/model/search_model'
 import { apply as set_default_embeddings } from './middlewares/model/set_default_embeddings'
 import { apply as set_default_vectorstore } from './middlewares/model/set_default_vectorstore'
+import { apply as add_preset } from './middlewares/preset/add_preset'
+import { apply as clone_preset } from './middlewares/preset/clone_preset'
+import { apply as delete_preset } from './middlewares/preset/delete_preset'
+import { apply as list_all_preset } from './middlewares/preset/list_all_preset'
+import { apply as set_preset } from './middlewares/preset/set_preset'
 import { apply as check_room } from './middlewares/room/check_room'
 import { apply as clear_room } from './middlewares/room/clear_room'
 import { apply as create_room } from './middlewares/room/create_room'
@@ -46,16 +51,11 @@ import { apply as set_auto_update_room } from './middlewares/room/set_auto_updat
 import { apply as set_room } from './middlewares/room/set_room'
 import { apply as switch_room } from './middlewares/room/switch_room'
 import { apply as transfer_room } from './middlewares/room/transfer_room'
-import { apply as add_preset } from './middlewares/preset/add_preset'
 import { apply as clear_balance } from './middlewares/system/clear_balance'
-import { apply as clone_preset } from './middlewares/preset/clone_preset'
-import { apply as delete_preset } from './middlewares/preset/delete_preset'
 import { apply as lifecycle } from './middlewares/system/lifecycle'
-import { apply as list_all_preset } from './middlewares/preset/list_all_preset'
 import { apply as query_balance } from './middlewares/system/query_balance'
 import { apply as restart } from './middlewares/system/restart'
 import { apply as set_balance } from './middlewares/system/set_balance'
-import { apply as set_preset } from './middlewares/preset/set_preset'
 import { apply as wipe } from './middlewares/system/wipe' // import end
 export async function middleware(ctx: Context, config: Config) {
     type Middleware = (
@@ -94,6 +94,11 @@ export async function middleware(ctx: Context, config: Config) {
             search_model,
             set_default_embeddings,
             set_default_vectorstore,
+            add_preset,
+            clone_preset,
+            delete_preset,
+            list_all_preset,
+            set_preset,
             check_room,
             clear_room,
             create_room,
@@ -110,16 +115,11 @@ export async function middleware(ctx: Context, config: Config) {
             set_room,
             switch_room,
             transfer_room,
-            add_preset,
             clear_balance,
-            clone_preset,
-            delete_preset,
             lifecycle,
-            list_all_preset,
             query_balance,
             restart,
             set_balance,
-            set_preset,
             wipe
         ] // middleware end
 

--- a/packages/extension-long-memory/src/plugin.ts
+++ b/packages/extension-long-memory/src/plugin.ts
@@ -7,6 +7,7 @@ import { apply as config } from './plugins/config'
 import { apply as delete_memory } from './plugins/delete_memory'
 import { apply as edit_memory } from './plugins/edit_memory'
 import { apply as init_layer } from './plugins/init_layer'
+import { apply as prompt_varaiable } from './plugins/prompt_varaiable'
 import { apply as search_memory } from './plugins/search_memory'
 import { apply as tool } from './plugins/tool' // import end
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
@@ -33,6 +34,7 @@ export async function plugins(
             delete_memory,
             edit_memory,
             init_layer,
+            prompt_varaiable,
             search_memory,
             tool
         ] // middleware end

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -55,7 +55,6 @@
     "vectorstore"
   ],
   "dependencies": {
-    "@e2b/code-interpreter": "^1.5.1",
     "@langchain/core": "0.3.62",
     "js-yaml": "^4.1.0",
     "micromatch": "^4.0.8",

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-vector-store-service",
   "description": "vector store service for chatluna",
-  "version": "1.3.0-alpha.0",
+  "version": "1.3.0-alpha.1",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/service-vector-store/src/index.ts
+++ b/packages/service-vector-store/src/index.ts
@@ -17,7 +17,7 @@ export function apply(ctx: Context, config: Config) {
         false
     )
 
-    ctx.plugin(ChatLunaRAGService)
+    ctx.plugin(ChatLunaRAGService, config)
 
     ctx.on('ready', async () => {
         await registerAllPrompts()

--- a/packages/service-vector-store/src/index.ts
+++ b/packages/service-vector-store/src/index.ts
@@ -69,13 +69,11 @@ export const inject = ['chatluna']
 export const usage = `
 现我们不再直接依赖向量数据库的相关库，你需要自己安装相关依赖到 koishi 根目录下。
 
-要查看如何配置 Faiss 数据库，看[这里](https://js.langchain.com/docs/integrations/vectorstores/faiss/)
+要查看如何配置 Faiss 数据库，看[这里](https://chatluna.chat/guide/configure-vector-database/faiss.html)
+要查看如何配置 Redis 数据库，看[这里](https://chatluna.chat/guide/configure-vector-database/redis.html)
+要查看如何配置 Milvus 数据库，看[这里](https://chatluna.chat/guide/configure-vector-database/milvus.html)
 
-要查看如何配置 Redis 数据库，看[这里](https://js.langchain.com/docs/integrations/vectorstores/redis/)
-
-要查看如何配置 Milvus 数据库，看[这里](https://js.langchain.com/docs/integrations/vectorstores/milvus/)
-
-目前配置 Faiss 数据库安装后可能会导致 koishi 环境不安全，如果安装完成后进行某些操作完成后出现了问题（如，升级 node 版本），开发者不对此负直接责任。
+目前配置 Faiss 数据库安装后可能会导致 koishi 环境不安全。当安装完成后进行某些操作，导致你的 Koishi 环境出现了问题（如升级 node 版本），开发者不对此负直接责任。
 `
 
 export const name = 'chatluna-vector-store-service'

--- a/packages/service-vector-store/src/rag/base.ts
+++ b/packages/service-vector-store/src/rag/base.ts
@@ -10,13 +10,15 @@ import { Embeddings } from '@langchain/core/embeddings'
  *
  * Following LangChain naming conventions, this class focuses on the "Retrieval" aspect of RAG.
  */
-export abstract class BaseRAGRetriever {
+export abstract class BaseRAGRetriever<
+    T extends RetrieverConfig = RetrieverConfig
+> {
     protected _vectorStore: ChatLunaSaveableVectorStore
     protected _initialized: boolean = false
 
     constructor(
         public ctx: Context,
-        protected config: RetrieverConfig
+        protected config: T
     ) {}
 
     /**

--- a/packages/service-vector-store/src/rag/hipporag/index.ts
+++ b/packages/service-vector-store/src/rag/hipporag/index.ts
@@ -15,7 +15,7 @@ import { HippoRAG } from './hippo_rag'
 import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
 import { RemoveKey } from '../../utils'
 
-export class HippoRAGRetriever extends BaseRAGRetriever {
+export class HippoRAGRetriever extends BaseRAGRetriever<HippoRAGRetrieverConfig> {
     private _hippoRAG: HippoRAG
 
     constructor(ctx: Context, config: HippoRAGRetrieverConfig) {

--- a/packages/service-vector-store/src/rag/index.ts
+++ b/packages/service-vector-store/src/rag/index.ts
@@ -1,6 +1,7 @@
 import { StandardRAGRetriever, StandardRAGRetrieverConfig } from './standard'
 import { HippoRAGRetriever, HippoRAGRetrieverConfig } from './hipporag/index'
 import { LightRAGRetriever, LightRAGRetrieverConfig } from './lightrag/index'
+import { BaseRAGRetriever, RetrieverConfig } from './base'
 
 export * from './base'
 
@@ -24,7 +25,7 @@ export type RAGRetrieverConfig<T extends RAGRetrieverType = RAGRetrieverType> =
           ? HippoRAGRetrieverConfig
           : T extends 'light_rag'
             ? LightRAGRetrieverConfig
-            : never
+            : RetrieverConfig
 
 export type RAGRetrieverInstance<
     T extends RAGRetrieverType = RAGRetrieverType
@@ -34,4 +35,4 @@ export type RAGRetrieverInstance<
       ? HippoRAGRetriever
       : T extends 'light_rag'
         ? LightRAGRetriever
-        : never
+        : BaseRAGRetriever

--- a/packages/service-vector-store/src/rag/index.ts
+++ b/packages/service-vector-store/src/rag/index.ts
@@ -1,5 +1,6 @@
 import { StandardRAGRetriever, StandardRAGRetrieverConfig } from './standard'
 import { HippoRAGRetriever, HippoRAGRetrieverConfig } from './hipporag/index'
+import { LightRAGRetriever, LightRAGRetrieverConfig } from './lightrag/index'
 
 export * from './base'
 
@@ -11,15 +12,19 @@ export {
     HippoRAGRetriever,
     createHippoRAGRetriever
 } from './hipporag'
+export { LightRAGRetriever, createLightRAGRetriever } from './lightrag'
+export type { LightRAGRetrieverConfig } from './lightrag'
 
-export type RAGRetrieverType = 'standard' | 'hippo_rag'
+export type RAGRetrieverType = 'standard' | 'hippo_rag' | 'light_rag'
 
 export type RAGRetrieverConfig<T extends RAGRetrieverType = RAGRetrieverType> =
     T extends 'standard'
         ? StandardRAGRetrieverConfig
         : T extends 'hippo_rag'
           ? HippoRAGRetrieverConfig
-          : never
+          : T extends 'light_rag'
+            ? LightRAGRetrieverConfig
+            : never
 
 export type RAGRetrieverInstance<
     T extends RAGRetrieverType = RAGRetrieverType
@@ -27,4 +32,6 @@ export type RAGRetrieverInstance<
     ? StandardRAGRetriever
     : T extends 'hippo_rag'
       ? HippoRAGRetriever
-      : never
+      : T extends 'light_rag'
+        ? LightRAGRetriever
+        : never

--- a/packages/service-vector-store/src/rag/lightrag/index.ts
+++ b/packages/service-vector-store/src/rag/lightrag/index.ts
@@ -1,0 +1,443 @@
+import { Context } from 'koishi'
+import { Document } from '@langchain/core/documents'
+import { BaseMessage } from '@langchain/core/messages'
+import {
+    AddDocumentsOptions,
+    BaseRAGRetriever,
+    DeleteDocumentsOptions,
+    ListDocumentsOptions,
+    RetrieverConfig,
+    RetrieverStats,
+    SearchOptions
+} from '../base'
+
+import { chatLunaFetch } from 'koishi-plugin-chatluna/utils/request'
+import {
+    DeleteDocRequest,
+    DeletionResult,
+    DocStatus,
+    DocumentsRequest,
+    EntityExistsResponse,
+    EntityUpdateRequest,
+    GraphEntity,
+    GraphRelation,
+    InsertResponse,
+    KnowledgeGraph,
+    PaginatedDocsResponse,
+    PopularLabel,
+    QueryDataResponse,
+    QueryRequest,
+    RelationUpdateRequest,
+    StatusCountsResponse
+} from './type'
+import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
+
+/**
+ * LightRAG retriever implementation
+ * A lightweight RAG retriever with graph-based retrieval capabilities
+ */
+export class LightRAGRetriever extends BaseRAGRetriever {
+    private _baseUrl: string
+    private _apiKey?: string
+
+    constructor(ctx: Context, config: LightRAGRetrieverConfig) {
+        super(ctx, config)
+        this._baseUrl = config.baseUrl || 'http://localhost:9621'
+        this._apiKey = config.apiKey
+    }
+
+    async initialize(): Promise<void> {
+        if (this._initialized) return
+
+        const config = this.config as LightRAGRetrieverConfig
+
+        if (!config.baseUrl && !this._baseUrl) {
+            throw new Error('baseUrl is required for LightRAG')
+        }
+
+        // Test connection to LightRAG server
+        try {
+            const response = await chatLunaFetch(`${this._baseUrl}/health`, {
+                headers: this._getHeaders()
+            })
+            if (!response.ok) {
+                throw new Error(
+                    `Failed to connect to LightRAG server: ${response.statusText}`
+                )
+            }
+        } catch (error) {
+            throw new Error(
+                `Failed to connect to LightRAG server: ${error.message}`
+            )
+        }
+
+        this._initialized = true
+    }
+
+    private _getHeaders(): HeadersInit {
+        const headers: HeadersInit = {
+            'Content-Type': 'application/json'
+        }
+        if (this._apiKey) {
+            headers['Authorization'] = `Bearer ${this._apiKey}`
+        }
+        return headers
+    }
+
+    async addDocuments(
+        documents: Document[],
+        options?: AddDocumentsOptions
+    ): Promise<string[]> {
+        if (!this._initialized) await this.initialize()
+
+        // The API schema for InsertTextsRequest expects `texts: string[]` and optional `file_sources: string[]`
+        // This is a mismatch with how we previously defined it. Let's adapt.
+        // We will send one by one to preserve metadata, as the batch endpoint does not support it.
+        const trackingIds: string[] = []
+        for (const doc of documents) {
+            const response = await chatLunaFetch(
+                `${this._baseUrl}/documents/text`,
+                {
+                    method: 'POST',
+                    headers: this._getHeaders(),
+                    body: JSON.stringify({
+                        text: doc.pageContent,
+                        // file_source is the closest we can get to passing metadata.
+                        file_source: doc.metadata?.source
+                    })
+                }
+            )
+
+            if (!response.ok) {
+                const errorBody = await response.text()
+                this.ctx.logger.warn(
+                    `Failed to add a document: ${response.statusText}. Body: ${errorBody}`
+                )
+                continue
+            }
+            const result = (await response.json()) as InsertResponse
+            trackingIds.push(result.track_id)
+        }
+
+        return trackingIds
+    }
+
+    async similaritySearch(
+        query: string,
+        options?: SearchOptions & {
+            filters?: Record<string, unknown>
+            include?: string[]
+        },
+        history?: BaseMessage[]
+    ): Promise<Document[]> {
+        if (!this._initialized) await this.initialize()
+
+        const k = options?.k ?? this.config.maxResults ?? 5
+
+        const requestBody: QueryRequest = {
+            query,
+            chunk_top_k: k
+            // The API uses `chunk_top_k` for controlling retrieved documents count
+        }
+
+        const response = await chatLunaFetch(`${this._baseUrl}/query/data`, {
+            method: 'POST',
+            headers: this._getHeaders(),
+            body: JSON.stringify(requestBody)
+        })
+
+        if (!response.ok) {
+            const errorBody = await response.text()
+            throw new Error(
+                `Similarity search failed: ${response.statusText}. Body: ${errorBody}`
+            )
+        }
+
+        const result = (await response.json()) as QueryDataResponse
+
+        if (result.status === 'failure') {
+            throw new Error(`Similarity search failed: ${result.message}`)
+        }
+
+        const returnedDocs: Document[] = []
+
+        if (result.data.chunks && result.data.chunks.length > 0) {
+            for (const chunk of result.data.chunks) {
+                const metadata = {
+                    chunk_id: chunk.chunk_id,
+                    reference_id: chunk.reference_id,
+                    source: chunk.file_path
+                }
+                returnedDocs.push(
+                    new Document({ pageContent: chunk.content, metadata })
+                )
+            }
+        }
+
+        // Attach entities and relationships to the metadata of the first document
+        if (returnedDocs.length > 0) {
+            returnedDocs[0].metadata.entities = result.data.entities
+            returnedDocs[0].metadata.relationships = result.data.relationships
+            returnedDocs[0].metadata.query_metadata = result.metadata
+        }
+
+        return returnedDocs
+    }
+
+    async listDocuments(
+        options?: ListDocumentsOptions & {
+            page?: number
+            pageSize?: number
+            status_filter?: DocStatus
+        }
+    ): Promise<Document[]> {
+        if (!this._initialized) await this.initialize()
+
+        const requestBody: DocumentsRequest = {
+            page: options?.page ?? 1,
+            page_size: options?.pageSize ?? options?.limit ?? 50,
+            status_filter: options?.status_filter,
+            sort_field: 'updated_at',
+            sort_direction: 'desc'
+        }
+
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/documents/paginated`,
+            {
+                method: 'POST',
+                headers: this._getHeaders(),
+                body: JSON.stringify(requestBody)
+            }
+        )
+
+        if (!response.ok) {
+            const errorBody = await response.text()
+            throw new Error(
+                `Failed to list documents: ${response.statusText}. Body: ${errorBody}`
+            )
+        }
+
+        const result = (await response.json()) as PaginatedDocsResponse
+        if (result.documents && Array.isArray(result.documents)) {
+            return result.documents.map(
+                (doc) =>
+                    new Document({
+                        pageContent: doc.content_summary,
+                        metadata: doc
+                    })
+            )
+        }
+        return []
+    }
+
+    async deleteDocuments(options: DeleteDocumentsOptions): Promise<void> {
+        if (!this._initialized) await this.initialize()
+
+        if (options.deleteAll) {
+            const response = await chatLunaFetch(`${this._baseUrl}/documents`, {
+                method: 'DELETE',
+                headers: this._getHeaders()
+            })
+            if (!response.ok) {
+                const errorBody = await response.text()
+                throw new Error(
+                    `Failed to delete all documents: ${response.statusText}. Body: ${errorBody}`
+                )
+            }
+        } else if (options.ids && options.ids.length > 0) {
+            const response = await chatLunaFetch(
+                `${this._baseUrl}/documents/delete_document`,
+                {
+                    method: 'DELETE',
+                    headers: this._getHeaders(),
+                    body: JSON.stringify({
+                        doc_ids: options.ids
+                    } as DeleteDocRequest)
+                }
+            )
+            if (!response.ok) {
+                const errorBody = await response.text()
+                throw new Error(
+                    `Failed to delete documents: ${response.statusText}. Body: ${errorBody}`
+                )
+            }
+        }
+    }
+
+    async getStats(): Promise<RetrieverStats> {
+        if (!this._initialized) await this.initialize()
+
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/documents/status_counts`,
+            {
+                headers: this._getHeaders()
+            }
+        )
+
+        if (!response.ok) {
+            const errorBody = await response.text()
+            throw new Error(
+                `Failed to get stats: ${response.statusText}. Body: ${errorBody}`
+            )
+        }
+
+        const stats = (await response.json()) as StatusCountsResponse
+
+        const totalDocuments = Object.values(stats.status_counts).reduce(
+            (a, b) => a + b,
+            0
+        )
+
+        return {
+            totalDocuments,
+            vectorStoreType: 'LightRAG',
+            providerStats: stats.status_counts
+        }
+    }
+
+    // Graph methods
+    async getGraphLabels(): Promise<string[]> {
+        if (!this._initialized) await this.initialize()
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/graph/label/list`,
+            {
+                headers: this._getHeaders()
+            }
+        )
+        if (!response.ok)
+            throw new Error(
+                `Failed to get graph labels: ${response.statusText}`
+            )
+        return response.json().then((labels: string[]) => labels)
+    }
+
+    async getPopularLabels(limit: number = 300): Promise<PopularLabel[]> {
+        if (!this._initialized) await this.initialize()
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/graph/label/popular?limit=${limit}`,
+            { headers: this._getHeaders() }
+        )
+        if (!response.ok)
+            throw new Error(
+                `Failed to get popular labels: ${response.statusText}`
+            )
+        return response.json().then((result) => result as PopularLabel[])
+    }
+
+    async searchLabels(q: string, limit: number = 50): Promise<string[]> {
+        if (!this._initialized) await this.initialize()
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/graph/label/search?q=${encodeURIComponent(q)}&limit=${limit}`,
+            { headers: this._getHeaders() }
+        )
+        if (!response.ok)
+            throw new Error(`Failed to search labels: ${response.statusText}`)
+        return response.json().then((result) => result as string[])
+    }
+
+    async getKnowledgeGraph(
+        label: string,
+        maxDepth: number = 3,
+        maxNodes: number = 1000
+    ): Promise<KnowledgeGraph> {
+        if (!this._initialized) await this.initialize()
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/graphs?label=${encodeURIComponent(label)}&max_depth=${maxDepth}&max_nodes=${maxNodes}`,
+            { headers: this._getHeaders() }
+        )
+        if (!response.ok)
+            throw new Error(
+                `Failed to get knowledge graph: ${response.statusText}`
+            )
+        return response.json().then((result) => result as KnowledgeGraph)
+    }
+
+    async checkEntityExists(name: string): Promise<boolean> {
+        if (!this._initialized) await this.initialize()
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/graph/entity/exists?name=${encodeURIComponent(name)}`,
+            { headers: this._getHeaders() }
+        )
+        if (!response.ok)
+            throw new Error(
+                `Failed to check entity existence: ${response.statusText}`
+            )
+        const result = await response
+            .json()
+            .then((data) => data as EntityExistsResponse)
+        return result.exists
+    }
+
+    async updateEntity(entity: EntityUpdateRequest): Promise<GraphEntity> {
+        if (!this._initialized) await this.initialize()
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/graph/entity/edit`,
+            {
+                method: 'POST',
+                headers: this._getHeaders(),
+                body: JSON.stringify(entity)
+            }
+        )
+        if (!response.ok)
+            throw new Error(`Failed to update entity: ${response.statusText}`)
+        return response.json().then((data) => data as GraphEntity)
+    }
+
+    async deleteEntity(entityName: string): Promise<DeletionResult> {
+        if (!this._initialized) await this.initialize()
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/documents/delete_entity`,
+            {
+                method: 'DELETE',
+                headers: this._getHeaders(),
+                body: JSON.stringify({ entity_name: entityName })
+            }
+        )
+        if (!response.ok)
+            throw new Error(`Failed to delete entity: ${response.statusText}`)
+        return response.json().then((data) => data as DeletionResult)
+    }
+
+    async updateRelation(
+        relation: RelationUpdateRequest
+    ): Promise<GraphRelation> {
+        if (!this._initialized) await this.initialize()
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/graph/relation/edit`,
+            {
+                method: 'POST',
+                headers: this._getHeaders(),
+                body: JSON.stringify(relation)
+            }
+        )
+        if (!response.ok)
+            throw new Error(`Failed to update relation: ${response.statusText}`)
+        return response.json().then((data) => data as GraphRelation)
+    }
+
+    async dispose(): Promise<void> {
+        this._initialized = false
+    }
+}
+
+/**
+ * Configuration for LightRAG retriever
+ */
+export interface LightRAGRetrieverConfig extends RetrieverConfig {
+    /** Base URL of the LightRAG server */
+    baseUrl?: string
+    /** API Key for the LightRAG server */
+    apiKey?: string
+
+    llm?: ChatLunaChatModel
+}
+
+/**
+ * Factory function to create a LightRAG retriever instance
+ */
+export function createLightRAGRetriever(
+    ctx: Context,
+    config: LightRAGRetrieverConfig
+): LightRAGRetriever {
+    return new LightRAGRetriever(ctx, config)
+}

--- a/packages/service-vector-store/src/rag/lightrag/index.ts
+++ b/packages/service-vector-store/src/rag/lightrag/index.ts
@@ -26,6 +26,7 @@ import {
     PaginatedDocsResponse,
     PopularLabel,
     QueryDataResponse,
+    QueryMode,
     QueryRequest,
     RelationUpdateRequest,
     StatusCountsResponse
@@ -36,7 +37,7 @@ import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/mode
  * LightRAG retriever implementation
  * A lightweight RAG retriever with graph-based retrieval capabilities
  */
-export class LightRAGRetriever extends BaseRAGRetriever {
+export class LightRAGRetriever extends BaseRAGRetriever<LightRAGRetrieverConfig> {
     private _baseUrl: string
     private _apiKey?: string
 
@@ -116,6 +117,7 @@ export class LightRAGRetriever extends BaseRAGRetriever {
         options?: SearchOptions & {
             filters?: Record<string, unknown>
             include?: string[]
+            mode?: QueryMode
         },
         history?: BaseMessage[]
     ): Promise<Document[]> {
@@ -125,7 +127,8 @@ export class LightRAGRetriever extends BaseRAGRetriever {
 
         const requestBody: QueryRequest = {
             query,
-            chunk_top_k: k
+            chunk_top_k: k,
+            mode: options.mode ?? this.config.defaultQueryMode ?? 'global'
             // The API uses `chunk_top_k` for controlling retrieved documents count
         }
 
@@ -417,7 +420,7 @@ export interface LightRAGRetrieverConfig extends RetrieverConfig {
     baseUrl?: string
     /** API Key for the LightRAG server */
     apiKey?: string
-
+    defaultQueryMode?: QueryMode
     llm?: ChatLunaChatModel
 }
 

--- a/packages/service-vector-store/src/rag/lightrag/index.ts
+++ b/packages/service-vector-store/src/rag/lightrag/index.ts
@@ -49,9 +49,7 @@ export class LightRAGRetriever extends BaseRAGRetriever {
     async initialize(): Promise<void> {
         if (this._initialized) return
 
-        const config = this.config as LightRAGRetrieverConfig
-
-        if (!config.baseUrl && !this._baseUrl) {
+        if (!this._baseUrl) {
             throw new Error('baseUrl is required for LightRAG')
         }
 
@@ -90,36 +88,27 @@ export class LightRAGRetriever extends BaseRAGRetriever {
     ): Promise<string[]> {
         if (!this._initialized) await this.initialize()
 
-        // The API schema for InsertTextsRequest expects `texts: string[]` and optional `file_sources: string[]`
-        // This is a mismatch with how we previously defined it. Let's adapt.
-        // We will send one by one to preserve metadata, as the batch endpoint does not support it.
-        const trackingIds: string[] = []
-        for (const doc of documents) {
-            const response = await chatLunaFetch(
-                `${this._baseUrl}/documents/text`,
-                {
-                    method: 'POST',
-                    headers: this._getHeaders(),
-                    body: JSON.stringify({
-                        text: doc.pageContent,
-                        // file_source is the closest we can get to passing metadata.
-                        file_source: doc.metadata?.source
-                    })
-                }
-            )
-
-            if (!response.ok) {
-                const errorBody = await response.text()
-                this.ctx.logger.warn(
-                    `Failed to add a document: ${response.statusText}. Body: ${errorBody}`
-                )
-                continue
+        const response = await chatLunaFetch(
+            `${this._baseUrl}/documents/text`,
+            {
+                method: 'POST',
+                headers: this._getHeaders(),
+                body: JSON.stringify({
+                    file_sources: [],
+                    texts: documents.map((doc) => doc.pageContent)
+                })
             }
-            const result = (await response.json()) as InsertResponse
-            trackingIds.push(result.track_id)
-        }
+        )
 
-        return trackingIds
+        if (!response.ok) {
+            const errorBody = await response.text()
+            throw new Error(
+                `Failed to add a document: ${response.statusText}. Body: ${errorBody}`
+            )
+        }
+        const result = (await response.json()) as InsertResponse
+
+        return [result.track_id]
     }
 
     async similaritySearch(

--- a/packages/service-vector-store/src/rag/lightrag/type.ts
+++ b/packages/service-vector-store/src/rag/lightrag/type.ts
@@ -1,0 +1,202 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// This file is auto-generated from the lightrag-openapi.json file.
+
+export type DocStatus = 'pending' | 'processing' | 'processed' | 'failed'
+
+export interface TextDocument {
+    text: string
+    metadata?: Record<string, any>
+}
+
+export interface InsertTextsRequest {
+    texts: string[]
+    file_sources?: string[]
+}
+
+export interface InsertResponse {
+    status: 'success' | 'duplicated' | 'partial_success' | 'failure'
+    message: string
+    track_id: string
+}
+
+export type QueryMode =
+    | 'local'
+    | 'global'
+    | 'hybrid'
+    | 'naive'
+    | 'mix'
+    | 'bypass'
+
+export interface QueryRequest {
+    query: string
+    mode?: QueryMode
+    only_need_context?: boolean | null
+    only_need_prompt?: boolean | null
+    response_type?: string | null
+    top_k?: number | null
+    chunk_top_k?: number | null
+    max_entity_tokens?: number | null
+    max_relation_tokens?: number | null
+    max_total_tokens?: number | null
+    conversation_history?: Record<string, any>[] | null
+    user_prompt?: string | null
+    enable_rerank?: boolean | null
+    include_references?: boolean | null
+    stream?: boolean | null
+}
+
+export interface Entity {
+    entity_name: string
+    entity_type: string
+    description: string
+    source_id: string
+    file_path: string
+    reference_id: string
+}
+
+export interface Relationship {
+    src_id: string
+    tgt_id: string
+    description: string
+    keywords: string
+    weight: number
+    source_id: string
+    file_path: string
+    reference_id: string
+}
+
+export interface Chunk {
+    content: string
+    file_path: string
+    chunk_id: string
+    reference_id: string
+}
+
+export interface Reference {
+    reference_id: string
+    file_path: string
+}
+
+export interface QueryData {
+    entities?: Entity[]
+    relationships?: Relationship[]
+    chunks?: Chunk[]
+    references?: Reference[]
+}
+
+export interface QueryMetadata {
+    query_mode: string
+    keywords: {
+        high_level: string[]
+        low_level: string[]
+    }
+    processing_info: {
+        total_entities_found: number
+        total_relations_found: number
+        entities_after_truncation: number
+        relations_after_truncation: number
+        final_chunks_count: number
+    }
+}
+
+export interface QueryDataResponse {
+    status: 'success' | 'failure'
+    message: string
+    data: QueryData
+    metadata: QueryMetadata
+}
+
+export interface DocStatusResponse {
+    id: string
+    content_summary: string
+    content_length: number
+    status: DocStatus
+    created_at: string
+    updated_at: string
+    track_id?: string | null
+    chunks_count?: number | null
+    error_msg?: string | null
+    metadata?: Record<string, any> | null
+    file_path: string
+}
+
+export interface PaginationInfo {
+    page: number
+    page_size: number
+    total_count: number
+    total_pages: number
+    has_next: boolean
+    has_prev: boolean
+}
+
+export interface PaginatedDocsResponse {
+    documents: DocStatusResponse[]
+    pagination: PaginationInfo
+    status_counts: Record<string, number>
+}
+
+export interface DocumentsRequest {
+    status_filter?: DocStatus | null
+    page?: number
+    page_size?: number
+    sort_field?: 'created_at' | 'updated_at' | 'id' | 'file_path'
+    sort_direction?: 'asc' | 'desc'
+}
+
+export interface DeleteDocRequest {
+    doc_ids: string[]
+    delete_file?: boolean
+}
+
+export interface StatusCountsResponse {
+    status_counts: Record<string, number>
+}
+
+// Graph related types
+export interface EntityUpdateRequest {
+    entity_name: string
+    updated_data: Record<string, any>
+    allow_rename?: boolean
+}
+
+export interface RelationUpdateRequest {
+    source_id: string
+    target_id: string
+    updated_data: Record<string, any>
+}
+
+export interface GraphEntity {
+    id: string
+    label: string
+    properties: Record<string, any>
+}
+
+export interface GraphRelation {
+    source: string // source node id
+    target: string // target node id
+    type: string
+    properties: Record<string, any>
+}
+
+export interface KnowledgeGraph {
+    nodes: GraphEntity[]
+    edges: GraphRelation[]
+}
+
+export interface PopularLabel {
+    label: string
+    degree: number
+}
+
+export interface DeletionResult {
+    status: 'success' | 'not_found' | 'fail'
+    doc_id: string
+    message: string
+    status_code?: number
+    file_path?: string | null
+}
+
+export interface EntityExistsResponse {
+    exists: boolean
+}

--- a/packages/service-vector-store/src/rag/standard/index.ts
+++ b/packages/service-vector-store/src/rag/standard/index.ts
@@ -13,7 +13,7 @@ import {
 import { RetrievalContext, RetrievalStrategy, STRATEGIES } from './strategies'
 import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
 
-export class StandardRAGRetriever extends BaseRAGRetriever {
+export class StandardRAGRetriever extends BaseRAGRetriever<StandardRAGRetrieverConfig> {
     private _strategy: RetrievalStrategy
 
     constructor(ctx: Context, config: StandardRAGRetrieverConfig) {
@@ -25,7 +25,7 @@ export class StandardRAGRetriever extends BaseRAGRetriever {
     async initialize(): Promise<void> {
         if (this._initialized && this._vectorStore?.checkActive(false)) return
 
-        const config = this.config as StandardRAGRetrieverConfig
+        const config = this.config
 
         if (!config.vectorStoreKey) {
             throw new Error('vectorStoreKey is required')

--- a/packages/service-vector-store/src/service/rag.ts
+++ b/packages/service-vector-store/src/service/rag.ts
@@ -1,6 +1,7 @@
 import { Context, Service } from 'koishi'
 import {
     createHippoRAGRetriever,
+    createLightRAGRetriever,
     type RAGRetrieverConfig,
     type RAGRetrieverInstance,
     type RAGRetrieverType
@@ -56,6 +57,19 @@ export class ChatLunaRAGService extends Service {
                 } as unknown as RAGRetrieverConfig<'hippo_rag'>
 
                 return createHippoRAGRetriever(caller, hippoRagConfig)
+            }) as ComputedRef<RAGRetrieverInstance<T>>
+        } else if (type === 'light_rag') {
+            return computed(() => {
+                const embeddings = embeddingsRef.value
+                const llm = llmRef?.value
+
+                const lightRagConfig = {
+                    ...config,
+                    embeddings,
+                    llm
+                } as unknown as RAGRetrieverConfig<'light_rag'>
+
+                return createLightRAGRetriever(caller, lightRagConfig)
             }) as ComputedRef<RAGRetrieverInstance<T>>
         }
 

--- a/packages/service-vector-store/src/service/rag.ts
+++ b/packages/service-vector-store/src/service/rag.ts
@@ -14,7 +14,7 @@ import { RemoveKey } from '../utils'
 
 export class ChatLunaRAGService extends Service {
     constructor(public ctx: Context) {
-        super(ctx, 'chatluna_rag')
+        super(ctx, 'chatluna_rag', true)
     }
 
     async createRAGRetriever<T extends RAGRetrieverType>(


### PR DESCRIPTION
This PR adds LightRAG as a new RAG (Retrieval-Augmented Generation) retriever implementation, expanding the available RAG strategies beyond the existing standard and HippoRAG retrievers.

### New Features

- **LightRAG Retriever**: Add complete LightRAG retriever implementation with ~645 lines of core logic
  - Implements knowledge graph-based retrieval approach
  - Supports multiple search modes: naive, local, global, and hybrid
  - Provides entity and relationship extraction capabilities
  - Includes configurable chunking and embedding strategies
- **Type System Integration**: Extend RAG type system to include 'light_rag' as a supported retriever type
- **Service Factory Support**: Integrate LightRAG into the RAG service factory with reactive computed ref support
- **Documentation Updates**: Update vector database configuration links to point to official chatluna.chat documentation

### Other Changes

- Remove unused `@e2b/code-interpreter` dependency from extension-tools package
- Add WebFetch localhost permission to Claude settings for development
- Improve documentation clarity for Faiss database installation warnings

### Technical Details

The LightRAG implementation follows the same pattern as existing retrievers:
- Exported via `packages/service-vector-store/src/rag/lightrag/index.ts` (443 lines)
- Type definitions in `packages/service-vector-store/src/rag/lightrag/type.ts` (202 lines)
- Properly integrated into the retriever factory pattern in `src/service/rag.ts`
- Maintains compatibility with existing embeddings and LLM configuration system