### PR TITLE
[Fix] Add error handling for image reading failures

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70",
     "koishi-plugin-chatluna-storage-service": "^0.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.69",
+  "version": "1.3.0-alpha.70",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -240,7 +240,7 @@ async function readImage(ctx: Context, url: string) {
             ext
         }
     } catch (error) {
-        logger.error(`Failed to read image from ${url}: ${error}`)
+        logger.error(`Failed to read image from ${url}:`, error)
         return {
             base64Source: null,
             buffer: null,

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -218,25 +218,34 @@ async function readImage(ctx: Context, url: string) {
         }
     }
 
-    const response = await ctx.http(url, {
-        responseType: 'arraybuffer',
-        method: 'get',
-        headers: {
-            'User-Agent':
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
+    try {
+        const response = await ctx.http(url, {
+            responseType: 'arraybuffer',
+            method: 'get',
+            headers: {
+                'User-Agent':
+                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
+            }
+        })
+
+        const buffer = Buffer.from(response.data)
+
+        const base64 = buffer.toString('base64')
+
+        const ext = getImageType(buffer)
+
+        return {
+            base64Source: `data:${ext};base64,${base64}`,
+            buffer,
+            ext
         }
-    })
-
-    const buffer = Buffer.from(response.data)
-
-    const base64 = buffer.toString('base64')
-
-    const ext = getImageType(buffer)
-
-    return {
-        base64Source: `data:${ext};base64,${base64}`,
-        buffer,
-        ext
+    } catch (error) {
+        logger.error(`Failed to read image from ${url}: ${error}`)
+        return {
+            base64Source: null,
+            buffer: null,
+            ext: null
+        }
     }
 }
 

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70",
     "koishi-plugin-chatluna-storage-service": "^0.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70",
     "koishi-plugin-chatluna-storage-service": "^0.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-image-service",
   "description": "image service for chatluna",
-  "version": "1.3.0-alpha.0",
+  "version": "1.3.0-alpha.1",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/service-image/src/index.ts
+++ b/packages/service-image/src/index.ts
@@ -53,6 +53,10 @@ export function apply(ctx: Context, config: Config) {
                 ) {
                     imageData = await readImage(ctx, url)
 
+                    if (imageData.ext == null) {
+                        return false
+                    }
+
                     if (imageData.ext === 'image/gif') {
                         logger.debug(`image url: ${url.substring(0, 50)}...`)
                         // Parse GIF and add multiple frames for models that support image input
@@ -103,6 +107,10 @@ export function apply(ctx: Context, config: Config) {
 
                     imageData = imageData ?? (await readImage(ctx, url))
 
+                    if (imageData.ext == null) {
+                        return false
+                    }
+
                     // Parse GIF if needed
                     if (imageData.ext === 'image/gif') {
                         const frames = await parseGifToFrames(
@@ -135,7 +143,7 @@ export function apply(ctx: Context, config: Config) {
                     }
                 } catch (error) {
                     logger.warn(
-                        `read image ${url} error, check your chat adapter`,
+                        `Eead image ${url} error, check your chat adapter`,
                         error
                     )
                 }

--- a/packages/service-image/src/index.ts
+++ b/packages/service-image/src/index.ts
@@ -143,7 +143,7 @@ export function apply(ctx: Context, config: Config) {
                     }
                 } catch (error) {
                     logger.warn(
-                        `Eead image ${url} error, check your chat adapter`,
+                        `Read image ${url} error, check your chat adapter`,
                         error
                     )
                 }

--- a/packages/service-image/src/utils.ts
+++ b/packages/service-image/src/utils.ts
@@ -116,25 +116,34 @@ export async function readImage(ctx: Context, url: string) {
         }
     }
 
-    const response = await ctx.http(url, {
-        responseType: 'arraybuffer',
-        method: 'get',
-        headers: {
-            'User-Agent':
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
+    try {
+        const response = await ctx.http(url, {
+            responseType: 'arraybuffer',
+            method: 'get',
+            headers: {
+                'User-Agent':
+                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
+            }
+        })
+
+        const buffer = Buffer.from(response.data)
+
+        const base64 = buffer.toString('base64')
+
+        const ext = getImageType(buffer)
+
+        return {
+            base64Source: `data:${ext};base64,${base64}`,
+            buffer,
+            ext
         }
-    })
-
-    const buffer = Buffer.from(response.data)
-
-    const base64 = buffer.toString('base64')
-
-    const ext = getImageType(buffer)
-
-    return {
-        base64Source: `data:${ext};base64,${base64}`,
-        buffer,
-        ext
+    } catch (error) {
+        logger.error(`Failed to read image from ${url}:`, error)
+        return {
+            base64Source: null,
+            buffer: null,
+            ext: null
+        }
     }
 }
 export async function processImageWithModel(

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.69"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.70"
   }
 }


### PR DESCRIPTION
This PR adds comprehensive error handling for image reading operations to prevent crashes when encountering invalid URLs or network errors.

### Bug fixes

- Fixed crashes when image download fails due to invalid URLs or network errors
- Added try-catch blocks around HTTP requests in `readImage` functions
- Added null checks before processing image data to prevent type errors
- Improved error logging for debugging failed image reads

### Changes

**packages/core/src/middlewares/chat/read_chat_message.ts:**
- Wrapped HTTP request in try-catch block
- Return null values (base64Source, buffer, ext) when image reading fails
- Added error logging with URL context

**packages/service-image/src/utils.ts:**
- Wrapped HTTP request in try-catch block
- Return null values when image reading fails
- Added error logging with URL context

**packages/service-image/src/index.ts:**
- Added null checks for `imageData.ext` before processing
- Early return `false` when image reading fails to skip invalid images
- Prevents downstream errors from null/undefined values

### Impact

This change makes the image handling system more robust by gracefully handling failures instead of crashing. Users will see error logs for debugging while the bot continues to function normally.