### PR TITLE
[Fix] Refactor tool selection and fix vector store operations

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63",
         "koishi-plugin-chatluna-storage-service": "^0.0.10"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.3.0-alpha.62",
+    "version": "1.3.0-alpha.63",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/agent/creator.ts
+++ b/packages/core/src/llm-core/agent/creator.ts
@@ -99,11 +99,11 @@ export function createToolsRef(options: CreateToolsRefOptions) {
                 : selected
         })
 
+        const oldToolIds = new Set(oldActiveTools.map((t) => t.id))
+
         const hasChanges =
             newActiveTools.length !== oldActiveTools.length ||
-            newActiveTools.some(
-                (tool) => !oldActiveTools.find((t) => t.id === tool.id)
-            )
+            newActiveTools.some((tool) => !oldToolIds.has(tool.id))
 
         return [newActiveTools, hasChanges]
     }

--- a/packages/core/src/llm-core/agent/creator.ts
+++ b/packages/core/src/llm-core/agent/creator.ts
@@ -89,48 +89,23 @@ export function createToolsRef(options: CreateToolsRefOptions) {
         session: Session,
         messages: BaseMessage[]
     ): [ChatLunaTool[], boolean] => {
-        const oldActiveTools: ChatLunaTool[] = activeTools.value
-
         const toolsRef = options.tools.value
+        const oldActiveTools = activeTools.value
 
-        const newActiveTools: [ChatLunaTool, boolean][] = toolsRef.map(
-            (tool) => {
-                const base = tool.selector(messages)
-
-                if (tool.authorization) {
-                    return [tool, tool.authorization(session) && base]
-                }
-
-                return [tool, base]
-            }
-        )
-
-        const differenceTools = newActiveTools.filter((newTool) => {
-            const include = oldActiveTools.find(
-                (oldTool) => oldTool.id === newTool[0].id
-            )
-
-            return !include || (include && newTool[1] === false)
+        const newActiveTools = toolsRef.filter((tool) => {
+            const selected = tool.selector(messages)
+            return tool.authorization
+                ? tool.authorization(session) && selected
+                : selected
         })
 
-        if (differenceTools.length < 1) {
-            return [toolsRef, oldActiveTools.length === toolsRef.length]
-        }
-
-        for (const differenceTool of differenceTools) {
-            const index = oldActiveTools.findIndex(
-                (tool) => tool.name === differenceTool[0].name
+        const hasChanges =
+            newActiveTools.length !== oldActiveTools.length ||
+            newActiveTools.some(
+                (tool) => !oldActiveTools.find((t) => t.id === tool.id)
             )
-            if (index > -1) {
-                oldActiveTools.splice(index, 1)
-            }
 
-            if (differenceTool[1] === true) {
-                oldActiveTools.push(differenceTool[0])
-            }
-        }
-
-        return [oldActiveTools, true]
+        return [newActiveTools, hasChanges]
     }
 
     const update = (session: Session, messages: BaseMessage[]) => {

--- a/packages/core/src/llm-core/chain/prompt.ts
+++ b/packages/core/src/llm-core/chain/prompt.ts
@@ -135,12 +135,12 @@ export class ChatLunaChatPrompt
                         `Relevant context: <context>{long_history}</context>
 
 Guidelines for response:
-1. Use the system prompt as your primary guide.
-2. Incorporate the provided context if relevant, but don't force its inclusion.
-3. Generate thoughtful, creative, and diverse responses.
-4. Avoid repetition and expand your perspective.
+1. The context above may contain documents, memories, or knowledge to help you better assist the user.
+2. Determine whether the content is documents, memories, or knowledge, and respond accordingly.
+3. If the user's question or chat is unrelated to the provided context, ignore the documents, memories, and knowledge.
+4. Use the system prompt as your primary guide and incorporate the context only when relevant.
 
-Your goal is to craft an insightful, engaging response that seamlessly integrates all relevant information while maintaining coherence and originality.`
+Your goal is to provide better assistance based on these materials while maintaining natural and coherent responses.`
                 )
         }
 

--- a/packages/core/src/llm-core/vectorstores/base.ts
+++ b/packages/core/src/llm-core/vectorstores/base.ts
@@ -37,14 +37,18 @@ export abstract class ChatLunaSaveableVectorStore<
         await this.addDocuments([newDocument])
     }
 
-    addVectors(
+    async addVectors(
         vectors: number[][],
         documents: DocumentInterface[],
         options?: AddDocumentOptions
     ): Promise<string[] | void> {
         this.checkActive()
 
-        return this._store.addVectors(vectors, documents, options)
+        const ids = await this._store.addVectors(vectors, documents, options)
+
+        await this.save()
+
+        return ids
     }
 
     async addDocuments(

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-long-memory",
     "description": "long memory for chatluna",
-    "version": "1.3.0-alpha.5",
+    "version": "1.3.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/extension-long-memory/src/layers/basic/layer.ts
+++ b/packages/extension-long-memory/src/layers/basic/layer.ts
@@ -67,10 +67,6 @@ export class BasicMemoryLayer<
                 .map((doc) => documentToEnhancedMemory(doc, this.info))
                 .filter((memory) => !isMemoryExpired(memory))
 
-            logger.debug(
-                `Basic layer returning ${memories.length} valid (non-expired) memories.`
-            )
-
             return memories
         } catch (error) {
             logger.error('Error retrieving memories from basic layer:', error)

--- a/packages/extension-long-memory/src/layers/emgas/layer.ts
+++ b/packages/extension-long-memory/src/layers/emgas/layer.ts
@@ -203,10 +203,6 @@ export class EmgasMemoryLayer<
             limit: passageIds.size
         })
 
-        logger.debug(
-            `Retrieved ${relevantDocs.length} full documents from doc store.`
-        )
-
         return relevantDocs.map((doc) =>
             documentToEnhancedMemory(doc, this.info)
         )

--- a/packages/extension-long-memory/src/plugins/prompt_varaiable.ts
+++ b/packages/extension-long-memory/src/plugins/prompt_varaiable.ts
@@ -2,6 +2,7 @@ import { Context } from 'koishi'
 import { Config, logger, MemoryRetrievalLayerType } from '..'
 import { enhancedMemoryToDocument, isMemoryExpired } from '../utils/memory'
 import { FunctionProvider } from '@chatluna/shared-prompt-renderer'
+import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 
 export async function apply(ctx: Context, config: Config) {
     const handler: FunctionProvider = async (args, variables, configurable) => {
@@ -28,7 +29,11 @@ export async function apply(ctx: Context, config: Config) {
             layerTypes
         )
 
-        const searchContent: string = (variables['prompt'] as string) || ''
+        let searchContent: string = variables['prompt'] as string
+
+        if (Array.isArray(variables['prompt'])) {
+            searchContent = getMessageContent(variables['prompt'])
+        }
 
         const memories = await Promise.all(
             layers.map((layer) => layer.retrieveMemory(searchContent))

--- a/packages/extension-long-memory/src/plugins/prompt_varaiable.ts
+++ b/packages/extension-long-memory/src/plugins/prompt_varaiable.ts
@@ -29,11 +29,11 @@ export async function apply(ctx: Context, config: Config) {
             layerTypes
         )
 
-        let searchContent: string = variables['prompt'] as string
-
-        if (Array.isArray(variables['prompt'])) {
-            searchContent = getMessageContent(variables['prompt'])
-        }
+        const searchContent = Array.isArray(variables['prompt'])
+            ? getMessageContent(variables['prompt'])
+            : typeof variables['prompt'] === 'string'
+              ? variables['prompt']
+              : ''
 
         const memories = await Promise.all(
             layers.map((layer) => layer.retrieveMemory(searchContent))

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63",
         "koishi-plugin-chatluna-storage-service": "^0.0.10"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-plugin-common",
     "description": "plugin service for agent mode of chatluna",
-    "version": "1.3.0-alpha.18",
+    "version": "1.3.0-alpha.19",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63",
         "koishi-plugin-chatluna-storage-service": "^0.0.10"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/src/plugins/command.ts
+++ b/packages/extension-tools/src/plugins/command.ts
@@ -42,6 +42,9 @@ export async function apply(
 
         plugin.registerTool(`command_execute_${normalizedName}`, {
             selector(history) {
+                if (command.selector == null || command.selector.length === 0) {
+                    return true
+                }
                 return history.some((item) => {
                     const content = getMessageContent(item.content)
 

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-vector-store-service",
     "description": "vector store service for chatluna",
-    "version": "1.3.0-alpha.1",
+    "version": "1.3.0-alpha.2",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.0",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -41,7 +41,7 @@
         }
     },
     "dependencies": {
-        "@chatluna/luna-vdb": "^0.0.11",
+        "@chatluna/luna-vdb": "^0.0.12",
         "@langchain/community": "0.3.48",
         "@langchain/core": "0.3.62",
         "@langchain/redis": "^0.1.3",

--- a/packages/service-vector-store/src/rag/standard/index.ts
+++ b/packages/service-vector-store/src/rag/standard/index.ts
@@ -107,9 +107,7 @@ export class StandardRAGRetriever extends BaseRAGRetriever<StandardRAGRetrieverC
                 : await this._vectorStore
                       .similaritySearchWithScore(query, k)
                       .then((results) =>
-                          results.filter(
-                              ([doc]) => doc.metadata.score >= threshold
-                          )
+                          results.filter(([doc, score]) => score >= threshold)
                       )
 
         const context: RetrievalContext = {

--- a/packages/service-vector-store/src/vectorstore/base/lunavdb.ts
+++ b/packages/service-vector-store/src/vectorstore/base/lunavdb.ts
@@ -17,7 +17,7 @@ export interface LunaVDBLibArgs {
 
 /**
  * Class that extends `VectorStore`. It allows to perform similarity search using
- * Voi similarity search engine. The class requires passing Voy Client as an input parameter.
+ * Voi similarity search engine. The class requires passing LunaVDB Client as an input parameter.
  */
 export class LunaDBVectorStore extends SaveableVectorStore {
     client: LunaDB

--- a/packages/service-vector-store/src/vectorstore/base/redis.ts
+++ b/packages/service-vector-store/src/vectorstore/base/redis.ts
@@ -24,7 +24,7 @@ export class RedisVectorStoreWrapper extends ChatLunaSaveableVectorStore<RedisVe
         keys = documents.map((document, i) => {
             const id = keys[i] ?? document.id ?? crypto.randomUUID()
 
-            document.id = id
+            document.id = this._store.keyPrefix + id
             document.metadata = { ...document.metadata, raw_id: id }
 
             return id

--- a/packages/service-vector-store/src/vectorstore/base/redis.ts
+++ b/packages/service-vector-store/src/vectorstore/base/redis.ts
@@ -27,7 +27,7 @@ export class RedisVectorStoreWrapper extends ChatLunaSaveableVectorStore<RedisVe
             document.id = id
             document.metadata = { ...document.metadata, raw_id: id }
 
-            return this._store.keyPrefix + id
+            return id
         })
 
         return super.addDocuments(documents, {

--- a/packages/service-vector-store/src/vectorstore/faiss.ts
+++ b/packages/service-vector-store/src/vectorstore/faiss.ts
@@ -75,6 +75,11 @@ export async function apply(
                 ]
             }
 
+            logger.info(
+                `ReIndex faiss store with %c documents`,
+                documents.length
+            )
+
             faissStore = await FaissStore.fromDocuments(documents, embeddings)
 
             await faissStore.save(directory)

--- a/packages/service-vector-store/src/vectorstore/lunavdb.ts
+++ b/packages/service-vector-store/src/vectorstore/lunavdb.ts
@@ -73,6 +73,11 @@ export async function apply(
                 ]
             }
 
+            logger.info(
+                `ReIndex lunavdb store with %c documents`,
+                documents.length
+            )
+
             const lunaDBStore = new LunaDB()
             tempStore = new LunaDBVectorStore(lunaDBStore, embeddings)
             await tempStore.addDocuments(documents)

--- a/packages/service-vector-store/src/vectorstore/redis.ts
+++ b/packages/service-vector-store/src/vectorstore/redis.ts
@@ -76,7 +76,7 @@ export async function apply(
                 (document) => document.id ?? randomUUID()
             )
             await vectorStore.addDocuments(documents, {
-                keys: tempIds.map((id) => vectorStore.keyPrefix + id)
+                keys: tempIds
             })
         }
 

--- a/packages/service-vector-store/src/vectorstore/redis.ts
+++ b/packages/service-vector-store/src/vectorstore/redis.ts
@@ -76,7 +76,7 @@ export async function apply(
                 (document) => document.id ?? randomUUID()
             )
             await vectorStore.addDocuments(documents, {
-                keys: tempIds
+                keys: tempIds.map((id) => vectorStore.keyPrefix + id)
             })
         }
 

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.62"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.63"
     }
 }


### PR DESCRIPTION
This PR refactors tool selection logic and fixes several issues in vector store operations across multiple packages.

### Bug Fixes

- Simplified tool selection logic in agent creator by directly filtering active tools instead of complex difference calculation
- Fixed vector store save operation to properly persist data after adding vectors
- Fixed prompt variable handling to support array-type prompts using getMessageContent
- Fixed tool selector to return true when no selector is defined (default behavior)
- Fixed score threshold filtering in RAG retriever to use actual similarity score instead of metadata
- Fixed Redis vector store to return correct document IDs without key prefix

### Other Changes

- Removed excessive debug logging from basic and emgas memory layers
- Added reindex logging for Faiss and LunaVDB stores for better observability
- Updated LunaVDB documentation comment for accuracy