### PR TITLE
fix(adapter-gemini): clear thinkingLevel when thinking mode is disabled

### DIFF
--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.6",
+    "version": "1.3.7",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -402,6 +402,8 @@ export function prepareModelConfig(
             model = model.replace('-thinking', '')
         }
         thinkingBudget = undefined
+    } else {
+        thinkingLevel = undefined
     }
 
     let imageGeneration = pluginConfig.imageGeneration ?? false


### PR DESCRIPTION
修复当思维模式禁用时未清除 thinkingLevel 参数的问题。

## Bug Fixes

- 当 thinkingBudget 被清除时,同步清除 thinkingLevel 参数
- 确保非思维模式下不会传递无效的 thinkingLevel 参数