### PR TITLE
[Feature] Add Gemini 3.0 thinking level and systemInstruction casing support

### DIFF
--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -72,11 +72,9 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                     ]
                 } satisfies ModelInfo
 
-                const thinkingModel = [
-                    'gemini-2.5-pro',
-                    'gemini-2.5-flash',
-                    'gemini-3.0-pro'
-                ]
+                const thinkingModel = ['gemini-2.5-pro', 'gemini-2.5-flash']
+
+                const thinkingLevelModel = ['gemini-3.0-pro']
 
                 if (
                     thinkingModel.some(
@@ -94,6 +92,17 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                     } else {
                         models.push(info)
                     }
+                } else if (
+                    thinkingLevelModel.some(
+                        (name) =>
+                            model.name.toLowerCase().includes(name) &&
+                            !model.name.toLowerCase().includes('image')
+                    )
+                ) {
+                    models.push(
+                        { ...info, name: model.name + '-low-thinking' },
+                        info
+                    )
                 } else {
                     models.push(info)
                 }

--- a/packages/adapter-gemini/src/index.ts
+++ b/packages/adapter-gemini/src/index.ts
@@ -50,6 +50,7 @@ export interface Config extends ChatLunaPlugin.Config {
     imageGeneration: boolean
     thinkingBudget: number
     includeThoughts: boolean
+    useCamelCaseSystemInstruction: boolean
 }
 
 export const Config: Schema<Config> = Schema.intersect([
@@ -84,7 +85,8 @@ export const Config: Schema<Config> = Schema.intersect([
         nonStreaming: Schema.boolean().default(false),
         imageGeneration: Schema.boolean().default(false),
         groundingContentDisplay: Schema.boolean().default(false),
-        searchThreshold: Schema.number().min(0).max(1).step(0.1).default(0.5)
+        searchThreshold: Schema.number().min(0).max(1).step(0.1).default(0.5),
+        useCamelCaseSystemInstruction: Schema.boolean().default(false)
     })
 ]).i18n({
     'zh-CN': require('./locales/zh-CN.schema.yml'),

--- a/packages/adapter-gemini/src/locales/en-US.schema.yml
+++ b/packages/adapter-gemini/src/locales/en-US.schema.yml
@@ -21,3 +21,4 @@ $inner:
       codeExecution: 'Enable code execution tool'
       urlContext: 'Enable URL context retrieval tool'
       nonStreaming: 'Force disable streaming response. When enabled, requests will always be made in non-streaming mode, even if the stream parameter is configured.'
+      useCamelCaseSystemInstruction: 'Use camelCase systemInstruction instead of snake_case system_instruction'

--- a/packages/adapter-gemini/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-gemini/src/locales/zh-CN.schema.yml
@@ -21,4 +21,4 @@ $inner:
       codeExecution: '为模型启用代码执行工具。'
       urlContext: '为模型启用 URL 内容获取工具。'
       nonStreaming: 强制不启用流式返回。开启后，将总是以非流式发起请求，即便配置了 stream 参数。
-
+      useCamelCaseSystemInstruction: 使用大写的 systemInstruction 而不是小写的 system_instruction

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -29,6 +29,7 @@ import {
 } from 'koishi-plugin-chatluna/utils/string'
 import { isZodSchemaV3 } from '@langchain/core/utils/types'
 import { generateSchema } from '@anatine/zod-openapi'
+import { filterKeys } from 'koishi'
 
 export async function langchainMessageToGeminiMessage(
     messages: BaseMessage[],
@@ -303,11 +304,7 @@ export function formatToolsToGeminiAITools(
     }
 
     if (googleSearch) {
-        if (model.includes('gemini-2')) {
-            result.push({
-                google_search: {}
-            })
-        } else {
+        if (model.includes('gemini-1')) {
             result.push({
                 google_search_retrieval: {
                     dynamic_retrieval_config: {
@@ -315,6 +312,10 @@ export function formatToolsToGeminiAITools(
                         dynamic_threshold: config.searchThreshold
                     }
                 }
+            })
+        } else {
+            result.push({
+                google_search: {}
             })
         }
     }
@@ -374,6 +375,7 @@ export function prepareModelConfig(
 ) {
     let model = params.model
     let enabledThinking: boolean | undefined = null
+    let thinkingLevel: string = 'high'
 
     if (model.includes('-thinking') && model.includes('gemini-2.5')) {
         enabledThinking = !model.includes('-non-thinking')
@@ -388,6 +390,20 @@ export function prepareModelConfig(
         thinkingBudget = 128
     }
 
+    if (model.includes('-thinking') && model.includes('gemini-3.0')) {
+        enabledThinking = true
+        const match = model.match(/-(low|medium|high)-thinking/)
+        if (match) {
+            thinkingLevel = match[1]
+            model = model.replace(`-${match[1]}-thinking`, '')
+        } else {
+            // Default to low for gemini-3.0 if no level specified
+            thinkingLevel = 'low'
+            model = model.replace('-thinking', '')
+        }
+        thinkingBudget = undefined
+    }
+
     let imageGeneration = pluginConfig.imageGeneration ?? false
 
     if (imageGeneration) {
@@ -396,32 +412,38 @@ export function prepareModelConfig(
             params.model.includes('gemini-2.5-flash-image')
     }
 
-    return { model, enabledThinking, thinkingBudget, imageGeneration }
+    return {
+        model,
+        enabledThinking,
+        thinkingBudget,
+        imageGeneration,
+        thinkingLevel
+    }
 }
 
 export function createSafetySettings(model: string) {
-    const isGemini2 = model.includes('gemini-2')
+    const isNonGemini1 = !model.includes('gemini-1')
 
     return [
         {
             category: 'HARM_CATEGORY_HARASSMENT',
-            threshold: isGemini2 ? 'OFF' : 'BLOCK_NONE'
+            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
         },
         {
             category: 'HARM_CATEGORY_HATE_SPEECH',
-            threshold: isGemini2 ? 'OFF' : 'BLOCK_NONE'
+            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
         },
         {
             category: 'HARM_CATEGORY_SEXUALLY_EXPLICIT',
-            threshold: isGemini2 ? 'OFF' : 'BLOCK_NONE'
+            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
         },
         {
             category: 'HARM_CATEGORY_DANGEROUS_CONTENT',
-            threshold: isGemini2 ? 'OFF' : 'BLOCK_NONE'
+            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
         },
         {
             category: 'HARM_CATEGORY_CIVIC_INTEGRITY',
-            threshold: isGemini2 ? 'OFF' : 'BLOCK_NONE'
+            threshold: isNonGemini1 ? 'OFF' : 'BLOCK_NONE'
         }
     ]
 }
@@ -443,10 +465,14 @@ export function createGenerationConfig(
             : undefined,
         thinkingConfig:
             modelConfig.enabledThinking != null || pluginConfig.includeThoughts
-                ? {
-                      thinkingBudget: modelConfig.thinkingBudget,
-                      includeThoughts: pluginConfig.includeThoughts
-                  }
+                ? filterKeys(
+                      {
+                          thinkingBudget: modelConfig.thinkingBudget,
+                          thinkingLevel: modelConfig.thinkingLevel,
+                          includeThoughts: pluginConfig.includeThoughts
+                      },
+                      (k, v) => v != null
+                  )
                 : undefined
     }
 }

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -375,7 +375,7 @@ export function prepareModelConfig(
 ) {
     let model = params.model
     let enabledThinking: boolean | undefined = null
-    let thinkingLevel: string = 'high'
+    let thinkingLevel: string = 'THINKING_LEVEL_UNSPECIFIED'
 
     if (model.includes('-thinking') && model.includes('gemini-2.5')) {
         enabledThinking = !model.includes('-non-thinking')
@@ -397,8 +397,8 @@ export function prepareModelConfig(
             thinkingLevel = match[1]
             model = model.replace(`-${match[1]}-thinking`, '')
         } else {
-            // Default to low for gemini-3.0 if no level specified
-            thinkingLevel = 'low'
+            // Default to THINKING_LEVEL_UNSPECIFIED for gemini-3.0 if no level specified
+            thinkingLevel = 'THINKING_LEVEL_UNSPECIFIED'
             model = model.replace('-thinking', '')
         }
         thinkingBudget = undefined
@@ -492,6 +492,10 @@ export async function createChatGenerationParams(
     const [systemInstruction, modelMessages] =
         extractSystemMessages(geminiMessages)
 
+    const systemInstructionKey = pluginConfig.useCamelCaseSystemInstruction
+        ? 'systemInstruction'
+        : 'system_instruction'
+
     return {
         contents: modelMessages,
         safetySettings: createSafetySettings(params.model),
@@ -500,7 +504,7 @@ export async function createChatGenerationParams(
             modelConfig,
             pluginConfig
         ),
-        system_instruction:
+        [systemInstructionKey]:
             systemInstruction != null ? systemInstruction : undefined,
         tools:
             params.tools != null ||


### PR DESCRIPTION
This PR adds Gemini 3.0 thinking level support and systemInstruction casing configuration.

## New Features

- Add Gemini 3.0 thinking level support (low/medium/high)
- Add `useCamelCaseSystemInstruction` config option
- Implement thinking level extraction from model names

## Other Changes

- Update default thinkingLevel to `THINKING_LEVEL_UNSPECIFIED`
- Separate thinking model handling for Gemini 2.5 and 3.0
- Fix Google Search API selection logic
- Bump version to 1.3.6