### PR TITLE
[Fix] Migrate token usage to response_metadata and add stream retry

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-azure-openai-adapter",
     "description": "azure openai adapter for chatluna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-claude-adapter",
     "description": "claude adapter for chatluna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-dify-adapter",
     "description": "dify adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0-alpha.14",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-doubao-adapter",
     "description": "doubao adapter for chatluna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.0-alpha.22",
+    "version": "1.3.0-alpha.23",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -497,11 +497,13 @@ export class GeminiRequester
                 ))
             ) {
                 const generationChunk = new ChatGenerationChunk({
-                    message: new AIMessageChunk(''),
-                    text: '',
-                    generationInfo: {
-                        tokenUsage: parsedChunk.usage
-                    }
+                    message: new AIMessageChunk({
+                        content: '',
+                        response_metadata: {
+                            tokenUsage: parsedChunk.usage
+                        }
+                    }),
+                    text: ''
                 })
 
                 yield { type: 'generation', generation: generationChunk }

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-hunyuan-adapter",
     "description": "hunyuan adapter for chatluna",
-    "version": "1.3.0-alpha.12",
+    "version": "1.3.0-alpha.13",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-ollama-adapter",
     "description": "ollama adapter for chatluna",
-    "version": "1.3.0-alpha.12",
+    "version": "1.3.0-alpha.13",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62"
     },
     "devDependencies": {
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.3.0-alpha.15",
+    "version": "1.3.0-alpha.16",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-qwen-adapter",
     "description": "qwen adapter for chatluna",
-    "version": "1.3.0-alpha.15",
+    "version": "1.3.0-alpha.16",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/src/requester.ts
+++ b/packages/adapter-qwen/src/requester.ts
@@ -141,15 +141,18 @@ export class QWenRequester
 
                 if (data.usage) {
                     yield new ChatGenerationChunk({
-                        message: new AIMessageChunk(''),
-                        text: '',
-                        generationInfo: {
-                            tokenUsage: {
-                                promptTokens: data.usage.prompt_tokens,
-                                completionTokens: data.usage.completion_tokens,
-                                totalTokens: data.usage.total_tokens
+                        message: new AIMessageChunk({
+                            content: '',
+                            response_metadata: {
+                                tokenUsage: {
+                                    promptTokens: data.usage.prompt_tokens,
+                                    completionTokens:
+                                        data.usage.completion_tokens,
+                                    totalTokens: data.usage.total_tokens
+                                }
                             }
-                        }
+                        }),
+                        text: ''
                     })
                 }
 

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-rmkv-adapter",
     "description": "rwkv adapter for chatluna",
-    "version": "1.3.0-alpha.12",
+    "version": "1.3.0-alpha.13",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "1.0.15",
+        "@chatluna/v1-shared-adapter": "1.0.16",
         "@langchain/core": "0.3.62",
         "zod-to-json-schema": "3.23.5"
     },
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-spark-adapter",
     "description": "spark adapter for chatluna",
-    "version": "1.3.0-alpha.12",
+    "version": "1.3.0-alpha.13",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-wenxin-adapter",
     "description": "wenxin adapter for chatluna",
-    "version": "1.3.0-alpha.12",
+    "version": "1.3.0-alpha.13",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-zhipu-adapter",
     "description": "zhipu(chatglm) adapter for chatluna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0-alpha.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.15",
+        "@chatluna/v1-shared-adapter": "^1.0.16",
         "@langchain/core": "0.3.62",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/src/requester.ts
+++ b/packages/adapter-zhipu/src/requester.ts
@@ -141,7 +141,8 @@ export class ZhipuRequester
                             response_metadata: {
                                 tokenUsage: {
                                     promptTokens: data.usage.prompt_tokens,
-                                    completionTokens: data.usage.completion_tokens,
+                                    completionTokens:
+                                        data.usage.completion_tokens,
                                     totalTokens: data.usage.total_tokens
                                 }
                             }

--- a/packages/adapter-zhipu/src/requester.ts
+++ b/packages/adapter-zhipu/src/requester.ts
@@ -136,15 +136,17 @@ export class ZhipuRequester
 
                 if (data.usage) {
                     yield new ChatGenerationChunk({
-                        message: new AIMessageChunk(''),
-                        text: '',
-                        generationInfo: {
-                            tokenUsage: {
-                                promptTokens: data.usage.prompt_tokens,
-                                completionTokens: data.usage.completion_tokens,
-                                totalTokens: data.usage.total_tokens
+                        message: new AIMessageChunk({
+                            content: '',
+                            response_metadata: {
+                                tokenUsage: {
+                                    promptTokens: data.usage.prompt_tokens,
+                                    completionTokens: data.usage.completion_tokens,
+                                    totalTokens: data.usage.total_tokens
+                                }
                             }
-                        }
+                        }),
+                        text: ''
                     })
                 }
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.3.0-alpha.76",
+    "version": "1.3.0-alpha.77",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -295,8 +295,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         chunk: ChatGenerationChunk,
         latestTokenUsage: TokenUsageTracker
     ) {
-        const tokenUsage =
-            chunk.message.response_metadata?.['tokenUsage'] ?? undefined
+        const tokenUsage = chunk.message.response_metadata?.['tokenUsage']
 
         if (!tokenUsage) {
             return
@@ -397,7 +396,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         response.message.response_metadata =
             response.message.response_metadata ?? {}
 
-        if (response.message.response_metadata == null) {
+        if (!response.message.response_metadata.tokenUsage) {
             const completionTokens = await this.countMessageTokens(
                 response.message
             )
@@ -407,18 +406,15 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 totalTokens: completionTokens + promptTokens
             }
         } else if (options.stream !== true) {
-            logger.debug(
-                'Token usage from API: Prompt Token = %d, Completion Token = %d, Total Token = %d',
-                response.message.response_metadata['tokenUsage']?.[
-                    'promptTokens'
-                ],
-                response.message.response_metadata['tokenUsage']?.[
-                    'completionTokens'
-                ],
-                response.message.response_metadata['tokenUsage']?.[
-                    'totalTokens'
-                ]
-            )
+            const tokenUsage = response.message.response_metadata['tokenUsage']
+            if (tokenUsage) {
+                logger.debug(
+                    'Token usage from API: Prompt Token = %d, Completion Token = %d, Total Token = %d',
+                    tokenUsage.promptTokens,
+                    tokenUsage.completionTokens,
+                    tokenUsage.totalTokens
+                )
+            }
         }
 
         return {

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -19,7 +19,10 @@ import {
     ModelRequester,
     ModelRequestParams
 } from 'koishi-plugin-chatluna/llm-core/platform/api'
-import { ModelInfo } from 'koishi-plugin-chatluna/llm-core/platform/types'
+import {
+    ModelInfo,
+    TokenUsageTracker
+} from 'koishi-plugin-chatluna/llm-core/platform/types'
 import {
     getModelContextSize,
     getModelNameForTiktoken,
@@ -196,82 +199,178 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             ;[messages] = await this.cropMessages(messages, options['tools'])
         }
 
-        const stream = await this._createStreamWithRetry({
+        const maxRetries = Math.max(1, this._options.maxRetries ?? 1)
+        const streamParams = {
             ...this.invocationParams(options),
             input: messages
-        })
+        }
 
-        let isToolCallMessage = false
-        let hasChunk = false
+        for (let attempt = 0; attempt < maxRetries; attempt++) {
+            const latestTokenUsage = this._createTokenUsageTracker()
+            let stream: AsyncGenerator<ChatGenerationChunk> | null = null
+            let hasChunk = false
+            let isToolCallMessage = false
 
-        const latestTokenUsage: {
-            promptTokens: number
-            completionTokens: number
-            totalTokens: number
-        } = {
+            try {
+                stream = await this._createStreamWithRetry(streamParams)
+
+                for await (const chunk of stream) {
+                    isToolCallMessage = this._handleStreamChunk(
+                        chunk,
+                        runManager,
+                        latestTokenUsage
+                    )
+                    hasChunk = true
+                    yield chunk
+                }
+
+                this._ensureChunksReceived(hasChunk)
+                this._finalizeStream(
+                    isToolCallMessage,
+                    latestTokenUsage,
+                    runManager
+                )
+                return
+            } catch (error) {
+                await this._closeStream(stream)
+
+                if (
+                    this._shouldRethrowStreamError(
+                        error,
+                        hasChunk,
+                        attempt,
+                        maxRetries
+                    )
+                ) {
+                    throw error
+                }
+
+                await sleep(2000)
+            }
+        }
+    }
+
+    private _createTokenUsageTracker(): TokenUsageTracker {
+        return {
             promptTokens: 0,
             completionTokens: 0,
             totalTokens: 0
         }
+    }
 
-        for await (const chunk of stream) {
-            yield chunk
+    private _handleStreamChunk(
+        chunk: ChatGenerationChunk,
+        runManager: CallbackManagerForLLMRun | undefined,
+        latestTokenUsage: TokenUsageTracker
+    ): boolean {
+        const chunkText = chunk.text ?? ''
 
-            const chunkText = chunk.text ?? ''
-
-            if (chunkText != null) {
-                // eslint-disable-next-line no-void
-                void runManager?.handleLLMNewToken(chunkText)
-
-                isToolCallMessage =
-                    ((chunk.message as AIMessageChunk)?.tool_calls?.length ??
-                        0) === 0 &&
-                    ((chunk.message as AIMessageChunk)?.tool_call_chunks
-                        ?.length ?? 0) === 0 &&
-                    ((chunk.message as AIMessageChunk)?.invalid_tool_calls
-                        ?.length ?? 0) === 0
-
-                if (isToolCallMessage) {
-                    // eslint-disable-next-line no-void
-                    void runManager?.handleCustomEvent(
-                        'LLMNewChunk',
-                        chunk.message
-                    )
-                }
-            }
-
-            if (
-                chunk.generationInfo != null &&
-                chunk.generationInfo['tokenUsage'] != null
-            ) {
-                latestTokenUsage.promptTokens =
-                    chunk.generationInfo['tokenUsage']['promptTokens']
-                latestTokenUsage.completionTokens =
-                    chunk.generationInfo['tokenUsage']['completionTokens']
-                latestTokenUsage.totalTokens =
-                    chunk.generationInfo['tokenUsage']['totalTokens']
-            }
-
-            if (!hasChunk) hasChunk = true
+        if (chunkText) {
+            // eslint-disable-next-line no-void
+            void runManager?.handleLLMNewToken(chunkText)
         }
 
-        if (!hasChunk) {
-            throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED)
+        const message = chunk.message as AIMessageChunk | undefined
+        const isToolCallMessage = this._isToolCallMessage(message)
+
+        if (isToolCallMessage) {
+            // eslint-disable-next-line no-void
+            void runManager?.handleCustomEvent('LLMNewChunk', message)
         }
 
+        this._updateTokenUsageFromChunk(chunk, latestTokenUsage)
+
+        return isToolCallMessage
+    }
+
+    private _isToolCallMessage(message?: AIMessageChunk): boolean {
+        return (
+            (message?.tool_calls?.length ?? 0) === 0 &&
+            (message?.tool_call_chunks?.length ?? 0) === 0 &&
+            (message?.invalid_tool_calls?.length ?? 0) === 0
+        )
+    }
+
+    private _updateTokenUsageFromChunk(
+        chunk: ChatGenerationChunk,
+        latestTokenUsage: TokenUsageTracker
+    ) {
+        const tokenUsage =
+            chunk.message.response_metadata?.['tokenUsage'] ?? undefined
+
+        if (!tokenUsage) {
+            return
+        }
+
+        latestTokenUsage.promptTokens = tokenUsage['promptTokens']
+        latestTokenUsage.completionTokens = tokenUsage['completionTokens']
+        latestTokenUsage.totalTokens = tokenUsage['totalTokens']
+    }
+
+    private _ensureChunksReceived(hasChunk: boolean) {
+        if (hasChunk) {
+            return
+        }
+
+        throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED)
+    }
+
+    private _finalizeStream(
+        isToolCallMessage: boolean,
+        latestTokenUsage: TokenUsageTracker,
+        runManager?: CallbackManagerForLLMRun
+    ) {
         if (isToolCallMessage) {
             // eslint-disable-next-line no-void
             void runManager?.handleCustomEvent('LLMNewChunk', undefined)
         }
 
-        if (latestTokenUsage.totalTokens > 0) {
+        if (latestTokenUsage.totalTokens <= 0) {
+            return
+        }
+
+        logger.debug(
+            'Token usage from API: Prompt Token = %d, Completion Token = %d, Total Token = %d',
+            latestTokenUsage.promptTokens,
+            latestTokenUsage.completionTokens,
+            latestTokenUsage.totalTokens
+        )
+    }
+
+    private async _closeStream(
+        stream: AsyncGenerator<ChatGenerationChunk> | null
+    ) {
+        if (stream?.return == null) {
+            return
+        }
+
+        try {
+            await stream.return(undefined)
+        } catch (error) {
             logger.debug(
-                'Token usage from API: Prompt Token = %d, Completion Token = %d, Total Token = %d',
-                latestTokenUsage.promptTokens,
-                latestTokenUsage.completionTokens,
-                latestTokenUsage.totalTokens
+                'Failed to close stream on retry: %s',
+                (error as Error)?.message
             )
         }
+    }
+
+    private _shouldRethrowStreamError(
+        error: unknown,
+        hasChunk: boolean,
+        attempt: number,
+        maxRetries: number
+    ): boolean {
+        return (
+            this._isAbortError(error) || hasChunk || attempt === maxRetries - 1
+        )
+    }
+
+    private _isAbortError(error: unknown): boolean {
+        if (error instanceof ChatLunaError) {
+            return error.errorCode === ChatLunaErrorCode.ABORTED
+        }
+
+        return (error as Error)?.name === 'AbortError'
     }
 
     async _generate(
@@ -295,13 +394,14 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED)
         }
 
-        response.generationInfo = response.generationInfo ?? {}
+        response.message.response_metadata =
+            response.message.response_metadata ?? {}
 
-        if (response.generationInfo.tokenUsage == null) {
+        if (response.message.response_metadata == null) {
             const completionTokens = await this.countMessageTokens(
                 response.message
             )
-            response.generationInfo.tokenUsage = {
+            response.message.response_metadata.tokenUsage = {
                 completionTokens,
                 promptTokens,
                 totalTokens: completionTokens + promptTokens
@@ -309,9 +409,15 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         } else if (options.stream !== true) {
             logger.debug(
                 'Token usage from API: Prompt Token = %d, Completion Token = %d, Total Token = %d',
-                response.generationInfo['tokenUsage']['promptTokens'],
-                response.generationInfo['tokenUsage']['completionTokens'],
-                response.generationInfo['tokenUsage']['totalTokens']
+                response.message.response_metadata['tokenUsage']?.[
+                    'promptTokens'
+                ],
+                response.message.response_metadata['tokenUsage']?.[
+                    'completionTokens'
+                ],
+                response.message.response_metadata['tokenUsage']?.[
+                    'totalTokens'
+                ]
             )
         }
 

--- a/packages/core/src/llm-core/platform/types.ts
+++ b/packages/core/src/llm-core/platform/types.ts
@@ -127,3 +127,9 @@ export function isPlatformModelInfo(model: any): model is PlatformModelInfo {
         model['platform'] !== 'default'
     )
 }
+
+export type TokenUsageTracker = {
+    promptTokens: number
+    completionTokens: number
+    totalTokens: number
+}

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -60,7 +60,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76",
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.76"
+        "koishi-plugin-chatluna": "^1.3.0-alpha.77"
     }
 }

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -152,15 +152,17 @@ export async function* processStreamResponse<
 
             if (data.usage) {
                 yield new ChatGenerationChunk({
-                    message: new AIMessageChunk(''),
-                    text: '',
-                    generationInfo: {
-                        tokenUsage: {
-                            promptTokens: data.usage.prompt_tokens,
-                            completionTokens: data.usage.completion_tokens,
-                            totalTokens: data.usage.total_tokens
+                    message: new AIMessageChunk({
+                        content: '',
+                        response_metadata: {
+                            tokenUsage: {
+                                promptTokens: data.usage.prompt_tokens,
+                                completionTokens: data.usage.completion_tokens,
+                                totalTokens: data.usage.total_tokens
+                            }
                         }
-                    }
+                    }),
+                    text: ''
                 })
             }
 


### PR DESCRIPTION
This PR migrates token usage tracking to LangChain's updated message structure and adds automatic retry mechanism for streaming requests.

### Bug Fixes

- Fixed token usage tracking to use `response_metadata` instead of deprecated `generationInfo`
- Added automatic retry mechanism for failed streaming requests to improve reliability
- Implemented proper stream cleanup on retry attempts to prevent resource leaks

### Other Changes

- Updated token usage handling in gemini, qwen, zhipu, and shared-adapter packages
- Refactored core model streaming logic to support configurable retry attempts
- Enhanced error handling for abort errors and partial stream failures