### PR TITLE
[Feature] Add Gemini 3.0 image generation support

### DIFF
--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/src/locales/en-US.schema.yml
+++ b/packages/adapter-gemini/src/locales/en-US.schema.yml
@@ -15,7 +15,7 @@ $inner:
       googleSearch: 'Enable Google search'
       thinkingBudget: 'Thinking budget (-1-24576). (0: dynamic thinking) Higher: more tokens spent on thinking. Currently only supports `gemini-2.5` series models.'
       groundingContentDisplay: "Enable display of search results"
-      imageGeneration: 'Enable image generation (only for `gemini-2.0-flash-exp` and `gemini-2.5-flash-image-preview` model)'
+      imageGeneration: 'Enable image generation (only for `gemini-3.0-pro-image-preview` and `gemini-2.5-flash-image-preview` model)'
       searchThreshold: 'Search confidence [threshold](https://ai.google.dev/gemini-api/docs/grounding?lang=rest#dynamic-retrieval) (0-1). Lower: more likely to use Google search'
       includeThoughts: 'Enable retrieval of model thoughts'
       codeExecution: 'Enable code execution tool'

--- a/packages/adapter-gemini/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-gemini/src/locales/zh-CN.schema.yml
@@ -15,7 +15,7 @@ $inner:
       googleSearch: '为模型启用谷歌搜索。'
       thinkingBudget: '思考预算，范围：(-1~24576)，设置的数值越大，思考时花费的 Token 越多,-1 为动态思考。目前仅支持 gemini 2.5 系列模型。'
       groundingContentDisplay: "是否显示谷歌搜索结果。"
-      imageGeneration: '为模型启用图像生成。目前仅支持 `gemini-2.0-flash-exp` 和 `gemini-2.5-flash-image-preview` 模型。'
+      imageGeneration: '为模型启用图像生成。目前仅支持 `gemini-3.0-pro-image-preview` 和 `gemini-2.5-flash-image-preview` 模型。'
       searchThreshold: '搜索的[置信度阈值](https://ai.google.dev/gemini-api/docs/grounding?lang=rest#dynamic-retrieval)，范围：0~1，设置的数值越低，则越倾向于使用谷歌搜索。（仅支持 `gemini-1.5` 系列模型。gemini 2.0 模型起使用动态的工具调用）'
       includeThoughts: '是否获取模型的思考内容。'
       codeExecution: '为模型启用代码执行工具。'

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -411,7 +411,7 @@ export function prepareModelConfig(
     if (imageGeneration) {
         imageGeneration =
             params.model.includes('gemini-2.0-flash-exp') ||
-            params.model.includes('gemini-2.5-flash-image')
+            params.model.includes('image')
     }
 
     return {


### PR DESCRIPTION
This PR adds support for Gemini 3.0 image generation capabilities.

## New Features

- Add support for Gemini 3.0 Pro Image Preview model's image generation feature
- Improve image generation model detection logic using generic 'image' keyword matching for better compatibility and future-proofing

## Other Changes

- Update documentation in both English and Chinese to reflect Gemini 3.0 support
- Bump package version to 1.3.8