### PR TITLE
[Fix] Improve MCP tool handling and timeout support

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74",
     "koishi-plugin-chatluna-storage-service": "^0.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.0-alpha.73",
+  "version": "1.3.0-alpha.74",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/agent/executor.ts
+++ b/packages/core/src/llm-core/agent/executor.ts
@@ -725,9 +725,11 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                         runManager?.getChild()
                     )
                     if (typeof observation !== 'string') {
-                        throw new Error(
-                            'Received unsupported non-string response from tool call.'
+                        logger.warn(
+                            `Tool ${tool.name} returned non-string observation`,
+                            observation
                         )
+                        observation = JSON.stringify(observation)
                     }
                 } catch (e) {
                     if (e instanceof ToolInputParsingException) {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-mcp-client",
   "description": "MCP Client for ChatLuna",
-  "version": "1.3.0-alpha.12",
+  "version": "1.3.0-alpha.13",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74",
     "koishi-plugin-chatluna-storage-service": "^0.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -50,9 +50,11 @@
   "dependencies": {
     "@langchain/core": "0.3.62",
     "@modelcontextprotocol/sdk": "^1.19.1",
+    "mime-types": "^3.0.1",
     "zod": "3.25.76"
   },
   "devDependencies": {
+    "@types/mime-types": "^3.0.1",
     "atsc": "^2.1.0",
     "koishi": "^4.18.9"
   },

--- a/packages/extension-mcp/src/index.ts
+++ b/packages/extension-mcp/src/index.ts
@@ -29,6 +29,7 @@ export const Config: Schema<Config> = Schema.object({
         Schema.object({
             name: Schema.string().required(),
             enabled: Schema.boolean().default(true),
+            timeout: Schema.number().default(60),
             selector: Schema.array(Schema.string()).default([])
         })
     )
@@ -49,6 +50,7 @@ export interface Config {
             headers?: Record<string, string>
             type: 'http' | 'studio' | 'streamable_http'
             env?: Record<string, string>
+            timeout?: number
             cwd?: string
         }
     >
@@ -57,6 +59,7 @@ export interface Config {
         string,
         {
             name: string
+            timeout?: number
             enabled: boolean
             selector: string[]
         }

--- a/packages/extension-mcp/src/locales/en-US.schema.yml
+++ b/packages/extension-mcp/src/locales/en-US.schema.yml
@@ -14,3 +14,4 @@ tools:
         name: Tool name
         enabled: Whether to enable the tool
         selector: Message content selector
+        timeout: Execution timeout (milliseconds)

--- a/packages/extension-mcp/src/locales/zh-CN.schema.yml
+++ b/packages/extension-mcp/src/locales/zh-CN.schema.yml
@@ -14,3 +14,4 @@ tools:
         name: 注册到 chatluna 的工具名称
         enabled: 是否启用此工具
         selector: 消息内容选择器
+        timeout: 执行超时时间（毫秒）

--- a/packages/extension-mcp/src/service.ts
+++ b/packages/extension-mcp/src/service.ts
@@ -173,9 +173,9 @@ export class ChatLunaMCPClientService extends Service {
                     enabled: toolConfig?.enabled ?? true,
                     selector: toolConfig?.selector ?? [],
                     timeout:
-                        (toolConfig?.timeout ?? 0) * 1000 ||
-                        serverConfig.timeout ||
-                        60 * 1000,
+                        ((toolConfig?.timeout ?? 0) ||
+                            serverConfig.timeout ||
+                            60) * 1000,
                     description: mcpTool.description ?? ''
                 }
             }

--- a/packages/extension-mcp/src/service.ts
+++ b/packages/extension-mcp/src/service.ts
@@ -12,7 +12,7 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { callTool } from './utils'
 
 export class ChatLunaMCPClientService extends Service {
-    private _clients: Client[] = []
+    private _clients: Map<Config['server'][0], Client> = new Map()
 
     private _globalTools: Record<
         string,
@@ -20,6 +20,7 @@ export class ChatLunaMCPClientService extends Service {
             name: string
             enabled: boolean
             description: string
+            timeout?: number
             selector: string[]
         }
     > = {}
@@ -142,7 +143,7 @@ export class ChatLunaMCPClientService extends Service {
 
                 await client.connect(transport)
 
-                this._clients.push(client)
+                this._clients.set(serverConfig, client)
                 logger.debug('MCP client connected at', serverConfig)
             } catch (error) {
                 this.ctx.logger.error(
@@ -154,21 +155,28 @@ export class ChatLunaMCPClientService extends Service {
             }
         }
 
-        return this._clients.length > 0
+        return this._clients.size > 0
     }
 
     async registerClientToolsToSchema() {
         const schemaValueArray: typeof this._globalTools = {}
 
-        for (const client of this._clients) {
+        for (const entry of this._clients) {
+            const [serverConfig, client] = entry
+
             const mcpTools = await client.listTools()
 
-            for (const tool of mcpTools.tools) {
-                schemaValueArray[tool.name] = {
-                    name: tool.name,
-                    enabled: this.config.tools?.[tool.name]?.enabled ?? true,
-                    selector: this.config.tools?.[tool.name]?.selector ?? [],
-                    description: tool.description ?? ''
+            for (const mcpTool of mcpTools.tools) {
+                const toolConfig = this.config.tools?.[mcpTool.name]
+                schemaValueArray[mcpTool.name] = {
+                    name: mcpTool.name,
+                    enabled: toolConfig?.enabled ?? true,
+                    selector: toolConfig?.selector ?? [],
+                    timeout:
+                        (toolConfig?.timeout ?? 0) * 1000 ||
+                        serverConfig.timeout ||
+                        60 * 1000,
+                    description: mcpTool.description ?? ''
                 }
             }
         }
@@ -184,7 +192,7 @@ export class ChatLunaMCPClientService extends Service {
             [Client, Awaited<ReturnType<Client['listTools']>>['tools'][number]]
         > = {}
 
-        for (const client of this._clients) {
+        for (const client of this._clients.values()) {
             const mcpTools = await client.listTools()
             for (const tool of mcpTools.tools) {
                 toolToClientMap[tool.name] = [client, tool] as const
@@ -215,6 +223,9 @@ export class ChatLunaMCPClientService extends Service {
                         toolName: mcpTool.name,
                         args: input,
                         serverName: name,
+                        config: {
+                            timeout: toolConfig.timeout
+                        },
                         ctx: this.ctx
                     })
                 },
@@ -252,9 +263,10 @@ export class ChatLunaMCPClientService extends Service {
     }
 
     async stop() {
-        for (const client of this._clients) {
+        for (const client of this._clients.values()) {
             await client.close()
         }
+        this._clients.clear()
     }
 
     get clients() {

--- a/packages/extension-mcp/src/utils.ts
+++ b/packages/extension-mcp/src/utils.ts
@@ -17,7 +17,7 @@ import {
     EmbeddedResource,
     ReadResourceResult
 } from '@modelcontextprotocol/sdk/types.js'
-import { Context, Logger } from 'koishi'
+import { Context } from 'koishi'
 import type {} from 'koishi-plugin-chatluna-storage-service'
 import mimeTypes from 'mime-types'
 

--- a/packages/extension-mcp/src/utils.ts
+++ b/packages/extension-mcp/src/utils.ts
@@ -17,7 +17,7 @@ import {
     EmbeddedResource,
     ReadResourceResult
 } from '@modelcontextprotocol/sdk/types.js'
-import { Context } from 'koishi'
+import { Context, Logger } from 'koishi'
 import type {} from 'koishi-plugin-chatluna-storage-service'
 import mimeTypes from 'mime-types'
 

--- a/packages/extension-mcp/src/utils.ts
+++ b/packages/extension-mcp/src/utils.ts
@@ -19,6 +19,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js'
 import { Context } from 'koishi'
 import type {} from 'koishi-plugin-chatluna-storage-service'
+import mimeTypes from 'mime-types'
 
 /**
  **
@@ -159,7 +160,7 @@ async function _toolOutputToContentBlocks(
             const file = await putResourceToStorage(
                 ctx,
                 content.data as string,
-                content.mineType as string
+                content.mimeType as string
             )
 
             if (file) {
@@ -495,5 +496,12 @@ async function putResourceToStorage(
     }
 
     const buffer = typeof blob === 'string' ? Buffer.from(blob, 'base64') : blob
-    return await ctx.chatluna_storage.createTempFile(buffer, `xxx.${mineType}`)
+    const extension = mimeTypes.extension(mineType)
+
+    if (!extension) {
+        throw new Error(`Unsupported mime type: ${mineType}`)
+    }
+
+    const fileName = `file.${extension}`
+    return await ctx.chatluna_storage.createTempFile(buffer, fileName)
 }

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73",
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74",
     "koishi-plugin-chatluna-storage-service": "^0.0.11"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "resolutions": {
     "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.0",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.0-alpha.73"
+    "koishi-plugin-chatluna": "^1.3.0-alpha.74"
   }
 }


### PR DESCRIPTION
This PR improves the MCP extension with better tool handling, timeout configuration support, and bug fixes.

### Bug Fixes

- Fixed #612: Add timeout configuration support for MCP tool calls at both server and tool levels
- Fixed #611: Correct file extension generation using proper MIME type lookup instead of hardcoded suffix
- Fixed non-string tool observation handling in agent executor (convert to JSON string instead of throwing error)

### Other Changes

- Refactor MCP client storage from array to Map for better server config tracking
- Add `mime-types` dependency for proper MIME type to file extension conversion
- Improve error handling and logging for tool observations
- Fix typo: `mineType` → `mimeType`