### PR TITLE
[Fix] Correct MCP timeout unit description

### DIFF
--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-mcp-client",
   "description": "MCP Client for ChatLuna",
-  "version": "1.3.0-alpha.13",
+  "version": "1.3.0-alpha.14",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/extension-mcp/src/locales/en-US.schema.yml
+++ b/packages/extension-mcp/src/locales/en-US.schema.yml
@@ -14,4 +14,4 @@ tools:
         name: Tool name
         enabled: Whether to enable the tool
         selector: Message content selector
-        timeout: Execution timeout (milliseconds)
+        timeout: Execution timeout (seconds)

--- a/packages/extension-mcp/src/locales/zh-CN.schema.yml
+++ b/packages/extension-mcp/src/locales/zh-CN.schema.yml
@@ -14,4 +14,4 @@ tools:
         name: 注册到 chatluna 的工具名称
         enabled: 是否启用此工具
         selector: 消息内容选择器
-        timeout: 执行超时时间（毫秒）
+        timeout: 执行超时时间（秒）


### PR DESCRIPTION
This PR corrects the timeout unit description in MCP extension locale files from milliseconds to seconds, which accurately reflects the actual implementation.

### Bug fixes

- Fixed incorrect timeout unit description in MCP tool configuration (changed from milliseconds to seconds in both en-US and zh-CN locales)

### Other Changes

- Bump extension-mcp version to 1.3.0-alpha.14