### PR TITLE
[Fix] Standardize modelMaxContextSize handling and bump versions

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-azure-openai-adapter",
     "description": "azure openai adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0-alpha.14",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-azure-openai/src/client.ts
+++ b/packages/adapter-azure-openai/src/client.ts
@@ -18,6 +18,7 @@ import { Config, logger as pluginLogger } from '.'
 import { OpenAIRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { AzureOpenAIClientConfig } from './types'
+import { getModelMaxContextSize } from '@chatluna/v1-shared-adapter'
 
 export class OpenAIClient extends PlatformModelAndEmbeddingsClient<AzureOpenAIClientConfig> {
     platform = 'azure'
@@ -91,13 +92,16 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient<AzureOpenAICl
         }
 
         if (info.type === ModelType.llm) {
+            const modelMaxContextSize = getModelMaxContextSize(info)
             return new ChatLunaChatModel({
                 modelInfo: info,
                 requester: this._requester,
                 model,
                 maxTokenLimit: Math.floor(
-                    info.maxTokens * this._config.maxContextRatio
+                    (info.maxTokens || modelMaxContextSize || 128_000) *
+                        this._config.maxContextRatio
                 ),
+                modelMaxContextSize,
                 frequencyPenalty: this._config.frequencyPenalty,
                 presencePenalty: this._config.presencePenalty,
                 timeout: this._config.timeout,

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-claude-adapter",
     "description": "claude adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0-alpha.14",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -60,14 +60,16 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
 
     protected _createModel(model: string): ChatLunaChatModel {
         const info = this._modelInfos[model]
+        const modelMaxContextSize = info.maxTokens ?? 128000
         return new ChatLunaChatModel({
             requester: this._requester,
             modelInfo: info,
             model,
             maxTokenLimit: Math.floor(
-                (info.maxTokens ?? 100000) * this._config.maxContextRatio
+                (info.maxTokens || modelMaxContextSize) *
+                    this._config.maxContextRatio
             ),
-            modelMaxContextSize: info.maxTokens ?? 100000,
+            modelMaxContextSize,
             timeout: this._config.timeout,
             maxRetries: this._config.maxRetries,
             llmType: model,

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0-alpha.14",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-dify-adapter",
     "description": "dify adapter for chatluna",
-    "version": "1.3.0-alpha.12",
+    "version": "1.3.0-alpha.13",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-doubao-adapter",
     "description": "doubao adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0-alpha.14",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.0-alpha.21",
+    "version": "1.3.0-alpha.22",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-hunyuan-adapter",
     "description": "hunyuan adapter for chatluna",
-    "version": "1.3.0-alpha.11",
+    "version": "1.3.0-alpha.12",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-ollama-adapter",
     "description": "ollama adapter for chatluna",
-    "version": "1.3.0-alpha.11",
+    "version": "1.3.0-alpha.12",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62"
     },
     "devDependencies": {
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai-like/src/client.ts
+++ b/packages/adapter-openai-like/src/client.ts
@@ -124,14 +124,16 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
         }
 
         if (info.type === ModelType.llm) {
+            const modelMaxContextSize = getModelMaxContextSize(info)
             return new ChatLunaChatModel({
                 modelInfo: info,
                 requester: this._requester,
                 model,
                 maxTokenLimit: Math.floor(
-                    (info.maxTokens || 100_000) * this._config.maxContextRatio
+                    (info.maxTokens || modelMaxContextSize || 128_000) *
+                        this._config.maxContextRatio
                 ),
-                modelMaxContextSize: getModelMaxContextSize(info),
+                modelMaxContextSize,
                 frequencyPenalty: this._config.frequencyPenalty,
                 presencePenalty: this._config.presencePenalty,
                 timeout: this._config.timeout,

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0-alpha.14",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/src/client.ts
+++ b/packages/adapter-openai/src/client.ts
@@ -18,7 +18,10 @@ import {
 import { Config, logger as pluginLogger } from '.'
 import { OpenAIRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
-import { supportImageInput } from '@chatluna/v1-shared-adapter'
+import {
+    getModelMaxContextSize,
+    supportImageInput
+} from '@chatluna/v1-shared-adapter'
 import { RunnableConfig } from '@langchain/core/runnables'
 
 export class OpenAIClient extends PlatformModelAndEmbeddingsClient<ClientConfig> {
@@ -103,13 +106,16 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         }
 
         if (info.type === ModelType.llm) {
+            const modelMaxContextSize = getModelMaxContextSize(info)
             return new ChatLunaChatModel({
                 modelInfo: info,
                 requester: this._requester,
                 model,
                 maxTokenLimit: Math.floor(
-                    (info.maxTokens || 100_000) * this._config.maxContextRatio
+                    (info.maxTokens || modelMaxContextSize || 128_000) *
+                        this._config.maxContextRatio
                 ),
+                modelMaxContextSize,
                 frequencyPenalty: this._config.frequencyPenalty,
                 presencePenalty: this._config.presencePenalty,
                 timeout: this._config.timeout,

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-qwen-adapter",
     "description": "qwen adapter for chatluna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/src/client.ts
+++ b/packages/adapter-qwen/src/client.ts
@@ -156,13 +156,15 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
         }
 
         if (info.type === ModelType.llm) {
+            const modelMaxContextSize = info.maxTokens
             return new ChatLunaChatModel({
                 modelInfo: info,
                 requester: this._requester,
                 model,
-                modelMaxContextSize: info.maxTokens,
+                modelMaxContextSize,
                 maxTokenLimit: Math.floor(
-                    (info.maxTokens || 100_000) * this._config.maxContextRatio
+                    (info.maxTokens || modelMaxContextSize || 128_000) *
+                        this._config.maxContextRatio
                 ),
                 timeout: this._config.timeout,
                 temperature: this._config.temperature,

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-rmkv-adapter",
     "description": "rwkv adapter for chatluna",
-    "version": "1.3.0-alpha.11",
+    "version": "1.3.0-alpha.12",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "1.0.14",
+        "@chatluna/v1-shared-adapter": "1.0.15",
         "@langchain/core": "0.3.62",
         "zod-to-json-schema": "3.23.5"
     },
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/src/client.ts
+++ b/packages/adapter-rwkv/src/client.ts
@@ -17,6 +17,7 @@ import {
 } from 'koishi-plugin-chatluna/utils/error'
 import { RWKVRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
+import { getModelMaxContextSize } from '@chatluna/v1-shared-adapter'
 
 export class RWKVClient extends PlatformModelAndEmbeddingsClient<ClientConfig> {
     platform = 'rwkv'
@@ -72,13 +73,16 @@ export class RWKVClient extends PlatformModelAndEmbeddingsClient<ClientConfig> {
         }
 
         if (info.type === ModelType.llm) {
+            const modelMaxContextSize = getModelMaxContextSize(info)
             return new ChatLunaChatModel({
                 modelInfo: info,
                 requester: this._requester,
                 model,
                 maxTokenLimit: Math.floor(
-                    (info.maxTokens || 100_000) * this._config.maxContextRatio
+                    (info.maxTokens || modelMaxContextSize || 128_000) *
+                        this._config.maxContextRatio
                 ),
+                modelMaxContextSize,
                 frequencyPenalty: this._config.frequencyPenalty,
                 presencePenalty: this._config.presencePenalty,
                 timeout: this._config.timeout,

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-spark-adapter",
     "description": "spark adapter for chatluna",
-    "version": "1.3.0-alpha.11",
+    "version": "1.3.0-alpha.12",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/src/client.ts
+++ b/packages/adapter-spark/src/client.ts
@@ -71,18 +71,20 @@ export class SparkClient extends PlatformModelClient<SparkClientConfig> {
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 
+        const modelMaxContextSize = info.maxTokens
         return new ChatLunaChatModel({
             modelInfo: info,
             requester: this._requester,
             model,
             maxTokenLimit: Math.floor(
-                (info.maxTokens || 100_000) * this._config.maxContextRatio
+                (info.maxTokens || modelMaxContextSize || 128_000) *
+                    this._config.maxContextRatio
             ),
             timeout: this._config.timeout,
             temperature: this._config.temperature,
             maxRetries: this._config.maxRetries,
             llmType: 'spark',
-            modelMaxContextSize: info.maxTokens
+            modelMaxContextSize
         })
     }
 }

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-wenxin-adapter",
     "description": "wenxin adapter for chatluna",
-    "version": "1.3.0-alpha.11",
+    "version": "1.3.0-alpha.12",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/src/client.ts
+++ b/packages/adapter-wenxin/src/client.ts
@@ -95,13 +95,15 @@ export class WenxinClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         }
 
         if (info.type === ModelType.llm) {
+            const modelMaxContextSize = info.maxTokens
             return new ChatLunaChatModel({
                 modelInfo: info,
                 requester: this._requester,
                 model,
-                modelMaxContextSize: info.maxTokens,
+                modelMaxContextSize,
                 maxTokenLimit: Math.floor(
-                    (info.maxTokens || 100_000) * this._config.maxContextRatio
+                    (info.maxTokens || modelMaxContextSize || 128_000) *
+                        this._config.maxContextRatio
                 ),
                 frequencyPenalty: this._config.frequencyPenalty,
                 presencePenalty: this._config.presencePenalty,

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-zhipu-adapter",
     "description": "zhipu(chatglm) adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0-alpha.14",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.14",
+        "@chatluna/v1-shared-adapter": "^1.0.15",
         "@langchain/core": "0.3.62",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/src/client.ts
+++ b/packages/adapter-zhipu/src/client.ts
@@ -121,13 +121,15 @@ export class ZhipuClient extends PlatformModelAndEmbeddingsClient<ClientConfig> 
             })
         }
 
+        const modelMaxContextSize = info.maxTokens
         return new ChatLunaChatModel({
             modelInfo: info,
             requester: this._requester,
             model: model.toLocaleLowerCase(),
-            modelMaxContextSize: info.maxTokens,
+            modelMaxContextSize,
             maxTokenLimit: Math.floor(
-                (info.maxTokens || 100_000) * this._config.maxContextRatio
+                (info.maxTokens || modelMaxContextSize || 128_000) *
+                    this._config.maxContextRatio
             ),
             frequencyPenalty: this._config.frequencyPenalty,
             presencePenalty: this._config.presencePenalty,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.3.0-alpha.75",
+    "version": "1.3.0-alpha.76",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-long-memory",
     "description": "long memory for chatluna",
-    "version": "1.3.0-alpha.7",
+    "version": "1.3.0-alpha.8",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/extension-long-memory/src/layers/emgas/extractor.ts
+++ b/packages/extension-long-memory/src/layers/emgas/extractor.ts
@@ -1,4 +1,3 @@
-import { logger } from '../..'
 import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
 import YAML from 'js-yaml'
 import { ComputedRef } from 'koishi-plugin-chatluna'

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-mcp-client",
     "description": "MCP Client for ChatLuna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-vector-store-service",
     "description": "vector store service for chatluna",
-    "version": "1.3.0-alpha.4",
+    "version": "1.3.0-alpha.5",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.75"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
     }
 }


### PR DESCRIPTION
This PR fixes inconsistent modelMaxContextSize handling across adapters and bumps package versions.

### Bug Fixes

- Standardized modelMaxContextSize handling across all adapters to ensure consistent behavior
- Fixed adapters that were not properly respecting the modelMaxContextSize configuration
- Improved context size validation logic in multiple adapter implementations

### Other Changes

- Bumped core package version to 1.3.0-alpha.76
- Bumped shared-adapter package version to 1.0.15
- Updated all adapter and extension packages to reference new core and shared-adapter versions