### PR TITLE
[Feature] Add DeepSeek reasoning content support

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62"
     },
     "devDependencies": {

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "1.0.17",
+        "@chatluna/v1-shared-adapter": "1.0.18",
         "@langchain/core": "0.3.62",
         "zod-to-json-schema": "3.23.5"
     },

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.17",
+        "@chatluna/v1-shared-adapter": "^1.0.18",
         "@langchain/core": "0.3.62",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -94,16 +94,21 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                     ? ctx.chatluna.platform.findModel(model)
                     : undefined
 
+            const isInstalledImageService =
+                ctx.chatluna.getPlugin('image-service') != null
+
             if (
                 parsedModelInfo?.value != null &&
                 !parsedModelInfo.value.capabilities.includes(
                     ModelCapabilities.ImageInput
                 )
             ) {
-                logger.warn(
-                    // eslint-disable-next-line max-len
-                    `Model "${model}" does not support image input. Please use a model that supports vision capabilities, or install chatluna-image-service plugin to enable image description.`
-                )
+                if (!isInstalledImageService) {
+                    logger.warn(
+                        // eslint-disable-next-line max-len
+                        `Model "${model}" does not support image input. Please use a model that supports vision capabilities, or install chatluna-image-service plugin to enable image description.`
+                    )
+                }
                 return false
             }
 
@@ -113,7 +118,13 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             logger.debug(`Processing image: ${displayUrl}`)
 
             if (!ctx.chatluna_storage) {
-                return await oldImageRead(ctx, url, message, element)
+                return await oldImageRead(
+                    ctx,
+                    url,
+                    message,
+                    element,
+                    isInstalledImageService
+                )
             }
 
             const { buffer, ext } = await readImage(ctx, url)
@@ -124,7 +135,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             // For GIF images, warn and let image-service handle it
             if (ext === 'image/gif') {
-                if (ctx.chatluna.getPlugin('image-service') == null) {
+                if (!isInstalledImageService) {
                     logger.warn(
                         `Detected GIF image, which is not supported by most models. Please install chatluna-image-service plugin to parse GIF animations.`
                     )
@@ -160,7 +171,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         ctx: Context,
         url: string,
         message: Message,
-        element: h
+        element: h,
+        isInstalledImageService: boolean
     ) {
         const imageHash = await hashString(url, 8)
         element.attrs['imageHash'] = imageHash
@@ -174,7 +186,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             // For GIF images, warn user
             if (ext === 'image/gif') {
-                if (ctx.chatluna.getPlugin('image-service') == null) {
+                if (!isInstalledImageService) {
                     logger.warn(
                         `Detected GIF image, which is not supported by most models. Please install chatluna-image-service plugin to parse GIF animations.`
                     )

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.17",
+    "version": "1.0.18",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -35,6 +35,7 @@ export async function langchainMessageToOpenAIMessage(
 ): Promise<ChatCompletionResponseMessage[]> {
     const result: ChatCompletionResponseMessage[] = []
 
+    const isDeepseekThinkModel = model?.includes('deepseek-reasoner')
     for (const rawMessage of messages) {
         const role = messageTypeToOpenAIRole(rawMessage.getType())
 
@@ -137,59 +138,98 @@ export async function langchainMessageToOpenAIMessage(
     }
 
     if (removeSystemMessage) {
-        const mappedMessage: ChatCompletionResponseMessage[] = []
+        return transformSystemMessages(result)
+    }
 
-        for (let i = 0; i < mappedMessage.length; i++) {
-            const message = mappedMessage[i]
-
-            if (message.role !== 'system') {
-                mappedMessage.push(message)
-                continue
-            }
-
-            if (removeSystemMessage) {
-                continue
-            }
-
-            mappedMessage.push({
-                role: 'user',
-                content: message.content
-            })
-
-            mappedMessage.push({
-                role: 'assistant',
-                content: 'Okay, what do I need to do?'
-            })
-
-            if (mappedMessage?.[i + 1]?.role === 'assistant') {
-                mappedMessage.push({
-                    role: 'user',
-                    content:
-                        'Continue what I said to you last message. Follow these instructions.'
-                })
-            }
-        }
-
-        if (mappedMessage[mappedMessage.length - 1].role === 'assistant') {
-            mappedMessage.push({
-                role: 'user',
-                content:
-                    'Continue what I said to you last message. Follow these instructions.'
-            })
-        }
-
-        if (mappedMessage[0].role === 'assistant') {
-            mappedMessage.unshift({
-                role: 'user',
-                content:
-                    'Continue what I said to you last time. Follow these instructions.'
-            })
-        }
-
-        return mappedMessage
+    if (isDeepseekThinkModel) {
+        return processDeepSeekThinkMessages(result, messages)
     }
 
     return result
+}
+
+export function processDeepSeekThinkMessages(
+    convertedMessages: ChatCompletionResponseMessage[],
+    originalMessages: BaseMessage[]
+): ChatCompletionResponseMessage[] {
+    if (originalMessages.length === 0) {
+        return convertedMessages
+    }
+
+    // Find the last AI message without tool calls to determine the start of the last turn
+    let lastTurnStartIndex = -1
+    for (let i = originalMessages.length - 1; i >= 0; i--) {
+        const message = originalMessages[i]
+        if (message.getType() === 'ai') {
+            const aiMessage = message as AIMessage
+            // Check if it's a non-tool-call AI message
+            if (!aiMessage.tool_calls || aiMessage.tool_calls.length === 0) {
+                lastTurnStartIndex = i
+                break
+            }
+        }
+    }
+
+    // If no suitable AI message found, return messages as-is
+    if (lastTurnStartIndex === -1) {
+        return convertedMessages
+    }
+
+    // For messages in the last turn, add reasoning_content from additional_kwargs
+    return convertedMessages.map((message, index) => {
+        // Only process messages in the last turn (from lastTurnStartIndex onwards)
+        if (index >= lastTurnStartIndex) {
+            const originalMessage = originalMessages[index]
+            const reasoningContent = originalMessage?.additional_kwargs
+                ?.reasoning_content as string | undefined
+
+            if (reasoningContent) {
+                return {
+                    ...message,
+                    reasoning_content: reasoningContent
+                }
+            }
+        }
+        return message
+    })
+}
+
+export function transformSystemMessages(
+    messages: ChatCompletionResponseMessage[]
+): ChatCompletionResponseMessage[] {
+    const mappedMessage: ChatCompletionResponseMessage[] = []
+
+    for (let i = 0; i < messages.length; i++) {
+        const message = messages[i]
+
+        if (message.role !== 'system') {
+            mappedMessage.push(message)
+            continue
+        }
+
+        // Skip system messages (remove them)
+        continue
+    }
+
+    // Ensure the conversation doesn't end with an assistant message
+    if (mappedMessage[mappedMessage.length - 1]?.role === 'assistant') {
+        mappedMessage.push({
+            role: 'user',
+            content:
+                'Continue what I said to you last message. Follow these instructions.'
+        })
+    }
+
+    // Ensure the conversation doesn't start with an assistant message
+    if (mappedMessage[0]?.role === 'assistant') {
+        mappedMessage.unshift({
+            role: 'user',
+            content:
+                'Continue what I said to you last time. Follow these instructions.'
+        })
+    }
+
+    return mappedMessage
 }
 
 export async function fetchImageUrl(


### PR DESCRIPTION
This PR adds support for DeepSeek's reasoning mode and refactors message transformation utilities.

## New Features

- Add `processDeepSeekThinkMessages` function to preserve reasoning_content for DeepSeek reasoner models during multi-turn tool calling
- Support `reasoning_content` field in message transformations

## Bug Fixes

- Fix bug in `removeSystemMessage` logic that was iterating over empty array

## Other Changes

- Extract `transformSystemMessages` function for better code organization
- Optimize image service plugin detection to avoid repeated lookups
- Bump shared-adapter to v1.0.18 and update all adapter dependencies