### PR TITLE
[Fix] Fix long-memory plugin lifecycle and initialization issues

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67",
         "koishi-plugin-chatluna-storage-service": "^0.0.10"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.3.0-alpha.66",
+    "version": "1.3.0-alpha.67",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/chains/chain.ts
+++ b/packages/core/src/chains/chain.ts
@@ -112,9 +112,9 @@ export class ChatChain {
 
         this._graph.addNode(result)
 
-        ctx.on('dispose', () => {
-            this._graph.removeNode(name)
-        })
+        const dispose = () => this._graph.removeNode(name)
+
+        ctx.effect(() => dispose)
 
         return result
     }
@@ -401,6 +401,7 @@ class ChatChainDependencyGraph {
             name: middleware.name,
             middleware
         })
+        this._cachedOrder = null
     }
 
     removeNode(name: string): void {
@@ -409,6 +410,7 @@ class ChatChainDependencyGraph {
         for (const deps of this._dependencies.values()) {
             deps.delete(name)
         }
+        this._cachedOrder = null
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -875,7 +875,7 @@ class ChatInterfaceWrapper {
             const humanMessage = new HumanMessage({
                 content: message.content,
                 name: message.name,
-                id: conversationId,
+                id: session.userId,
                 additional_kwargs: {
                     ...message.additional_kwargs,
                     preset: room.preset

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-long-memory",
     "description": "long memory for chatluna",
-    "version": "1.3.0-alpha.6",
+    "version": "1.3.0-alpha.7",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/extension-long-memory/src/index.ts
+++ b/packages/extension-long-memory/src/index.ts
@@ -10,6 +10,7 @@ export let logger: Logger
 
 export function apply(ctx: Context, config: Config) {
     logger = createLogger(ctx, 'chatluna-long-memory')
+
     const plugin = new ChatLunaPlugin<ClientConfig, Config>(
         ctx,
         config,
@@ -17,13 +18,11 @@ export function apply(ctx: Context, config: Config) {
         false
     )
 
-    ctx.on('ready', async () => {
-        ctx.plugin(ChatLunaLongMemoryService, config)
+    ctx.plugin(ChatLunaLongMemoryService, config)
 
-        ctx.inject(['chatluna_long_memory'], (ctx) => {
-            ctx.on('ready', async () => {
-                await plugins(ctx, config, plugin)
-            })
+    ctx.inject(['chatluna_long_memory'], (ctx) => {
+        ctx.on('ready', async () => {
+            await plugins(ctx, config, plugin)
         })
     })
 }

--- a/packages/extension-long-memory/src/plugins/add_memory.ts
+++ b/packages/extension-long-memory/src/plugins/add_memory.ts
@@ -8,70 +8,79 @@ export function apply(ctx: Context, config: Config) {
     const chain = ctx.chatluna.chatChain
 
     chain
-        .middleware('add_memory', async (session, context) => {
-            let {
-                command,
-                options: { type, content, room, view }
-            } = context
+        .middleware(
+            'add_memory',
+            async (session, context) => {
+                let {
+                    command,
+                    options: { type, content, room, view }
+                } = context
 
-            if (command !== 'add_memory')
-                return ChainMiddlewareRunStatus.SKIPPED
+                if (command !== 'add_memory')
+                    return ChainMiddlewareRunStatus.SKIPPED
 
-            if (!type) {
-                type = room.preset
-            }
-
-            let parsedLayerType = MemoryRetrievalLayerType.USER
-
-            if (view != null) {
-                parsedLayerType = MemoryRetrievalLayerType[view.toUpperCase()]
-
-                if (parsedLayerType == null) {
-                    context.message = session.text('.invalid_view', [
-                        ['global', 'preset', 'user', 'preset_user'].join(', ')
-                    ])
-                    return ChainMiddlewareRunStatus.STOP
+                if (!type) {
+                    type = room.preset
                 }
-            }
 
-            try {
-                const layers = await ctx.chatluna_long_memory.initMemoryLayers(
-                    {
-                        presetId: type as string,
-                        guildId: session.guildId || session.channelId,
-                        userId: session.userId
-                    },
-                    room.conversationId,
-                    parsedLayerType
-                )
+                let parsedLayerType = MemoryRetrievalLayerType.USER
 
-                await Promise.all(
-                    layers.map((layer) =>
-                        layer.addMemories([
-                            {
-                                content,
-                                id: randomUUID(),
-                                type: MemoryType.PREFERENCE,
-                                importance: 10,
-                                // 10 years
-                                expirationDate: new Date(
-                                    Date.now() + 1000 * 60 * 60 * 24 * 365 * 10
-                                )
-                            }
+                if (view != null) {
+                    parsedLayerType =
+                        MemoryRetrievalLayerType[view.toUpperCase()]
+
+                    if (parsedLayerType == null) {
+                        context.message = session.text('.invalid_view', [
+                            ['global', 'preset', 'user', 'preset_user'].join(
+                                ', '
+                            )
                         ])
+                        return ChainMiddlewareRunStatus.STOP
+                    }
+                }
+
+                try {
+                    const layers =
+                        await ctx.chatluna_long_memory.initMemoryLayers(
+                            {
+                                presetId: type as string,
+                                guildId: session.guildId || session.channelId,
+                                userId: session.userId
+                            },
+                            room.conversationId,
+                            parsedLayerType
+                        )
+
+                    await Promise.all(
+                        layers.map((layer) =>
+                            layer.addMemories([
+                                {
+                                    content,
+                                    id: randomUUID(),
+                                    type: MemoryType.PREFERENCE,
+                                    importance: 10,
+                                    // 10 years
+                                    expirationDate: new Date(
+                                        Date.now() +
+                                            1000 * 60 * 60 * 24 * 365 * 10
+                                    )
+                                }
+                            ])
+                        )
                     )
-                )
 
-                await ctx.chatluna.clearCache(room)
+                    await ctx.chatluna.clearCache(room)
 
-                context.message = session.text('.add_success')
-            } catch (error) {
-                logger?.error(error)
-                context.message = session.text('.add_failed')
-            }
+                    context.message = session.text('.add_success')
+                } catch (error) {
+                    logger?.error(error)
+                    context.message = session.text('.add_failed')
+                }
 
-            return ChainMiddlewareRunStatus.STOP
-        })
+                return ChainMiddlewareRunStatus.STOP
+            },
+            ctx
+        )
         .after('lifecycle-handle_command')
 }
 

--- a/packages/extension-long-memory/src/plugins/clear_memory.ts
+++ b/packages/extension-long-memory/src/plugins/clear_memory.ts
@@ -7,8 +7,6 @@ import { Config } from '..'
 export function apply(ctx: Context, config: Config) {
     const chain = ctx.chatluna.chatChain
 
-    console.log('Initializing memory layers...')
-
     chain
         .middleware(
             'clear_memory',

--- a/packages/extension-long-memory/src/plugins/clear_memory.ts
+++ b/packages/extension-long-memory/src/plugins/clear_memory.ts
@@ -7,55 +7,67 @@ import { Config } from '..'
 export function apply(ctx: Context, config: Config) {
     const chain = ctx.chatluna.chatChain
 
+    console.log('Initializing memory layers...')
+
     chain
-        .middleware('clear_memory', async (session, context) => {
-            let {
-                command,
-                options: { type, room, view }
-            } = context
+        .middleware(
+            'clear_memory',
+            async (session, context) => {
+                let {
+                    command,
+                    options: { type, room, view }
+                } = context
 
-            if (command !== 'clear_memory')
-                return ChainMiddlewareRunStatus.SKIPPED
+                if (command !== 'clear_memory')
+                    return ChainMiddlewareRunStatus.SKIPPED
 
-            if (!type) {
-                type = room.preset
-            }
-
-            let parsedLayerType = MemoryRetrievalLayerType.USER
-
-            if (view != null) {
-                parsedLayerType = MemoryRetrievalLayerType[view.toUpperCase()]
-
-                if (parsedLayerType == null) {
-                    context.message = session.text('.invalid_view', [
-                        ['global', 'preset', 'user', 'preset_user'].join(', ')
-                    ])
-                    return ChainMiddlewareRunStatus.STOP
+                if (!type) {
+                    type = room.preset
                 }
-            }
 
-            try {
-                const layers = await ctx.chatluna_long_memory.initMemoryLayers(
-                    {
-                        presetId: type as string,
-                        guildId: session.guildId || session.channelId,
-                        userId: session.userId
-                    },
-                    room.conversationId,
-                    parsedLayerType
-                )
+                let parsedLayerType = MemoryRetrievalLayerType.USER
 
-                await Promise.all(layers.map((layer) => layer.clearMemories()))
+                if (view != null) {
+                    parsedLayerType =
+                        MemoryRetrievalLayerType[view.toUpperCase()]
 
-                await ctx.chatluna.clearCache(room)
-                context.message = session.text('.clear_success')
-            } catch (error) {
-                logger?.error(error)
-                context.message = session.text('.clear_failed')
-            }
+                    if (parsedLayerType == null) {
+                        context.message = session.text('.invalid_view', [
+                            ['global', 'preset', 'user', 'preset_user'].join(
+                                ', '
+                            )
+                        ])
+                        return ChainMiddlewareRunStatus.STOP
+                    }
+                }
 
-            return ChainMiddlewareRunStatus.STOP
-        })
+                try {
+                    const layers =
+                        await ctx.chatluna_long_memory.initMemoryLayers(
+                            {
+                                presetId: type as string,
+                                guildId: session.guildId || session.channelId,
+                                userId: session.userId
+                            },
+                            room.conversationId,
+                            parsedLayerType
+                        )
+
+                    await Promise.all(
+                        layers.map((layer) => layer.clearMemories())
+                    )
+
+                    await ctx.chatluna.clearCache(room)
+                    context.message = session.text('.clear_success')
+                } catch (error) {
+                    logger?.error(error)
+                    context.message = session.text('.clear_failed')
+                }
+
+                return ChainMiddlewareRunStatus.STOP
+            },
+            ctx
+        )
         .after('lifecycle-handle_command')
 }
 

--- a/packages/extension-long-memory/src/plugins/delete_memory.ts
+++ b/packages/extension-long-memory/src/plugins/delete_memory.ts
@@ -7,56 +7,64 @@ export function apply(ctx: Context, config: Config) {
     const chain = ctx.chatluna.chatChain
 
     chain
-        .middleware('delete_memory', async (session, context) => {
-            let {
-                command,
-                options: { type, room, ids, view }
-            } = context
+        .middleware(
+            'delete_memory',
+            async (session, context) => {
+                let {
+                    command,
+                    options: { type, room, ids, view }
+                } = context
 
-            if (command !== 'delete_memory')
-                return ChainMiddlewareRunStatus.SKIPPED
+                if (command !== 'delete_memory')
+                    return ChainMiddlewareRunStatus.SKIPPED
 
-            if (!type) {
-                type = room.preset
-            }
-
-            let parsedLayerType = MemoryRetrievalLayerType.USER
-
-            if (view != null) {
-                parsedLayerType = MemoryRetrievalLayerType[view.toUpperCase()]
-
-                if (parsedLayerType == null) {
-                    context.message = session.text('.invalid_view', [
-                        ['global', 'preset', 'user', 'preset_user'].join(', ')
-                    ])
-                    return ChainMiddlewareRunStatus.STOP
+                if (!type) {
+                    type = room.preset
                 }
-            }
 
-            try {
-                const layers = await ctx.chatluna_long_memory.initMemoryLayers(
-                    {
-                        presetId: type as string,
-                        guildId: session.guildId || session.channelId,
-                        userId: session.userId
-                    },
-                    room.conversationId,
-                    parsedLayerType
-                )
+                let parsedLayerType = MemoryRetrievalLayerType.USER
 
-                await Promise.all(
-                    layers.map((layer) => layer.deleteMemories(ids))
-                )
+                if (view != null) {
+                    parsedLayerType =
+                        MemoryRetrievalLayerType[view.toUpperCase()]
 
-                await ctx.chatluna.clearCache(room)
-                context.message = session.text('.delete_success')
-            } catch (error) {
-                logger?.error(error)
-                context.message = session.text('.delete_failed')
-            }
+                    if (parsedLayerType == null) {
+                        context.message = session.text('.invalid_view', [
+                            ['global', 'preset', 'user', 'preset_user'].join(
+                                ', '
+                            )
+                        ])
+                        return ChainMiddlewareRunStatus.STOP
+                    }
+                }
 
-            return ChainMiddlewareRunStatus.STOP
-        })
+                try {
+                    const layers =
+                        await ctx.chatluna_long_memory.initMemoryLayers(
+                            {
+                                presetId: type as string,
+                                guildId: session.guildId || session.channelId,
+                                userId: session.userId
+                            },
+                            room.conversationId,
+                            parsedLayerType
+                        )
+
+                    await Promise.all(
+                        layers.map((layer) => layer.deleteMemories(ids))
+                    )
+
+                    await ctx.chatluna.clearCache(room)
+                    context.message = session.text('.delete_success')
+                } catch (error) {
+                    logger?.error(error)
+                    context.message = session.text('.delete_failed')
+                }
+
+                return ChainMiddlewareRunStatus.STOP
+            },
+            ctx
+        )
         .after('lifecycle-handle_command')
 }
 

--- a/packages/extension-long-memory/src/plugins/edit_memory.ts
+++ b/packages/extension-long-memory/src/plugins/edit_memory.ts
@@ -8,71 +8,79 @@ export function apply(ctx: Context, config: Config) {
     const chain = ctx.chatluna.chatChain
 
     chain
-        .middleware('edit_memory', async (session, context) => {
-            let {
-                command,
-                options: { type, room, memoryId, view }
-            } = context
+        .middleware(
+            'edit_memory',
+            async (session, context) => {
+                let {
+                    command,
+                    options: { type, room, memoryId, view }
+                } = context
 
-            if (command !== 'edit_memory')
-                return ChainMiddlewareRunStatus.SKIPPED
+                if (command !== 'edit_memory')
+                    return ChainMiddlewareRunStatus.SKIPPED
 
-            if (!type) {
-                type = room.preset
-            }
-
-            let parsedLayerType = MemoryRetrievalLayerType.USER
-
-            if (view != null) {
-                parsedLayerType = MemoryRetrievalLayerType[view.toUpperCase()]
-
-                if (parsedLayerType == null) {
-                    context.message = session.text('.invalid_view', [
-                        ['global', 'preset', 'user', 'preset_user'].join(', ')
-                    ])
-                    return ChainMiddlewareRunStatus.STOP
+                if (!type) {
+                    type = room.preset
                 }
-            }
-            try {
-                await session.send(session.text('.edit_memory_start'))
 
-                const content = await session.prompt()
+                let parsedLayerType = MemoryRetrievalLayerType.USER
 
-                const layers = await ctx.chatluna_long_memory.initMemoryLayers(
-                    {
-                        presetId: type as string,
-                        userId: session.userId,
-                        guildId: session.guildId || session.channelId,
-                        type: parsedLayerType,
-                        memoryId
-                    },
-                    room.conversationId,
-                    parsedLayerType
-                )
+                if (view != null) {
+                    parsedLayerType =
+                        MemoryRetrievalLayerType[view.toUpperCase()]
 
-                await Promise.all(
-                    layers.map((layer) => layer.deleteMemories([memoryId]))
-                )
+                    if (parsedLayerType == null) {
+                        context.message = session.text('.invalid_view', [
+                            ['global', 'preset', 'user', 'preset_user'].join(
+                                ', '
+                            )
+                        ])
+                        return ChainMiddlewareRunStatus.STOP
+                    }
+                }
+                try {
+                    await session.send(session.text('.edit_memory_start'))
 
-                const memory = createDefaultMemory(
-                    content,
-                    MemoryType.PREFERENCE,
-                    10
-                )
+                    const content = await session.prompt()
 
-                await Promise.all(
-                    layers.map((layer) => layer.addMemories([memory]))
-                )
+                    const layers =
+                        await ctx.chatluna_long_memory.initMemoryLayers(
+                            {
+                                presetId: type as string,
+                                userId: session.userId,
+                                guildId: session.guildId || session.channelId,
+                                type: parsedLayerType,
+                                memoryId
+                            },
+                            room.conversationId,
+                            parsedLayerType
+                        )
 
-                await ctx.chatluna.clearCache(room)
-                context.message = session.text('.edit_success')
-            } catch (error) {
-                logger?.error(error)
-                context.message = session.text('.edit_failed')
-            }
+                    await Promise.all(
+                        layers.map((layer) => layer.deleteMemories([memoryId]))
+                    )
 
-            return ChainMiddlewareRunStatus.STOP
-        })
+                    const memory = createDefaultMemory(
+                        content,
+                        MemoryType.PREFERENCE,
+                        10
+                    )
+
+                    await Promise.all(
+                        layers.map((layer) => layer.addMemories([memory]))
+                    )
+
+                    await ctx.chatluna.clearCache(room)
+                    context.message = session.text('.edit_success')
+                } catch (error) {
+                    logger?.error(error)
+                    context.message = session.text('.edit_failed')
+                }
+
+                return ChainMiddlewareRunStatus.STOP
+            },
+            ctx
+        )
         .after('lifecycle-handle_command')
 }
 

--- a/packages/extension-long-memory/src/plugins/search_memory.ts
+++ b/packages/extension-long-memory/src/plugins/search_memory.ts
@@ -18,69 +18,80 @@ export function apply(ctx: Context, config: Config) {
     })
 
     chain
-        .middleware('search_memory', async (session, context) => {
-            let {
-                command,
-                options: { page, limit, query, type, room, view }
-            } = context
+        .middleware(
+            'search_memory',
+            async (session, context) => {
+                let {
+                    command,
+                    options: { page, limit, query, type, room, view }
+                } = context
 
-            if (command !== 'search_memory')
-                return ChainMiddlewareRunStatus.SKIPPED
+                if (command !== 'search_memory')
+                    return ChainMiddlewareRunStatus.SKIPPED
 
-            if (!type) {
-                type = room.preset
-            }
-
-            pagination.updateFormatString({
-                top: session.text('.header', [query, type]) + '\n',
-                bottom: session.text('.footer'),
-                pages: session.text('.pages')
-            })
-
-            pagination.updateFormatItem((value) =>
-                formatDocumentInfo(session, value)
-            )
-
-            query = query ?? ' '
-
-            let parsedLayerType = MemoryRetrievalLayerType.USER
-
-            if (view != null) {
-                parsedLayerType = MemoryRetrievalLayerType[view.toUpperCase()]
-
-                if (parsedLayerType == null) {
-                    context.message = session.text('.invalid_view', [
-                        ['global', 'preset', 'user', 'preset_user'].join(', ')
-                    ])
-                    return ChainMiddlewareRunStatus.STOP
+                if (!type) {
+                    type = room.preset
                 }
-            }
 
-            try {
-                const layers = await ctx.chatluna_long_memory.initMemoryLayers(
-                    {
-                        presetId: type as string,
-                        guildId: session.guildId || session.channelId,
-                        userId: session.userId
-                    },
-                    room.conversationId,
-                    parsedLayerType
+                pagination.updateFormatString({
+                    top: session.text('.header', [query, type]) + '\n',
+                    bottom: session.text('.footer'),
+                    pages: session.text('.pages')
+                })
+
+                pagination.updateFormatItem((value) =>
+                    formatDocumentInfo(session, value)
                 )
 
-                const documents = await Promise.all(
-                    layers.map((layer) => layer.retrieveMemory(query))
-                ).then((documents) => documents.flat())
+                query = query ?? ' '
 
-                await pagination.push(documents)
+                let parsedLayerType = MemoryRetrievalLayerType.USER
 
-                context.message = await pagination.getFormattedPage(page, limit)
-            } catch (error) {
-                logger?.error(error)
-                context.message = session.text('.search_failed')
-            }
+                if (view != null) {
+                    parsedLayerType =
+                        MemoryRetrievalLayerType[view.toUpperCase()]
 
-            return ChainMiddlewareRunStatus.STOP
-        })
+                    if (parsedLayerType == null) {
+                        context.message = session.text('.invalid_view', [
+                            ['global', 'preset', 'user', 'preset_user'].join(
+                                ', '
+                            )
+                        ])
+                        return ChainMiddlewareRunStatus.STOP
+                    }
+                }
+
+                try {
+                    const layers =
+                        await ctx.chatluna_long_memory.initMemoryLayers(
+                            {
+                                presetId: type as string,
+                                guildId: session.guildId || session.channelId,
+                                userId: session.userId
+                            },
+                            room.conversationId,
+                            parsedLayerType
+                        )
+
+                    const documents = await Promise.all(
+                        layers.map((layer) => layer.retrieveMemory(query))
+                    ).then((documents) => documents.flat())
+
+                    await pagination.push(documents)
+
+                    context.message = await pagination.getFormattedPage(
+                        page,
+                        limit
+                    )
+                } catch (error) {
+                    logger?.error(error)
+                    context.message = session.text('.search_failed')
+                }
+
+                return ChainMiddlewareRunStatus.STOP
+            },
+            ctx
+        )
         .after('lifecycle-handle_command')
 }
 

--- a/packages/extension-long-memory/src/service/memory.ts
+++ b/packages/extension-long-memory/src/service/memory.ts
@@ -70,6 +70,21 @@ export class ChatLunaLongMemoryService extends Service {
     ) {
         const layerTypes = Array.isArray(types) ? types : [types]
 
+        const resolveLayers = () => {
+            return layerTypes
+                .map(
+                    (layerType) =>
+                        this._memoryLayers[resolveLongMemoryId(info, layerType)]
+                )
+                .filter((layer): layer is BaseMemoryRetrievalLayer => !!layer)
+        }
+
+        let layers = resolveLayers()
+
+        if (layers.length === layerTypes.length) {
+            return layers
+        }
+
         if (
             this._memoryLayerNamespaces[namespace] == null ||
             this._memoryLayerNamespaces[namespace].some(
@@ -101,12 +116,9 @@ export class ChatLunaLongMemoryService extends Service {
             )
         }
 
-        return layerTypes
-            .map(
-                (layerType) =>
-                    this._memoryLayers[resolveLongMemoryId(info, layerType)]
-            )
-            .filter((layer): layer is BaseMemoryRetrievalLayer => !!layer)
+        layers = resolveLayers()
+
+        return layers
     }
 
     getMemoryLayers(
@@ -332,6 +344,8 @@ export class ChatLunaLongMemoryService extends Service {
             throw error
         }
     }
+
+    static inject = ['chatluna', 'database']
 }
 
 declare module 'koishi' {

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67",
         "koishi-plugin-chatluna-storage-service": "^0.0.10"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67",
         "koishi-plugin-chatluna-storage-service": "^0.0.10"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-vector-store-service",
     "description": "vector store service for chatluna",
-    "version": "1.3.0-alpha.2",
+    "version": "1.3.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.0",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/service-vector-store/src/vectorstore/base/faiss.ts
+++ b/packages/service-vector-store/src/vectorstore/base/faiss.ts
@@ -37,6 +37,7 @@ export class FaissVectorStore extends ChatLunaSaveableVectorStore<FaissStore> {
 
     async delete(options: ChatLunaSaveableVectorDelete): Promise<void> {
         if (options.deleteAll) {
+            await super.delete(options)
             await fs.rm(this._directory, { recursive: true })
             return
         }

--- a/packages/service-vector-store/src/vectorstore/base/milvus.ts
+++ b/packages/service-vector-store/src/vectorstore/base/milvus.ts
@@ -61,6 +61,7 @@ export class MilvusVectorStore extends ChatLunaSaveableVectorStore<Milvus> {
             await this._store.client.dropCollection({
                 collection_name: 'chatluna_collection'
             })
+            await super.delete(options)
             return
         }
 

--- a/packages/service-vector-store/src/vectorstore/base/redis.ts
+++ b/packages/service-vector-store/src/vectorstore/base/redis.ts
@@ -41,6 +41,7 @@ export class RedisVectorStoreWrapper extends ChatLunaSaveableVectorStore<RedisVe
             await this._client.ft.dropIndex(this._store.indexName, {
                 DD: true
             })
+            await super.delete(options)
             return
         }
 

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.66"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.67"
     }
 }


### PR DESCRIPTION
This PR fixes critical lifecycle and initialization issues in the long-memory extension that prevented middleware from being properly registered and caused memory layer initialization problems.

### Bug Fixes

- **Fix plugin initialization lifecycle**: Removed nested `ready` event listeners that caused middleware registration to fail
- **Fix middleware context binding**: Added missing `ctx` parameter to all middleware registrations to ensure proper lifecycle management and disposal
- **Fix service dependency injection**: Added explicit `inject` declaration to `ChatLunaLongMemoryService` for proper dependency resolution
- **Fix memory layer caching**: Optimized `initMemoryLayers` to check cache first and avoid redundant initialization
- **Fix vector store deletion**: Ensured parent class `delete` method is called before removing directories in Faiss/Milvus/Redis stores
- **Fix message identification**: Changed chat service to use `userId` instead of `conversationId` for message ID to ensure proper user tracking
- **Fix chain middleware disposal**: Improved disposal pattern using `ctx.effect` instead of direct `ctx.on('dispose')` 
- **Fix middleware order caching**: Invalidate cached middleware execution order when nodes are added/removed from the dependency graph

### Root Cause

The main issue was that the plugin wrapped the service initialization in a `ready` event handler, and then wrapped the middleware registration in another nested `ready` handler. This double-nesting caused the middleware to never be properly registered because the inner `ready` event would not fire correctly.

Additionally, all middleware registrations were missing the `ctx` parameter, which prevented proper lifecycle management and caused memory leaks when plugins were disposed.

### Testing

- Verified middleware registration works correctly
- Confirmed memory layers initialize without redundant calls
- Tested vector store deletion operations
- Validated proper cleanup on plugin disposal