### PR TITLE
[Feature] Add tool listing command and refactor reactive chain management

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "js-yaml": "^4.1.0",
     "koishi": "^4.18.9",
     "koishi-plugin-cache-database": "^2.1.0",
-    "koishi-plugin-chatluna-storage-service": "^0.0.9",
+    "koishi-plugin-chatluna-storage-service": "^0.0.10",
     "koishi-plugin-markdown": "^1.1.1",
     "koishi-plugin-puppeteer": "^3.9.0",
     "marked": "^15.0.12",

--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -74,7 +74,7 @@
   "peerDependencies": {
     "koishi": "^4.18.9",
     "koishi-plugin-chatluna": "^1.3.0-alpha.60",
-    "koishi-plugin-chatluna-storage-service": "^0.0.9"
+    "koishi-plugin-chatluna-storage-service": "^0.0.10"
   },
   "peerDependenciesMeta": {
     "koishi-plugin-chatluna-storage-service": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.0-alpha.18",
+  "version": "1.3.0-alpha.19",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61",
     "koishi-plugin-chatluna-storage-service": "^0.0.10"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -55,7 +55,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.60",
+  "version": "1.3.0-alpha.61",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -258,7 +258,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna-storage-service": "^0.0.9"
+    "koishi-plugin-chatluna-storage-service": "^0.0.10"
   },
   "peerDependenciesMeta": {
     "koishi-plugin-chatluna-storage-service": {

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -8,7 +8,8 @@ import { apply as memory } from './commands/memory'
 import { apply as model } from './commands/model'
 import { apply as preset } from './commands/preset'
 import { apply as providers } from './commands/providers'
-import { apply as room } from './commands/room' // import end
+import { apply as room } from './commands/room'
+import { apply as tool } from './commands/tool' // import end
 
 export async function command(ctx: Context, config: Config) {
     type Command = (
@@ -19,7 +20,7 @@ export async function command(ctx: Context, config: Config) {
 
     const middlewares: Command[] =
         // middleware start
-        [auth, chat, memory, model, preset, providers, room] // middleware end
+        [auth, chat, memory, model, preset, providers, room, tool] // middleware end
 
     for (const middleware of middlewares) {
         await middleware(ctx, config, ctx.chatluna.chatChain)

--- a/packages/core/src/commands/tool.ts
+++ b/packages/core/src/commands/tool.ts
@@ -1,0 +1,19 @@
+import { Context } from 'koishi'
+import { Config } from '../config'
+import { ChatChain } from '../chains/chain'
+
+export function apply(ctx: Context, config: Config, chain: ChatChain) {
+    ctx.command('chatluna.tool', {
+        authority: 1
+    })
+
+    ctx.command('chatluna.tool.list')
+        .option('page', '-p <page:number>')
+        .option('limit', '-l <limit:number>')
+        .action(async ({ options, session }) => {
+            await chain.receiveCommand(session, 'list_tool', {
+                page: options.page ?? 1,
+                limit: options.limit ?? 5
+            })
+        })
+}

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -28,14 +28,14 @@ import { AIMessage, HumanMessage, ToolMessage } from '@langchain/core/messages'
 import { PresetTemplate } from 'koishi-plugin-chatluna/llm-core/prompt'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import type { HandlerResult } from '../../utils/types'
-import { computed, ComputedRef, watch } from '@vue/reactivity'
-import { AgentStep } from '../agent'
+import { computed, ComputedRef } from '@vue/reactivity'
+import type { AgentStep } from '../agent'
 
 export class ChatInterface {
     private _input: ChatInterfaceInput
     private _chatHistory: KoishiChatMessageHistory
-    private _chain: ChatLunaLLMChainWrapper | undefined
-    private _embeddings: Embeddings | undefined
+    private _chain: ComputedRef<ChatLunaLLMChainWrapper | undefined> | undefined
+    private _embeddings: ComputedRef<Embeddings>
 
     private _chatCount = 0
 
@@ -82,7 +82,7 @@ export class ChatInterface {
         let wrapper: ChatLunaLLMChainWrapper
 
         try {
-            wrapper = await this.createChatLunaLLMChainWrapper()
+            wrapper = await this.getChatLunaLLMChainWrapper()
         } catch (error) {
             await this.handleChatError(arg, wrapper, error)
             throw error
@@ -232,15 +232,25 @@ export class ChatInterface {
         )
     }
 
-    async createChatLunaLLMChainWrapper(): Promise<ChatLunaLLMChainWrapper> {
+    async getChatLunaLLMChainWrapper(): Promise<ChatLunaLLMChainWrapper> {
         if (this._chain) {
-            return this._chain
+            const chainValue = this._chain.value
+            if (chainValue) {
+                return chainValue
+            }
+        }
+
+        await this.createChatLunaLLMChainWrapper()
+        return this._chain.value
+    }
+
+    async createChatLunaLLMChainWrapper(): Promise<void> {
+        if (this._chain) {
+            return
         }
 
         const service = this.ctx.chatluna.platform
         const [llmPlatform, llmModelName] = parseRawModelName(this._input.model)
-
-        let embeddings: ComputedRef<Embeddings>
 
         let llm: ComputedRef<ChatLunaChatModel>
 
@@ -248,7 +258,7 @@ export class ChatInterface {
         let historyMemory: BufferMemory
 
         try {
-            embeddings = await this._initEmbeddings(service)
+            this._embeddings = await this._initEmbeddings(service)
         } catch (error) {
             if (error instanceof ChatLunaError) {
                 throw error
@@ -293,11 +303,14 @@ export class ChatInterface {
             throw new ChatLunaError(ChatLunaErrorCode.UNKNOWN_ERROR, error)
         }
 
-        const createChain = () =>
-            service.createChatChain(this._input.chatMode, {
+        this._chain = computed(() => {
+            if (llm.value == null) {
+                return undefined
+            }
+            return service.createChatChain(this._input.chatMode, {
                 botName: this._input.botName,
                 model: llm.value,
-                embeddings: embeddings.value,
+                embeddings: this._embeddings.value,
                 historyMemory,
                 preset: this._input.preset,
                 vectorStoreName: this._input.vectorStoreName,
@@ -305,38 +318,7 @@ export class ChatInterface {
                     modelInfo?.value != null &&
                     this._supportChatMode(modelInfo.value)
             })
-
-        this._chain = createChain()
-        this._embeddings = embeddings.value
-
-        this.ctx.effect(() => {
-            const watcher = watch(
-                llm,
-                (newValue: ChatLunaChatModel | undefined) => {
-                    if (newValue == null) {
-                        this._chain = undefined
-                        return
-                    }
-                    this._chain = createChain()
-                }
-            )
-
-            return () => watcher.stop()
         })
-
-        this.ctx.effect(() => {
-            const watcher = watch(
-                embeddings,
-                (newValue: Embeddings | undefined) => {
-                    this._embeddings = newValue
-                    this._chain = createChain()
-                }
-            )
-
-            return () => watcher.stop()
-        })
-
-        return this._chain
     }
 
     get chatHistory(): BaseChatMessageHistory {
@@ -347,7 +329,7 @@ export class ChatInterface {
         return this._input.chatMode
     }
 
-    get embeddings(): Embeddings {
+    get embeddings(): ComputedRef<Embeddings> {
         return this._embeddings
     }
 
@@ -396,7 +378,7 @@ export class ChatInterface {
 
         await this._chatHistory.clear()
 
-        await this._chain?.model.clearContext(this._input.conversationId)
+        await this._chain?.value?.model.clearContext(this._input.conversationId)
     }
 
     private async _initEmbeddings(service: PlatformService) {
@@ -413,19 +395,17 @@ export class ChatInterface {
         const clientRef = await service.getClient(platform)
 
         return computed(() => {
+            const client = clientRef.value
+
             logger.info(`Init embeddings for %c`, this._input.embeddings)
 
-            if (
-                clientRef.value == null ||
-                clientRef.value instanceof PlatformModelClient
-            ) {
+            if (client == null || client instanceof PlatformModelClient) {
                 logger.warn(
                     `Platform ${platform} is not supported, falling back to fake embeddings`
                 )
                 return emptyEmbeddings
             }
 
-            const client = clientRef.value
             if (client instanceof PlatformEmbeddingsClient) {
                 return client.createModel(modelName)
             } else if (client instanceof PlatformModelAndEmbeddingsClient) {

--- a/packages/core/src/llm-core/platform/service.ts
+++ b/packages/core/src/llm-core/platform/service.ts
@@ -317,7 +317,11 @@ export class PlatformService {
         if (this._tmpTools[name]) {
             return this._tmpTools[name]
         }
-        const tool = this._tools[name].createTool(params)
+        const chatLunaTool = this._tools[name]
+        if (chatLunaTool == null) {
+            throw new Error(`Tool ${name} not found`)
+        }
+        const tool = chatLunaTool.createTool(params)
         this._tmpTools[name] = tool
         return tool
     }

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -446,6 +446,19 @@ commands:
                     test_failed: "Model {0} test failed!\nResponse time: {1}ms\nError message: {2}"
                     test_error: 'Error occurred during testing: {0}'
 
+        tool:
+            description: ChatLuna tool management.
+            list:
+                description: Display available tools.
+                usage: 'chatluna tool list --page 1 --limit 10'
+                options:
+                    page: Page number
+                    limit: Items per page
+                messages:
+                    header: 'Available tools:'
+                    footer: 'You can use these tools in conversations to enhance model capabilities'
+                    pages: 'Page: [page] / [total]'
+
         memory:
             description: 'ChatLuna memory-related commands.'
 

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -447,6 +447,19 @@ commands:
                     test_failed: "模型 {0} 测试失败！\n响应时间：{1}ms\n错误信息：{2}"
                     test_error: '测试过程中发生错误：{0}'
 
+        tool:
+            description: ChatLuna 工具相关指令。
+            list:
+                description: 列出所有可用的工具。
+                usage: 'chatluna tool list --page 1 --limit 10'
+                options:
+                    page: 页码。
+                    limit: 每页显示的数量。
+                messages:
+                    header: '以下是目前可用的工具列表：'
+                    footer: '你可以在对话中使用这些工具来增强模型的能力'
+                    pages: '当前为第 [page] / [total] 页'
+
         memory:
             description: 'ChatLuna 记忆相关指令。'
             search:

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -24,6 +24,7 @@ import { apply as thinking_message_recall } from './middlewares/chat/thinking_me
 import { apply as thinking_message_send } from './middlewares/chat/thinking_message_send'
 import { apply as list_all_embeddings } from './middlewares/model/list_all_embeddings'
 import { apply as list_all_model } from './middlewares/model/list_all_model'
+import { apply as list_all_tool } from './middlewares/model/list_all_tool'
 import { apply as list_all_vectorstore } from './middlewares/model/list_all_vectorstore'
 import { apply as request_model } from './middlewares/model/request_model'
 import { apply as resolve_model } from './middlewares/model/resolve_model'
@@ -89,6 +90,7 @@ export async function middleware(ctx: Context, config: Config) {
             thinking_message_send,
             list_all_embeddings,
             list_all_model,
+            list_all_tool,
             list_all_vectorstore,
             request_model,
             resolve_model,

--- a/packages/core/src/middlewares/model/list_all_tool.ts
+++ b/packages/core/src/middlewares/model/list_all_tool.ts
@@ -1,0 +1,56 @@
+import { Context } from 'koishi'
+
+import { ChainMiddlewareRunStatus, ChatChain } from '../../chains/chain'
+import { Config } from '../../config'
+import { Pagination } from 'koishi-plugin-chatluna/utils/pagination'
+
+export function apply(ctx: Context, config: Config, chain: ChatChain) {
+    const services = ctx.chatluna.platform
+
+    const pagination = new Pagination<string>({
+        formatItem: (value) => value,
+        formatString: {
+            top: '',
+            bottom: '',
+            pages: ''
+        }
+    })
+
+    chain
+        .middleware('list_all_tool', async (session, context) => {
+            const {
+                command,
+                options: { page, limit }
+            } = context
+
+            if (command !== 'list_tool')
+                return ChainMiddlewareRunStatus.SKIPPED
+
+            pagination.updateFormatString({
+                top: session.text('.header') + '\n',
+                bottom: '\n' + session.text('.footer'),
+                pages: '\n' + session.text('.pages')
+            })
+
+            const tools = services.getTools().value.sort((a, b) => {
+                return a.localeCompare(b, undefined, {
+                    numeric: true,
+                    sensitivity: 'base'
+                })
+            })
+
+            await pagination.push(tools)
+
+            context.message = await pagination.getFormattedPage(page, limit)
+
+            return ChainMiddlewareRunStatus.STOP
+        })
+        .after('lifecycle-handle_command')
+        .before('lifecycle-request_model')
+}
+
+declare module '../../chains/chain' {
+    interface ChainMiddlewareName {
+        list_all_tool: never
+    }
+}

--- a/packages/core/src/middlewares/model/list_all_tool.ts
+++ b/packages/core/src/middlewares/model/list_all_tool.ts
@@ -23,8 +23,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 options: { page, limit }
             } = context
 
-            if (command !== 'list_tool')
-                return ChainMiddlewareRunStatus.SKIPPED
+            if (command !== 'list_tool') return ChainMiddlewareRunStatus.SKIPPED
 
             pagination.updateFormatString({
                 top: session.text('.header') + '\n',

--- a/packages/core/src/middlewares/model/request_model.ts
+++ b/packages/core/src/middlewares/model/request_model.ts
@@ -117,10 +117,6 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 context.options.messageId
             )
 
-            logger.debug(
-                `Create request id: ${requestId} in ${room.roomName}-'${room.roomId}'`
-            )
-
             const chatCallbacks = createChatCallbacks(
                 context,
                 session,

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-long-memory",
   "description": "long memory for chatluna",
-  "version": "1.3.0-alpha.3",
+  "version": "1.3.0-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-long-memory/src/utils/chat-history.ts
+++ b/packages/extension-long-memory/src/utils/chat-history.ts
@@ -141,7 +141,7 @@ export async function extractMemoriesFromChat(
     for (let i = 0; i < 2; i++) {
         try {
             memories = await extractMemory()
-            if (memories && memories.length > 0) {
+            if (Array.isArray(memories)) {
                 break
             }
         } catch (e) {

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-mcp-client",
   "description": "MCP Client for ChatLuna",
-  "version": "1.3.0-alpha.7",
+  "version": "1.3.0-alpha.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61",
     "koishi-plugin-chatluna-storage-service": "^0.0.10"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -60,7 +60,7 @@
   "peerDependencies": {
     "koishi": "^4.18.9",
     "koishi-plugin-chatluna": "^1.3.0-alpha.60",
-    "koishi-plugin-chatluna-storage-service": "^0.0.9"
+    "koishi-plugin-chatluna-storage-service": "^0.0.10"
   },
   "peerDependenciesMeta": {
     "koishi-plugin-chatluna-storage-service": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-plugin-common",
   "description": "plugin service for agent mode of chatluna",
-  "version": "1.3.0-alpha.17",
+  "version": "1.3.0-alpha.18",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61",
     "koishi-plugin-chatluna-storage-service": "^0.0.10"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -70,7 +70,7 @@
   "peerDependencies": {
     "koishi": "^4.18.9",
     "koishi-plugin-chatluna": "^1.3.0-alpha.60",
-    "koishi-plugin-chatluna-storage-service": "^0.0.9"
+    "koishi-plugin-chatluna-storage-service": "^0.0.10"
   },
   "peerDependenciesMeta": {
     "koishi-plugin-chatluna-storage-service": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -64,7 +64,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -76,7 +76,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -59,7 +59,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.60"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.61"
   }
 }


### PR DESCRIPTION
This PR adds a new tool listing command with pagination support and refactors the reactive chain management system to improve code maintainability and reduce potential memory leaks.

### New Features

- **Tool listing command**: Added `chatluna.tool.list` command with pagination support (`--page` and `--limit` options) to display all available tools
- Added localization support for the new tool command in both English and Chinese
- Implemented dedicated middleware `list_all_tool` for handling tool list requests with pagination

### Bug Fixes

- Fixed memory extraction validation in long-memory extension to properly check for array type
- Added null check for tool lookup in platform service to prevent runtime errors
- Improved error handling when tools are not found

### Other Changes

- **Refactored reactive management**: Simplified ChatInterface to use ComputedRef for chain wrapper instead of manual watchers
- Removed manual watch subscriptions in favor of Vue's computed properties for better automatic reactivity
- Simplified chain initialization logic and lifecycle management
- Updated embeddings property to return ComputedRef for consistency across the codebase
- Removed unnecessary debug logging in request_model middleware  
- Bumped koishi-plugin-chatluna-storage-service peer dependency from ^0.0.9 to ^0.0.10

**Technical improvements**: The reactive refactoring reduces complexity by leveraging Vue's computed properties instead of manual watch subscriptions, making the code more maintainable and reducing potential memory leaks from untracked watchers.