### PR TITLE
[Release] Version 1.3.0 Stable Release

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-azure-openai-adapter",
     "description": "azure openai adapter for chatluna",
-    "version": "1.3.0-alpha.15",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-claude-adapter",
     "description": "claude adapter for chatluna",
-    "version": "1.3.0-alpha.15",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.3.0-alpha.15",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-dify-adapter",
     "description": "dify adapter for chatluna",
-    "version": "1.3.0-alpha.14",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-doubao-adapter",
     "description": "doubao adapter for chatluna",
-    "version": "1.3.0-alpha.15",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.0-alpha.23",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78",
+        "koishi-plugin-chatluna": "^1.3.0",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-hunyuan-adapter",
     "description": "hunyuan adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-ollama-adapter",
     "description": "ollama adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.3.0-alpha.16",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.3.0-alpha.15",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-qwen-adapter",
     "description": "qwen adapter for chatluna",
-    "version": "1.3.0-alpha.16",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-rmkv-adapter",
     "description": "rwkv adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-spark-adapter",
     "description": "spark adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-wenxin-adapter",
     "description": "wenxin adapter for chatluna",
-    "version": "1.3.0-alpha.13",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-zhipu-adapter",
     "description": "zhipu(chatglm) adapter for chatluna",
-    "version": "1.3.0-alpha.15",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.3.0-alpha.78",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-long-memory",
     "description": "long memory for chatluna",
-    "version": "1.3.0-alpha.8",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-mcp-client",
     "description": "MCP Client for ChatLuna",
-    "version": "1.3.0-alpha.16",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78",
+        "koishi-plugin-chatluna": "^1.3.0",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-plugin-common",
     "description": "plugin service for agent mode of chatluna",
-    "version": "1.3.0-alpha.22",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78",
+        "koishi-plugin-chatluna": "^1.3.0",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-variable-extension",
     "description": "variable extension for ChatLuna",
-    "version": "1.2.7",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-image-renderer",
     "description": "image renderer for chatluna",
-    "version": "1.2.8",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-embeddings-service",
     "description": "embeddings service for chatluna",
-    "version": "1.3.0-alpha.1",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-image-service",
     "description": "image service for chatluna",
-    "version": "1.3.0-alpha.1",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-search-service",
     "description": "search support for chatluna",
-    "version": "1.3.0-alpha.3",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-vector-store-service",
     "description": "vector store service for chatluna",
-    "version": "1.3.0-alpha.5",
+    "version": "1.3.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0-alpha.78"
+        "koishi-plugin-chatluna": "^1.3.0"
     }
 }


### PR DESCRIPTION
This PR finalizes the version 1.3.0 stable release by bumping all package versions from their alpha releases to the stable 1.3.0 version.

## Summary

This release includes all the improvements and fixes that have been developed and tested during the alpha phase. All packages are now ready for the stable 1.3.0 release.

### Version Updates

- **Core**: `1.3.0-alpha.78` → `1.3.0`
- **Adapters**: All adapter packages updated from various alpha versions to `1.3.0`
  - azure-openai, claude, deepseek, dify, doubao, gemini, hunyuan, ollama, openai-like, openai, qwen, rwkv, spark, wenxin, zhipu
- **Extensions**: All extension packages updated to `1.3.0`
  - long-memory, mcp-client, plugin-common, variable-extension
- **Services**: All service packages updated to `1.3.0`
  - embeddings-service, image-service, search-service, vector-store-service
- **Other Packages**: renderer-image, shared-adapter updated to `1.3.0`

All peer dependency references have been updated to reference the stable `^1.3.0` version.

## Recent Improvements Included in This Release

Based on recent commits in v1-dev, this release includes:

- Improved tool error handling and async operations
- Token usage migration to response_metadata with stream retry support
- Standardized modelMaxContextSize handling
- Fixed Hippo and EMGAS long-term memory retrieval issues
- MCP proxy support
- Improved crypto imports and Milvus metadata handling
- MCP timeout support and tool handling improvements
- Improved Gemini schema generation and MCP tool display
- Refactored MCP commands to use core command pattern

## Checklist

- [x] All package versions bumped to 1.3.0
- [x] All peer dependencies updated
- [x] Commit follows Angular format
- [x] Ready for stable release