### PR TITLE
[Refactor] Refactor MCP commands to use core command pattern

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72",
     "koishi-plugin-chatluna-storage-service": "^0.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.71",
+  "version": "1.3.0-alpha.72",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/command.ts
+++ b/packages/core/src/command.ts
@@ -4,6 +4,7 @@ import { Config } from './config'
 // import start
 import { apply as auth } from './commands/auth'
 import { apply as chat } from './commands/chat'
+import { apply as mcp } from './commands/mcp'
 import { apply as memory } from './commands/memory'
 import { apply as model } from './commands/model'
 import { apply as preset } from './commands/preset'
@@ -20,7 +21,7 @@ export async function command(ctx: Context, config: Config) {
 
     const middlewares: Command[] =
         // middleware start
-        [auth, chat, memory, model, preset, providers, room, tool] // middleware end
+        [auth, chat, mcp, memory, model, preset, providers, room, tool] // middleware end
 
     for (const middleware of middlewares) {
         await middleware(ctx, config, ctx.chatluna.chatChain)

--- a/packages/core/src/commands/mcp.ts
+++ b/packages/core/src/commands/mcp.ts
@@ -1,0 +1,41 @@
+import { Context } from 'koishi'
+import { ChatChain } from '../chains/chain'
+import { Config } from '../config'
+
+export function apply(ctx: Context, config: Config, chain: ChatChain) {
+    ctx.inject(['chatluna_mcp'], (ctx) => {
+        ctx.command('chatluna.mcp', { authority: 1 })
+
+        // List command
+        ctx.command('chatluna.mcp.list').action(async ({ session }) => {
+            await chain.receiveCommand(session, 'list_mcp_tools', {})
+        })
+
+        // Add command
+        ctx.command('chatluna.mcp.add <mcpConfig:text>', {
+            authority: 3
+        }).action(async ({ session }, mcpConfig) => {
+            await chain.receiveCommand(session, 'add_mcp_server', {
+                mcpConfig
+            })
+        })
+
+        // Remove command
+        ctx.command('chatluna.mcp.remove <serverName:string>', {
+            authority: 3
+        }).action(async ({ session }, serverName) => {
+            await chain.receiveCommand(session, 'remove_mcp_server', {
+                serverName
+            })
+        })
+
+        // Enable/Disable tool
+        ctx.command('chatluna.mcp.enable <toolName:string>', {
+            authority: 3
+        }).action(async ({ session }, toolName) => {
+            await chain.receiveCommand(session, 'enable_mcp_tool', {
+                toolName
+            })
+        })
+    })
+}

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -459,6 +459,62 @@ commands:
                     footer: 'You can use these tools in conversations to enhance model capabilities'
                     pages: 'Page: [page] / [total]'
 
+        mcp:
+            description: 'MCP tool management commands'
+            list:
+                description: 'List all MCP tools'
+                options:
+                    raw: 'List raw MCP server configurations'
+                messages:
+                    list_servers_header: 'Current MCP server configurations:'
+                    server_name: 'Server name: {0}'
+                    server_config: 'Server config:\n{0}'
+                    empty_servers: 'No MCP servers configured.'
+                    list_tools_header: 'Available MCP tools:'
+                    tool_name: 'Tool name: {0}'
+                    tool_enabled: 'Status: {0}'
+                    tool_selector: 'Selector: {0}'
+                    no_selector: 'None'
+                    empty_tools: 'No MCP tools registered.'
+                    parse_error: 'Failed to parse MCP server configuration. Please check the format.'
+                    list_error: 'Error listing tools: {0}'
+                    service_not_ready: 'MCP service is not ready. Please try again later.'
+            add:
+                description: 'Add MCP server'
+                arguments:
+                    mcpConfig: 'MCP server configuration (JSON format)'
+                messages:
+                    add_usage: 'Usage: chatluna.mcp.add <mcpConfig>\n\nExample:\nchatluna.mcp.add {"mcpServers": {"server1": {"command": "node", "args": ["server.js"]}}}'
+                    add_conflict: 'The following server names already exist: {0}'
+                    add_overwrite_confirm: 'Overwrite existing server configuration? Enter Y to confirm, any other input to cancel.'
+                    add_cancelled: 'Add operation cancelled.'
+                    add_success: 'Successfully added {0} MCP server(s).'
+                    add_error: 'Error adding MCP server: {0}'
+                    restart_required: 'Note: Changes will take effect after restart.'
+            remove:
+                description: 'Remove MCP server'
+                arguments:
+                    serverName: 'Server name'
+                messages:
+                    remove_usage: 'Usage: chatluna.mcp.remove <serverName>\n\nExample:\nchatluna.mcp.remove server1'
+                    server_not_found: 'Server {0} not found.'
+                    remove_success: 'Successfully removed server {0}.'
+                    remove_error: 'Error removing server: {0}'
+                    restart_required: 'Note: Changes will take effect after restart.'
+                    empty_servers: 'No MCP servers configured.'
+            enable:
+                description: 'Enable or disable MCP tool'
+                arguments:
+                    toolName: 'Tool name'
+                messages:
+                    enable_usage: 'Usage: chatluna.mcp.enable <toolName>\n\nExample:\nchatluna.mcp.enable my_tool'
+                    tool_not_found: 'Tool {0} not found.'
+                    enable_success: 'Tool {0} has been {1}.'
+                    enable_error: 'Error toggling tool status: {0}'
+                    service_not_ready: 'MCP service is not ready. Please try again later.'
+                    status_enabled: 'enabled'
+                    status_disabled: 'disabled'
+
         memory:
             description: 'ChatLuna memory-related commands.'
 

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -460,6 +460,62 @@ commands:
                     footer: '你可以在对话中使用这些工具来增强模型的能力'
                     pages: '当前为第 [page] / [total] 页'
 
+        mcp:
+            description: 'MCP 工具管理相关命令'
+            list:
+                description: '列出所有 MCP 工具'
+                options:
+                    raw: '列出原始的 MCP 服务器配置'
+                messages:
+                    list_servers_header: '以下是当前配置的 MCP 服务器列表：'
+                    server_name: '服务器名称：{0}'
+                    server_config: '服务器配置：\n{0}'
+                    empty_servers: '当前没有配置任何 MCP 服务器。'
+                    list_tools_header: '以下是当前可用的 MCP 工具列表：'
+                    tool_name: '工具名称：{0}'
+                    tool_enabled: '工具状态：{0}'
+                    tool_selector: '选择器：{0}'
+                    no_selector: '无'
+                    empty_tools: '当前没有注册任何 MCP 工具。'
+                    parse_error: '解析 MCP 服务器配置时出错，请检查配置格式。'
+                    list_error: '列出工具时出错：{0}'
+                    service_not_ready: 'MCP 服务未准备就绪，请稍后再试。'
+            add:
+                description: '添加 MCP 服务器'
+                arguments:
+                    mcpConfig: 'MCP 服务器配置（JSON 格式）'
+                messages:
+                    add_usage: '使用方法：chatluna.mcp.add <mcpConfig>\n\n示例：\nchatluna.mcp.add {"mcpServers": {"server1": {"command": "node", "args": ["server.js"]}}}'
+                    add_conflict: '检测到以下服务器名称已存在：{0}'
+                    add_overwrite_confirm: '是否覆盖现有服务器配置？输入 Y 确认，其他任何输入取消。'
+                    add_cancelled: '已取消添加操作。'
+                    add_success: '成功添加了 {0} 个 MCP 服务器。'
+                    add_error: '添加 MCP 服务器时出错：{0}'
+                    restart_required: '请注意：需要重启后更改才会生效。'
+            remove:
+                description: '移除 MCP 服务器'
+                arguments:
+                    serverName: '服务器名称'
+                messages:
+                    remove_usage: '使用方法：chatluna.mcp.remove <serverName>\n\n示例：\nchatluna.mcp.remove server1'
+                    server_not_found: '未找到名为 {0} 的服务器。'
+                    remove_success: '成功移除服务器 {0}。'
+                    remove_error: '移除服务器时出错：{0}'
+                    restart_required: '请注意：需要重启后更改才会生效。'
+                    empty_servers: '当前没有配置任何 MCP 服务器。'
+            enable:
+                description: '启用或禁用 MCP 工具'
+                arguments:
+                    toolName: '工具名称'
+                messages:
+                    enable_usage: '使用方法：chatluna.mcp.enable <toolName>\n\n示例：\nchatluna.mcp.enable my_tool'
+                    tool_not_found: '未找到名为 {0} 的工具。'
+                    enable_success: '已将工具 {0} {1}。'
+                    enable_error: '切换工具状态时出错：{0}'
+                    service_not_ready: 'MCP 服务未准备就绪，请稍后再试。'
+                    status_enabled: '启用'
+                    status_disabled: '禁用'
+
         memory:
             description: 'ChatLuna 记忆相关指令。'
             search:

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-mcp-client",
   "description": "MCP Client for ChatLuna",
-  "version": "1.3.0-alpha.10",
+  "version": "1.3.0-alpha.11",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72",
     "koishi-plugin-chatluna-storage-service": "^0.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-mcp/src/command.ts
+++ b/packages/extension-mcp/src/command.ts
@@ -296,7 +296,11 @@ export function apply(ctx: Context, config: Config) {
                         : session.text('.status_disabled')
                     context.message =
                         session.text('.enable_success', [toolName, status]) +
-                        ctx.scope.parent.scope.update(config, true)
+                        '\n' +
+                        session.text('.restart_required')
+
+                    // Restart the plugin
+                    ctx.scope.parent.scope.update(config, true)
                 } catch (error) {
                     context.message = session.text('.enable_error', [
                         error.message

--- a/packages/extension-mcp/src/command.ts
+++ b/packages/extension-mcp/src/command.ts
@@ -1,240 +1,328 @@
 import { Context } from 'koishi'
-import { Config } from '.'
+import { ChainMiddlewareRunStatus } from 'koishi-plugin-chatluna/chains'
+import { Config } from './index'
 
 export function apply(ctx: Context, config: Config) {
-    ctx.command('chatluna.mcp', 'MCP 工具管理相关命令')
+    const chain = ctx.chatluna.chatChain
 
-    // List command
-    ctx.command('chatluna.mcp.list', '列出所有 MCP 工具').action(
-        async ({ session, options }) => {
-            // List tools
-            try {
-                const service = ctx.chatluna_mcp
-                if (!service) {
-                    await session.send(session.text('.service_not_ready'))
-                    return
+    // List MCP tools middleware
+    chain
+        .middleware(
+            'list_mcp_tools',
+            async (session, context) => {
+                const { command } = context
+
+                if (command !== 'list_mcp_tools')
+                    return ChainMiddlewareRunStatus.SKIPPED
+
+                try {
+                    const service = ctx.chatluna_mcp
+                    if (!service) {
+                        context.message = session.text('.service_not_ready')
+                        return ChainMiddlewareRunStatus.STOP
+                    }
+
+                    const tools = service.globalTools
+
+                    if (Object.keys(tools).length === 0) {
+                        context.message = session.text('.empty_tools')
+                        return ChainMiddlewareRunStatus.STOP
+                    }
+
+                    const messages = [session.text('.list_tools_header')]
+                    for (const [name, tool] of Object.entries(tools)) {
+                        const selectorText =
+                            tool.selector && tool.selector.length > 0
+                                ? tool.selector.join(', ')
+                                : session.text('.no_selector')
+                        messages.push(
+                            session.text('.tool_name', [name]),
+                            session.text('.tool_enabled', [
+                                tool.enabled ? '✓' : '✗'
+                            ]),
+                            session.text('.tool_selector', [selectorText]),
+                            '---'
+                        )
+                    }
+
+                    context.message = messages.join('\n')
+                } catch (error) {
+                    context.message = session.text('.list_error', [
+                        error.message
+                    ])
                 }
 
-                const tools = service.globalTools
+                return ChainMiddlewareRunStatus.STOP
+            },
+            ctx
+        )
+        .after('lifecycle-handle_command')
 
-                if (Object.keys(tools).length === 0) {
-                    await session.send(session.text('.empty_tools'))
-                    return
+    // Add MCP server middleware
+    chain
+        .middleware(
+            'add_mcp_server',
+            async (session, context) => {
+                const {
+                    command,
+                    options: { mcpConfig }
+                } = context
+
+                if (command !== 'add_mcp_server')
+                    return ChainMiddlewareRunStatus.SKIPPED
+
+                if (!mcpConfig) {
+                    context.message = session.text('.add_usage')
+                    return ChainMiddlewareRunStatus.STOP
                 }
 
-                const messages = [session.text('.list_tools_header')]
-                for (const [name, tool] of Object.entries(tools)) {
-                    const selectorText =
-                        tool.selector && tool.selector.length > 0
-                            ? tool.selector.join(', ')
-                            : session.text('.no_selector')
-                    messages.push(
-                        session.text('.tool_name', [name]),
-                        session.text('.tool_enabled', [
-                            tool.enabled ? '✓' : '✗'
-                        ]),
-                        session.text('.tool_selector', [selectorText]),
-                        '---'
-                    )
+                try {
+                    // Parse the MCP config (Claude Code / VSCode format)
+                    const parsedInput = JSON.parse(mcpConfig)
+
+                    // Parse current config
+                    let currentConfig
+                    try {
+                        currentConfig = JSON.parse(config.servers)
+                    } catch {
+                        currentConfig = { mcpServers: {} }
+                    }
+
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    let mcpServers: Record<string, any> = {}
+
+                    // Get current servers
+                    if (Array.isArray(currentConfig)) {
+                        // Convert array to object format
+                        mcpServers = currentConfig.reduce(
+                            (acc, server, index) => {
+                                acc[`server-${index}`] = server
+                                return acc
+                            },
+                            {}
+                        )
+                    } else if (currentConfig['mcpServers']) {
+                        mcpServers = { ...currentConfig['mcpServers'] }
+                    } else if (
+                        typeof currentConfig === 'object' &&
+                        Object.keys(currentConfig)
+                    ) {
+                        mcpServers = currentConfig
+                    }
+
+                    let addedCount = 0
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    const serversToAdd: Record<string, any> = {}
+
+                    // Prepare servers to add
+                    if (parsedInput['mcpServers']) {
+                        // Claude Code / VSCode format
+                        Object.assign(serversToAdd, parsedInput['mcpServers'])
+                    } else {
+                        // Assume it's a direct server config
+                        const serverName = `server-${Date.now()}`
+                        serversToAdd[serverName] = parsedInput
+                    }
+
+                    // Check for conflicts
+                    const conflicts: string[] = []
+                    for (const name of Object.keys(serversToAdd)) {
+                        if (mcpServers[name]) {
+                            conflicts.push(name)
+                        }
+                    }
+
+                    // Handle conflicts
+                    if (conflicts.length > 0) {
+                        await session.send(
+                            session.text('.add_conflict', [
+                                conflicts.join(', ')
+                            ])
+                        )
+
+                        await session.send(
+                            session.text('.add_overwrite_confirm')
+                        )
+
+                        const response = await session.prompt()
+
+                        if (!response || response.toUpperCase() !== 'Y') {
+                            context.message = session.text('.add_cancelled')
+                            return ChainMiddlewareRunStatus.STOP
+                        }
+                    }
+
+                    // Add new servers
+                    for (const [name, serverConfig] of Object.entries(
+                        serversToAdd
+                    )) {
+                        mcpServers[name] = serverConfig
+                        addedCount++
+                    }
+
+                    // Update config
+                    config.servers = JSON.stringify({ mcpServers }, null, 2)
+
+                    context.message = session.text('.add_success', [
+                        addedCount.toString()
+                    ])
+                    // Restart the plugin
+                    ctx.scope.parent.scope.update(config, true)
+                } catch (error) {
+                    context.message = session.text('.add_error', [
+                        error.message
+                    ])
                 }
 
-                await session.send(messages.join('\n'))
-            } catch (error) {
-                await session.send(session.text('.list_error', [error.message]))
-            }
-        }
-    )
+                return ChainMiddlewareRunStatus.STOP
+            },
+            ctx
+        )
+        .after('lifecycle-handle_command')
 
-    // Add command
-    ctx.command('chatluna.mcp.add <mcpConfig:text>', '添加 MCP 服务器', {
-        authority: 3
-    }).action(async ({ session }, mcpConfig) => {
-        if (!mcpConfig) {
-            await session.send(session.text('.add_usage'))
-            return
-        }
+    // Remove MCP server middleware
+    chain
+        .middleware(
+            'remove_mcp_server',
+            async (session, context) => {
+                const {
+                    command,
+                    options: { serverName }
+                } = context
 
-        try {
-            // Parse the MCP config (Claude Code / VSCode format)
-            const parsedInput = JSON.parse(mcpConfig)
+                if (command !== 'remove_mcp_server')
+                    return ChainMiddlewareRunStatus.SKIPPED
 
-            // Parse current config
-            let currentConfig
-            try {
-                currentConfig = JSON.parse(config.servers)
-            } catch {
-                currentConfig = { mcpServers: {} }
-            }
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            let mcpServers: Record<string, any> = {}
-
-            // Get current servers
-            if (Array.isArray(currentConfig)) {
-                // Convert array to object format
-                mcpServers = currentConfig.reduce((acc, server, index) => {
-                    acc[`server-${index}`] = server
-                    return acc
-                }, {})
-            } else if (currentConfig['mcpServers']) {
-                mcpServers = { ...currentConfig['mcpServers'] }
-            } else if (
-                typeof currentConfig === 'object' &&
-                Object.keys(currentConfig)
-            ) {
-                mcpServers = currentConfig
-            }
-
-            let addedCount = 0
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const serversToAdd: Record<string, any> = {}
-
-            // Prepare servers to add
-            if (parsedInput['mcpServers']) {
-                // Claude Code / VSCode format
-                Object.assign(serversToAdd, parsedInput['mcpServers'])
-            } else {
-                // Assume it's a direct server config
-                const serverName = `server-${Date.now()}`
-                serversToAdd[serverName] = parsedInput
-            }
-
-            // Check for conflicts
-            const conflicts: string[] = []
-            for (const name of Object.keys(serversToAdd)) {
-                if (mcpServers[name]) {
-                    conflicts.push(name)
+                if (!serverName) {
+                    context.message = session.text('.remove_usage')
+                    return ChainMiddlewareRunStatus.STOP
                 }
-            }
 
-            // Handle conflicts
-            if (conflicts.length > 0) {
-                await session.send(
-                    session.text('.add_conflict', [conflicts.join(', ')])
-                )
+                try {
+                    const parsedConfig = JSON.parse(config.servers)
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    let mcpServers: Record<string, any> = {}
 
-                await session.send(session.text('.add_overwrite_confirm'))
+                    if (Array.isArray(parsedConfig)) {
+                        mcpServers = parsedConfig.reduce(
+                            (acc, server, index) => {
+                                acc[`server-${index}`] = server
+                                return acc
+                            },
+                            {}
+                        )
+                    } else if (parsedConfig['mcpServers']) {
+                        mcpServers = { ...parsedConfig['mcpServers'] }
+                    } else {
+                        context.message = session.text('.empty_servers')
+                        return ChainMiddlewareRunStatus.STOP
+                    }
 
-                const response = await session.prompt()
+                    if (!mcpServers[serverName]) {
+                        context.message = session.text('.server_not_found', [
+                            serverName
+                        ])
+                        return ChainMiddlewareRunStatus.STOP
+                    }
 
-                if (!response || response.toUpperCase() !== 'Y') {
-                    await session.send(session.text('.add_cancelled'))
-                    return
+                    delete mcpServers[serverName]
+                    config.servers = JSON.stringify({ mcpServers }, null, 2)
+
+                    context.message = session.text('.remove_success', [
+                        serverName
+                    ])
+
+                    // Restart the plugin
+                    ctx.scope.parent.scope.update(config, true)
+                } catch (error) {
+                    context.message = session.text('.remove_error', [
+                        error.message
+                    ])
                 }
-            }
 
-            // Add new servers
-            for (const [name, serverConfig] of Object.entries(serversToAdd)) {
-                mcpServers[name] = serverConfig
-                addedCount++
-            }
+                return ChainMiddlewareRunStatus.STOP
+            },
+            ctx
+        )
+        .after('lifecycle-handle_command')
 
-            // Update config
-            config.servers = JSON.stringify({ mcpServers }, null, 2)
+    // Enable/Disable MCP tool middleware
+    chain
+        .middleware(
+            'enable_mcp_tool',
+            async (session, context) => {
+                const {
+                    command,
+                    options: { toolName }
+                } = context
 
-            await session.send(
-                session.text('.add_success', [addedCount.toString()])
-            )
+                if (command !== 'enable_mcp_tool')
+                    return ChainMiddlewareRunStatus.SKIPPED
 
-            ctx.scope.parent.scope.update(config, true)
-        } catch (error) {
-            await session.send(session.text('.add_error', [error.message]))
-        }
-    })
+                if (!toolName) {
+                    context.message = session.text('.enable_usage')
+                    return ChainMiddlewareRunStatus.STOP
+                }
 
-    // Remove command
-    ctx.command('chatluna.mcp.remove <serverName:string>', '移除 MCP 服务器', {
-        authority: 3
-    }).action(async ({ session }, serverName) => {
-        if (!serverName) {
-            await session.send(session.text('.remove_usage'))
-            return
-        }
+                try {
+                    const service = ctx.chatluna_mcp
+                    if (!service) {
+                        context.message = session.text('.service_not_ready')
+                        return ChainMiddlewareRunStatus.STOP
+                    }
 
-        try {
-            const parsedConfig = JSON.parse(config.servers)
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            let mcpServers: Record<string, any> = {}
+                    const tools = service.globalTools
+                    const tool = config.tools[toolName] || tools[toolName]
 
-            if (Array.isArray(parsedConfig)) {
-                mcpServers = parsedConfig.reduce((acc, server, index) => {
-                    acc[`server-${index}`] = server
-                    return acc
-                }, {})
-            } else if (parsedConfig['mcpServers']) {
-                mcpServers = { ...parsedConfig['mcpServers'] }
-            } else {
-                await session.send(session.text('.empty_servers'))
-                return
-            }
+                    if (!tool) {
+                        context.message = session.text('.tool_not_found', [
+                            toolName
+                        ])
+                        return ChainMiddlewareRunStatus.STOP
+                    }
 
-            if (!mcpServers[serverName]) {
-                await session.send(
-                    session.text('.server_not_found', [serverName])
-                )
-                return
-            }
+                    tool.enabled = !tool.enabled
 
-            delete mcpServers[serverName]
-            config.servers = JSON.stringify({ mcpServers }, null, 2)
+                    // Update config.tools to persist the change
+                    if (!config.tools) {
+                        config.tools = {}
+                    }
+                    config.tools[toolName] = {
+                        ...tool
+                    }
 
-            await session.send(session.text('.remove_success', [serverName]))
+                    const status = tool.enabled
+                        ? session.text('.status_enabled')
+                        : session.text('.status_disabled')
+                    context.message =
+                        session.text('.enable_success', [toolName, status]) +
+                        ctx.scope.parent.scope.update(config, true)
+                } catch (error) {
+                    context.message = session.text('.enable_error', [
+                        error.message
+                    ])
+                }
 
-            ctx.scope.parent.scope.update(config, true)
-        } catch (error) {
-            await session.send(session.text('.remove_error', [error.message]))
-        }
-    })
+                return ChainMiddlewareRunStatus.STOP
+            },
+            ctx
+        )
+        .after('lifecycle-handle_command')
+}
 
-    // Enable/Disable tool
-    ctx.command(
-        'chatluna.mcp.enable <toolName:string>',
-        '启用或禁用 MCP 工具',
-        {
-            authority: 3
-        }
-    ).action(async ({ session }, toolName) => {
-        if (!toolName) {
-            await session.send(session.text('.enable_usage'))
-            return
-        }
+declare module 'koishi-plugin-chatluna/chains' {
+    interface ChainMiddlewareName {
+        list_mcp_tools: never
+        add_mcp_server: never
+        remove_mcp_server: never
+        enable_mcp_tool: never
+    }
 
-        try {
-            const service = ctx.chatluna_mcp
-            if (!service) {
-                await session.send(session.text('.service_not_ready'))
-                return
-            }
-
-            const tools = service.globalTools
-            const tool = config.tools[toolName] || tools[toolName]
-
-            if (!tool) {
-                await session.send(session.text('.tool_not_found', [toolName]))
-                return
-            }
-
-            tool.enabled = !tool.enabled
-
-            // Update config.tools to persist the change
-            if (!config.tools) {
-                config.tools = {}
-            }
-            config.tools[toolName] = {
-                ...tool
-            }
-
-            const status = tool.enabled
-                ? session.text('.status_enabled')
-                : session.text('.status_disabled')
-            await session.send(
-                session.text('.enable_success', [toolName, status])
-            )
-            ctx.scope.parent.scope.update(config, true)
-        } catch (error) {
-            await session.send(session.text('.enable_error', [error.message]))
-        }
-    })
+    interface ChainMiddlewareContextOptions {
+        mcpConfig?: string
+        serverName?: string
+        toolName?: string
+    }
 }
 
 export const inject = ['chatluna_mcp']

--- a/packages/extension-mcp/src/service.ts
+++ b/packages/extension-mcp/src/service.ts
@@ -26,7 +26,7 @@ export class ChatLunaMCPClientService extends Service {
     private _plugin: ChatLunaPlugin
 
     constructor(
-        ctx: Context,
+        public ctx: Context,
         public config: Config
     ) {
         super(ctx, 'chatluna_mcp')

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72",
     "koishi-plugin-chatluna-storage-service": "^0.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.71"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.72"
   }
 }


### PR DESCRIPTION
This PR refactors the MCP server management commands to follow the same architectural pattern as the memory commands, improving consistency and integration with the ChatLuna command chain system.

### New Features

- MCP commands now integrated into core command system (`core/src/commands/mcp.ts`)
- MCP command locales added to core locale files (en-US and zh-CN)
- All MCP commands now use the `receiveCommand` pattern for better consistency

### Bug Fixes

N/A

### Other Changes

- Refactored extension-mcp command handlers to use middleware pattern
- Updated restart mechanism to use `ctx.scope.parent.scope.update` instead of service method
- Removed deprecated `restart()` method from `ChatLunaMCPClientService`
- Added ChainMiddleware type declarations for MCP commands:
  - `list_mcp_tools`
  - `add_mcp_server`
  - `remove_mcp_server`
  - `enable_mcp_tool`
- Made `ctx` public in `ChatLunaMCPClientService` constructor for middleware access

### Technical Details

This change follows the exact same pattern as the memory commands (`commands/memory.ts` + `extension-long-memory/src/plugins/add_memory.ts`):
- Command registration happens in core using `receiveCommand()`
- Actual command logic implemented as chain middlewares in the extension
- Proper context passing throughout the middleware chain