### PR TITLE
[Fix] Fix streaming response handling and bump version to 1.3.0-alpha.60

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-azure-openai-adapter",
   "description": "azure openai adapter for chatluna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -46,7 +46,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-claude-adapter",
   "description": "claude adapter for chatluna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -47,7 +47,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-deepseek-adapter",
   "description": "deepseek adapter for chatluna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-dify-adapter",
   "description": "dify adapter for chatluna",
-  "version": "1.3.0-alpha.10",
+  "version": "1.3.0-alpha.11",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.0-alpha.17",
+  "version": "1.3.0-alpha.18",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-hunyuan-adapter",
   "description": "hunyuan adapter for chatluna",
-  "version": "1.3.0-alpha.10",
+  "version": "1.3.0-alpha.11",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-ollama-adapter",
   "description": "ollama adapter for chatluna",
-  "version": "1.3.0-alpha.10",
+  "version": "1.3.0-alpha.11",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62"
   },
   "devDependencies": {
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-like-adapter",
   "description": "openai style api adapter for chatluna",
-  "version": "1.3.0-alpha.13",
+  "version": "1.3.0-alpha.14",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-adapter",
   "description": "openai adapter for chatluna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.0-alpha.13",
+  "version": "1.3.0-alpha.14",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/src/requester.ts
+++ b/packages/adapter-qwen/src/requester.ts
@@ -151,7 +151,6 @@ export class QWenRequester
                             }
                         }
                     })
-                    continue
                 }
 
                 if (!choice) {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-rmkv-adapter",
   "description": "rwkv adapter for chatluna",
-  "version": "1.3.0-alpha.10",
+  "version": "1.3.0-alpha.11",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "1.0.13",
+    "@chatluna/v1-shared-adapter": "1.0.14",
     "@langchain/core": "0.3.62",
     "zod-to-json-schema": "3.23.5"
   },
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-spark-adapter",
   "description": "spark adapter for chatluna",
-  "version": "1.3.0-alpha.10",
+  "version": "1.3.0-alpha.11",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-wenxin-adapter",
   "description": "wenxin adapter for chatluna",
-  "version": "1.3.0-alpha.10",
+  "version": "1.3.0-alpha.11",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-zhipu-adapter",
   "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.13",
+    "@chatluna/v1-shared-adapter": "^1.0.14",
     "@langchain/core": "0.3.62",
     "jsonwebtoken": "^9.0.2",
     "zod": "3.25.76",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/src/requester.ts
+++ b/packages/adapter-zhipu/src/requester.ts
@@ -146,7 +146,6 @@ export class ZhipuRequester
                             }
                         }
                     })
-                    continue
                 }
 
                 const choice = data.choices?.[0]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.59",
+  "version": "1.3.0-alpha.60",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -89,7 +89,8 @@ function setupEntryPoint(
                     chatluna: { required: true },
                     chatluna_auth: { required: false },
                     chatluna_storage: { required: false },
-                    database: { required: false }
+                    database: { required: false },
+                    notifier: { required: false }
                 },
                 name: 'chatluna_entry_point'
             },

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60",
     "koishi-plugin-chatluna-storage-service": "^0.0.9"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -59,7 +59,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chatluna/v1-shared-adapter",
   "description": "chatluna shared adapter",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.59"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
   }
 }

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -162,7 +162,6 @@ export async function* processStreamResponse<
                         }
                     }
                 })
-                continue
             }
 
             if (!choice) continue


### PR DESCRIPTION
This PR fixes streaming response handling issues in adapters and bumps the version to 1.3.0-alpha.60.

### Bug Fixes

- **Streaming Response Handling**: Remove unnecessary `continue` statements in Qwen, Zhipu, and shared adapter streaming response handlers that were preventing proper chunk processing after handling usage/web_search data
- This fix ensures that all response chunks are properly processed even after metadata chunks

### Other Changes

- **Core**: Add optional `notifier` service dependency to entry point configuration
- **Version Bump**: Bump core package to 1.3.0-alpha.60 and shared-adapter to 1.0.14
- **Dependencies**: Update all adapter and extension packages to reference new core and shared-adapter versions

### Technical Details

The removed `continue` statements were causing streaming responses to skip chunk processing after encountering usage or web_search metadata, which could result in incomplete responses.

**Modified Files:**
- `packages/adapter-qwen/src/requester.ts`
- `packages/adapter-zhipu/src/requester.ts`
- `packages/shared-adapter/src/requester.ts`
- `packages/core/src/index.ts`
- 26 package.json files (version bumps and dependency updates)