### PR TITLE
[Release] Version 1.3.1

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.9",
+    "version": "1.3.10",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0",
+        "koishi-plugin-chatluna": "^1.3.1",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62"
     },
     "devDependencies": {
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "1.0.16",
+        "@chatluna/v1-shared-adapter": "1.0.17",
         "@langchain/core": "0.3.62",
         "zod-to-json-schema": "3.23.5"
     },
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.16",
+        "@chatluna/v1-shared-adapter": "^1.0.17",
         "@langchain/core": "0.3.62",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -152,7 +152,7 @@
             "import": "./lib/utils/schema.mjs",
             "require": "./lib/utils/schema.cjs"
         },
-         "./utils/object": {
+        "./utils/object": {
             "types": "./lib/utils/object.d.ts",
             "import": "./lib/utils/object.mjs",
             "require": "./lib/utils/object.cjs"

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -60,7 +60,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0",
+        "koishi-plugin-chatluna": "^1.3.1",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0",
+        "koishi-plugin-chatluna": "^1.3.1",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-image-service",
     "description": "image service for chatluna",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.16",
+    "version": "1.0.17",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.0"
+        "koishi-plugin-chatluna": "^1.3.1"
     }
 }


### PR DESCRIPTION
This PR bumps the version to 1.3.1 across all packages in the monorepo.

## Version Updates

- Core: 1.3.0 → 1.3.1
- Shared Adapter: 1.0.16 → 1.0.17
- Gemini Adapter: 1.3.9 → 1.3.10
- OpenAI Adapters: 1.3.0 → 1.3.1
- Image Service: 1.3.0 → 1.3.1

## Included Changes

This release includes:
- Gemini 3.0 image generation with configurable sizes (1K/2K/4K)
- GIF frame extraction optimization
- MCP client reconnection improvements
- Prototype pollution fix in deepAssign utility