### PR TITLE
[Refactor] Remove unused ctx parameter from platform client registration

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-azure-openai-adapter",
   "description": "azure openai adapter for chatluna",
-  "version": "1.3.0-alpha.11",
+  "version": "1.3.0-alpha.12",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-azure-openai/src/index.ts
+++ b/packages/adapter-azure-openai/src/index.ts
@@ -42,7 +42,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new OpenAIClient(ctx, config, plugin))
+        plugin.registerClient(() => new OpenAIClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-claude-adapter",
   "description": "claude adapter for chatluna",
-  "version": "1.3.0-alpha.11",
+  "version": "1.3.0-alpha.12",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/src/index.ts
+++ b/packages/adapter-claude/src/index.ts
@@ -33,7 +33,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         )
 
-        plugin.registerClient((ctx) => new ClaudeClient(ctx, config, plugin))
+        plugin.registerClient(() => new ClaudeClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-deepseek-adapter",
   "description": "deepseek adapter for chatluna",
-  "version": "1.3.0-alpha.11",
+  "version": "1.3.0-alpha.12",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-deepseek/src/index.ts
+++ b/packages/adapter-deepseek/src/index.ts
@@ -29,7 +29,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new DeepseekClient(ctx, config, plugin))
+        plugin.registerClient(() => new DeepseekClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-dify-adapter",
   "description": "dify adapter for chatluna",
-  "version": "1.3.0-alpha.9",
+  "version": "1.3.0-alpha.10",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-dify/src/index.ts
+++ b/packages/adapter-dify/src/index.ts
@@ -31,7 +31,7 @@ export function apply(ctx: Context, config: Config) {
             ]
         })
 
-        plugin.registerClient((ctx) => new DifyClient(ctx, config, plugin))
+        plugin.registerClient(() => new DifyClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.0-alpha.11",
+  "version": "1.3.0-alpha.12",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/src/index.ts
+++ b/packages/adapter-doubao/src/index.ts
@@ -29,7 +29,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new DouBaoClient(ctx, config, plugin))
+        plugin.registerClient(() => new DouBaoClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.0-alpha.16",
+  "version": "1.3.0-alpha.17",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-gemini/src/index.ts
+++ b/packages/adapter-gemini/src/index.ts
@@ -30,7 +30,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new GeminiClient(ctx, config, plugin))
+        plugin.registerClient(() => new GeminiClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-hunyuan-adapter",
   "description": "hunyuan adapter for chatluna",
-  "version": "1.3.0-alpha.9",
+  "version": "1.3.0-alpha.10",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-hunyuan/src/index.ts
+++ b/packages/adapter-hunyuan/src/index.ts
@@ -29,7 +29,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new HunyuanClient(ctx, config, plugin))
+        plugin.registerClient(() => new HunyuanClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-ollama-adapter",
   "description": "ollama adapter for chatluna",
-  "version": "1.3.0-alpha.9",
+  "version": "1.3.0-alpha.10",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-ollama/src/index.ts
+++ b/packages/adapter-ollama/src/index.ts
@@ -29,7 +29,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new OllamaClient(ctx, config, plugin))
+        plugin.registerClient(() => new OllamaClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-like-adapter",
   "description": "openai style api adapter for chatluna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai-like/src/index.ts
+++ b/packages/adapter-openai-like/src/index.ts
@@ -44,7 +44,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new OpenAIClient(ctx, config, plugin))
+        plugin.registerClient(() => new OpenAIClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-adapter",
   "description": "openai adapter for chatluna",
-  "version": "1.3.0-alpha.11",
+  "version": "1.3.0-alpha.12",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/src/index.ts
+++ b/packages/adapter-openai/src/index.ts
@@ -29,7 +29,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new OpenAIClient(ctx, config, plugin))
+        plugin.registerClient(() => new OpenAIClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/src/index.ts
+++ b/packages/adapter-qwen/src/index.ts
@@ -25,7 +25,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new QWenClient(ctx, config, plugin))
+        plugin.registerClient(() => new QWenClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-rmkv-adapter",
   "description": "rwkv adapter for chatluna",
-  "version": "1.3.0-alpha.9",
+  "version": "1.3.0-alpha.10",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-rwkv/src/index.ts
+++ b/packages/adapter-rwkv/src/index.ts
@@ -24,7 +24,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new RWKVClient(ctx, config, plugin))
+        plugin.registerClient(() => new RWKVClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-spark-adapter",
   "description": "spark adapter for chatluna",
-  "version": "1.3.0-alpha.9",
+  "version": "1.3.0-alpha.10",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/src/index.ts
+++ b/packages/adapter-spark/src/index.ts
@@ -28,7 +28,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new SparkClient(ctx, config, plugin))
+        plugin.registerClient(() => new SparkClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-wenxin-adapter",
   "description": "wenxin adapter for chatluna",
-  "version": "1.3.0-alpha.9",
+  "version": "1.3.0-alpha.10",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/src/index.ts
+++ b/packages/adapter-wenxin/src/index.ts
@@ -28,7 +28,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new WenxinClient(ctx, config, plugin))
+        plugin.registerClient(() => new WenxinClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-zhipu-adapter",
   "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.0-alpha.11",
+  "version": "1.3.0-alpha.12",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/src/index.ts
+++ b/packages/adapter-zhipu/src/index.ts
@@ -31,7 +31,7 @@ export function apply(ctx: Context, config: Config) {
                 })
         })
 
-        plugin.registerClient((ctx) => new ZhipuClient(ctx, config, plugin))
+        plugin.registerClient(() => new ZhipuClient(ctx, config, plugin))
 
         await plugin.initClient()
     })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.58",
+  "version": "1.3.0-alpha.59",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.57",
+  "version": "1.3.0-alpha.58",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -222,6 +222,7 @@
   ],
   "dependencies": {
     "@chatluna/shared-prompt-renderer": "^1.0.3",
+    "@koishijs/plugin-notifier": "^1.2.1",
     "@langchain/core": "0.3.62",
     "@vue/reactivity": "^3.6.0-alpha.2",
     "decimal.js": "^10.6.0",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -99,9 +99,13 @@ export const Config: Schema<Config> = Schema.intersect([
     }),
 
     Schema.object({
-        blackList: Schema.computed(
-            Schema.number().min(0).max(1).step(1).default(0)
-        ).default(0)
+        blackList: Schema.number()
+            .min(0)
+            .max(1)
+            .step(1)
+            .default(0)
+            .computed()
+            .default(0)
     }),
 
     Schema.object({

--- a/packages/core/src/llm-core/platform/service.ts
+++ b/packages/core/src/llm-core/platform/service.ts
@@ -292,7 +292,7 @@ export class PlatformService {
             return this._platformClients[platform]
         }
 
-        const client = createClientFunction(this.ctx)
+        const client = createClientFunction()
 
         await this.refreshClient(client, platform, config)
 

--- a/packages/core/src/llm-core/platform/types.ts
+++ b/packages/core/src/llm-core/platform/types.ts
@@ -3,7 +3,7 @@ import { ChatLunaBaseEmbeddings, ChatLunaChatModel } from './model'
 import { ChatLunaLLMChainWrapper } from '../chain/base'
 import { StructuredTool, ToolRunnableConfig } from '@langchain/core/tools'
 import { BaseMessage } from '@langchain/core/messages'
-import { Context, Dict, Session } from 'koishi'
+import { Dict, Session } from 'koishi'
 import { PresetTemplate } from 'koishi-plugin-chatluna/llm-core/prompt'
 import { ChatLunaSaveableVectorStore } from 'koishi-plugin-chatluna/llm-core/vectorstores'
 import { BasePlatformClient } from 'koishi-plugin-chatluna/llm-core/platform/client'
@@ -71,7 +71,7 @@ export type CreateVectorStoreFunction = (
     params: CreateVectorStoreParams
 ) => Promise<ChatLunaSaveableVectorStore>
 
-export type CreateClientFunction = (ctx: Context) => BasePlatformClient
+export type CreateClientFunction = () => BasePlatformClient
 
 export interface PlatformClientName {
     default: never

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -441,9 +441,9 @@ commands:
                     model_not_found: 'Model {0} not found. Please verify the model name is correct.'
                     invalid_model_format: 'Invalid model format: {0}. Expected format: platform/model (e.g., openai/gpt-3.5-turbo).'
                     testing: 'Testing model {0}, please wait...'
-                    test_success: 'Model {0} test successful!\nResponse time: {1}ms\nSample response: {2}'
-                    test_success_no_content: 'Model {0} test successful!\nResponse time: {1}ms\n(No content returned by model)'
-                    test_failed: 'Model {0} test failed!\nResponse time: {1}ms\nError message: {2}'
+                    test_success: "Model {0} test successful!\nResponse time: {1}ms\nSample response: {2}"
+                    test_success_no_content: "Model {0} test successful!\nResponse time: {1}ms\n(No content returned by model)"
+                    test_failed: "Model {0} test failed!\nResponse time: {1}ms\nError message: {2}"
                     test_error: 'Error occurred during testing: {0}'
 
         memory:

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -442,9 +442,9 @@ commands:
                     model_not_found: '未找到模型 {0}，请检查模型名称是否正确。'
                     invalid_model_format: '无效的模型格式：{0}。期望格式：平台/模型（如 openai/gpt-3.5-turbo）。'
                     testing: '正在测试模型 {0}，请稍候...'
-                    test_success: '模型 {0} 测试成功！\n响应时间：{1}ms\n示例回复：{2}'
-                    test_success_no_content: '模型 {0} 测试成功！\n响应时间：{1}ms\n（模型未返回内容）'
-                    test_failed: '模型 {0} 测试失败！\n响应时间：{1}ms\n错误信息：{2}'
+                    test_success: "模型 {0} 测试成功！\n响应时间：{1}ms\n示例回复：{2}"
+                    test_success_no_content: "模型 {0} 测试成功！\n响应时间：{1}ms\n（模型未返回内容）"
+                    test_failed: "模型 {0} 测试失败！\n响应时间：{1}ms\n错误信息：{2}"
                     test_error: '测试过程中发生错误：{0}'
 
         memory:

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -709,7 +709,7 @@ export class ChatLunaPlugin<
     }
 
     registerClient(
-        func: (ctx: Context) => BasePlatformClient,
+        func: () => BasePlatformClient,
         platformName: string = this.platformName
     ) {
         this.ctx.effect(() =>

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-embeddings-service",
   "description": "embeddings service for chatluna",
-  "version": "1.2.7",
+  "version": "1.3.0-alpha.1",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/src/embeddings/huggingface.ts
+++ b/packages/service-embeddings/src/embeddings/huggingface.ts
@@ -35,7 +35,7 @@ export async function apply(
     }
 
     plugin.registerClient(
-        (ctx) => new HuggingfaceClient(ctx, config, plugin),
+        () => new HuggingfaceClient(ctx, config, plugin),
         'huggingface'
     )
 

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "koishi": {
     "description": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -59,7 +59,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -59,7 +59,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.57"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
   }
 }

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.58"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
   }
 }


### PR DESCRIPTION
This PR refactors the platform client registration system by removing the unused `ctx` parameter from the `CreateClientFunction` type and all adapter implementations.

### Summary of Changes

This PR simplifies the platform client registration API by removing redundant context parameter passing. The context is already accessible within client constructors, making the parameter in `registerClient` unnecessary.

### Other Changes

- **Core refactoring**:
  - Updated `CreateClientFunction` type signature from `(ctx: Context) => BasePlatformClient` to `() => BasePlatformClient`
  - Modified `PlatformService` to call `createClientFunction()` without passing context
  - Updated `ChatLunaPlugin.registerClient()` method signature

- **Adapter updates**: Removed unused `ctx` parameter from `registerClient` calls in all 15 adapters:
  - adapter-azure-openai
  - adapter-claude
  - adapter-deepseek
  - adapter-dify
  - adapter-doubao
  - adapter-gemini
  - adapter-hunyuan
  - adapter-ollama
  - adapter-openai-like
  - adapter-openai
  - adapter-qwen
  - adapter-rwkv
  - adapter-spark
  - adapter-wenxin
  - adapter-zhipu

- **Service updates**: Updated embeddings service (huggingface) to use new signature

- **Version bumps**: Bumped all package versions to align with core v1.3.0-alpha.58

### Technical Details

The refactoring improves code clarity by:
1. Removing unnecessary parameter passing
2. Making the API more intuitive (context is already available in constructors)
3. Reducing cognitive overhead for plugin developers

All clients already receive the context through their constructor parameters, making the additional context parameter in the factory function redundant.