### PR TITLE
[Fix] Improve tool system stability and simplify MCP commands

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65",
         "koishi-plugin-chatluna-storage-service": "^0.0.10"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.3.0-alpha.64",
+    "version": "1.3.0-alpha.65",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/agent/creator.ts
+++ b/packages/core/src/llm-core/agent/creator.ts
@@ -78,11 +78,17 @@ export function createToolsRef(options: CreateToolsRefOptions) {
     const activeTools = shallowRef<ChatLunaTool[]>([])
 
     const tools = computed(() => {
-        return activeTools.value.map((tool) =>
-            tool.createTool({
-                embeddings: options.embeddings
+        return activeTools.value
+            .map((tool) => {
+                try {
+                    return tool.createTool({
+                        embeddings: options.embeddings
+                    })
+                } catch (error) {
+                    console.error(`Error creating tool ${tool.id}:`, error)
+                }
             })
-        )
+            .filter(Boolean)
     })
 
     const getActiveTools = (

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/extension-long-memory/src/plugins/prompt_varaiable.ts
+++ b/packages/extension-long-memory/src/plugins/prompt_varaiable.ts
@@ -133,15 +133,17 @@ export async function apply(ctx: Context, config: Config) {
         return result
     }
 
-    ctx.chatluna.promptRenderer.registerFunctionProvider(
-        'long_memory',
-        async (args, variables, configurable) => {
-            try {
-                return await handler(args, variables, configurable)
-            } catch (error) {
-                logger.error(error)
-                return 'Error retrieving long-term memory'
+    ctx.effect(() =>
+        ctx.chatluna.promptRenderer.registerFunctionProvider(
+            'long_memory',
+            async (args, variables, configurable) => {
+                try {
+                    return await handler(args, variables, configurable)
+                } catch (error) {
+                    logger.error(error)
+                    return 'Error retrieving long-term memory'
+                }
             }
-        }
+        )
     )
 }

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-mcp-client",
     "description": "MCP Client for ChatLuna",
-    "version": "1.3.0-alpha.8",
+    "version": "1.3.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65",
         "koishi-plugin-chatluna-storage-service": "^0.0.10"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-mcp/src/command.ts
+++ b/packages/extension-mcp/src/command.ts
@@ -5,90 +5,45 @@ export function apply(ctx: Context, config: Config) {
     ctx.command('chatluna.mcp', 'MCP 工具管理相关命令')
 
     // List command
-    ctx.command('chatluna.mcp.list', '列出所有 MCP 工具')
-        .option('raw', '-r 列出原始的 MCP 服务器配置')
-        .action(async ({ session, options }) => {
-            if (options.raw) {
-                // List raw MCP servers
-                try {
-                    const parsedConfig = JSON.parse(config.servers)
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    let servers: Record<string, any> = {}
-
-                    if (Array.isArray(parsedConfig)) {
-                        servers = parsedConfig.reduce((acc, server, index) => {
-                            acc[`server-${index}`] = server
-                            return acc
-                        }, {})
-                    } else if (parsedConfig['mcpServers']) {
-                        servers = parsedConfig['mcpServers']
-                    } else {
-                        await session.send(session.text('.empty_servers'))
-                        return
-                    }
-
-                    if (Object.keys(servers).length === 0) {
-                        await session.send(session.text('.empty_servers'))
-                        return
-                    }
-
-                    const messages = [session.text('.list_servers_header')]
-                    for (const [name, serverConfig] of Object.entries(
-                        servers
-                    )) {
-                        messages.push(
-                            session.text('.server_name', [name]),
-                            session.text('.server_config', [
-                                JSON.stringify(serverConfig, null, 2)
-                            ]),
-                            '---'
-                        )
-                    }
-
-                    await session.send(messages.join('\n'))
-                } catch (error) {
-                    await session.send(session.text('.parse_error'))
+    ctx.command('chatluna.mcp.list', '列出所有 MCP 工具').action(
+        async ({ session, options }) => {
+            // List tools
+            try {
+                const service = ctx.chatluna_mcp
+                if (!service) {
+                    await session.send(session.text('.service_not_ready'))
+                    return
                 }
-            } else {
-                // List tools
-                try {
-                    const service = ctx.chatluna_mcp
-                    if (!service) {
-                        await session.send(session.text('.service_not_ready'))
-                        return
-                    }
 
-                    const tools = service.globalTools
+                const tools = service.globalTools
 
-                    if (Object.keys(tools).length === 0) {
-                        await session.send(session.text('.empty_tools'))
-                        return
-                    }
+                if (Object.keys(tools).length === 0) {
+                    await session.send(session.text('.empty_tools'))
+                    return
+                }
 
-                    const messages = [session.text('.list_tools_header')]
-                    for (const [name, tool] of Object.entries(tools)) {
-                        const selectorText =
-                            tool.selector && tool.selector.length > 0
-                                ? tool.selector.join(', ')
-                                : session.text('.no_selector')
-                        messages.push(
-                            session.text('.tool_name', [name]),
-                            session.text('.tool_enabled', [
-                                tool.enabled ? '✓' : '✗'
-                            ]),
-                            session.text('.tool_selector', [selectorText]),
-                            '---'
-                        )
-                    }
-
-                    await session.send(messages.join('\n'))
-                } catch (error) {
-                    await session.send(
-                        session.text('.list_error', [error.message])
+                const messages = [session.text('.list_tools_header')]
+                for (const [name, tool] of Object.entries(tools)) {
+                    const selectorText =
+                        tool.selector && tool.selector.length > 0
+                            ? tool.selector.join(', ')
+                            : session.text('.no_selector')
+                    messages.push(
+                        session.text('.tool_name', [name]),
+                        session.text('.tool_enabled', [
+                            tool.enabled ? '✓' : '✗'
+                        ]),
+                        session.text('.tool_selector', [selectorText]),
+                        '---'
                     )
                 }
+
+                await session.send(messages.join('\n'))
+            } catch (error) {
+                await session.send(session.text('.list_error', [error.message]))
             }
-        })
+        }
+    )
 
     // Add command
     ctx.command('chatluna.mcp.add <mcpConfig:text>', '添加 MCP 服务器', {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-plugin-common",
     "description": "plugin service for agent mode of chatluna",
-    "version": "1.3.0-alpha.20",
+    "version": "1.3.0-alpha.21",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65",
         "koishi-plugin-chatluna-storage-service": "^0.0.10"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/src/plugins/command.ts
+++ b/packages/extension-tools/src/plugins/command.ts
@@ -131,39 +131,54 @@ function getCommandList(
     ctx: Context,
     rawCommandList: Config['commandList']
 ): PickCommandType[] {
-    return ctx.$commander._commandList
-        .filter((item) => !item.name.includes('chatluna'))
-        .filter((item) => {
-            if (rawCommandList.length < 1) {
-                return true
-            }
-            return rawCommandList.some(
-                (command) => command.command === item.name
-            )
-        })
-        .map((item) => item.toJSON())
-        .map((item) => {
-            const rawCommand = rawCommandList.find(
-                (command) => command.command === item.name
-            )
+    const commandMap = new Map(
+        ctx.$commander._commandList
+            .filter((item) => !item.name.includes('chatluna'))
+            .map((cmd) => [cmd.name, cmd.toJSON()])
+    )
 
-            let description: string | CommandType['description'] =
-                rawCommand?.description
+    // If rawCommandList is provided, map based on it
+    if (rawCommandList.length > 0) {
+        return rawCommandList
+            .map((rawCommand) => {
+                const item = commandMap.get(rawCommand.command)
 
-            if (
-                (rawCommand?.description?.length ?? 0) < 1 &&
-                item.description
-            ) {
-                description = JSON.stringify(item.description)
-            }
+                if (!item) {
+                    ctx.logger.warn(
+                        `Command "${rawCommand.command}" not found in command list`
+                    )
+                    return null
+                }
 
-            return {
-                ...item,
-                selector: rawCommand?.selector,
-                confirm: rawCommand?.confirm ?? true,
-                description
-            }
-        })
+                let description: string | CommandType['description'] =
+                    rawCommand.description
+
+                if (
+                    (rawCommand.description?.length ?? 0) < 1 &&
+                    item.description
+                ) {
+                    description = JSON.stringify(item.description)
+                }
+
+                return {
+                    ...item,
+                    selector: rawCommand.selector,
+                    confirm: rawCommand.confirm ?? true,
+                    description
+                } satisfies PickCommandType
+            })
+            .filter((item) => item !== null)
+    }
+
+    // Otherwise, return all commands except chatluna
+    return Array.from(commandMap.values()).map((item) => ({
+        ...item,
+        confirm: true,
+        description:
+            typeof item.description === 'string'
+                ? item.description
+                : JSON.stringify(item.description)
+    }))
 }
 
 export class CommandExecuteTool extends StructuredTool {

--- a/packages/extension-tools/src/plugins/command.ts
+++ b/packages/extension-tools/src/plugins/command.ts
@@ -285,7 +285,7 @@ export class CommandExecuteTool extends StructuredTool {
                                       return `[image:${imageUrl.substring(0, 12)}]`
                                   }
 
-                                  return `[image:${imageUrl}] Please use ![image](url)  send image to user`
+                                  return `[image:${imageUrl}] Please use ![image](url) send image to user`
                               }
                           })
                           .join('\n\n')

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.0",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.64"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.65"
     }
 }


### PR DESCRIPTION
This PR improves the stability of the tool system and simplifies the MCP command interface.

## Bug Fixes

- **Fix tool creation error handling**: Added try-catch blocks in `createToolsRef` to gracefully handle tool creation failures and filter out undefined tools (packages/core/src/llm-core/agent/creator.ts:78-91)
- **Fix lifecycle management**: Wrapped prompt function provider registration in `ctx.effect()` for proper cleanup in long-memory extension (packages/extension-long-memory/src/plugins/prompt_varaiable.ts:136-148)

## Refactor

- **Simplify MCP list command**: Removed the `-r/--raw` option from `chatluna.mcp.list` command to streamline user experience and focus on tool management rather than exposing internal server configuration details (packages/extension-mcp/src/command.ts:8-45)
- **Code cleanup**: Minor formatting fix in command execute tool

## Other Changes

- Improved error logging for tool creation failures with descriptive messages
- Reduced code complexity by removing unnecessary nested logic in MCP commands

These changes enhance system stability by preventing crashes from tool creation errors and ensuring proper resource cleanup through Koishi's effect system.