### PR TITLE
fix: correct DeepSeek reasoning content turn detection logic

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62"
     },
     "devDependencies": {

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "1.0.19",
+        "@chatluna/v1-shared-adapter": "1.0.20",
         "@langchain/core": "0.3.62",
         "zod-to-json-schema": "3.23.5"
     },

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.19",
+        "@chatluna/v1-shared-adapter": "^1.0.20",
         "@langchain/core": "0.3.62",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -156,23 +156,20 @@ export function processDeepSeekThinkMessages(
         return convertedMessages
     }
 
-    // Find the last AI message without tool calls to determine the start of the last turn
+    // Find the start of the last turn by locating the last user message
+    // According to DeepSeek docs: a turn starts with a user message
     let lastTurnStartIndex = -1
     for (let i = originalMessages.length - 1; i >= 0; i--) {
         const message = originalMessages[i]
-        if (message.getType() === 'ai') {
-            const aiMessage = message as AIMessage
-            // Check if it's a non-tool-call AI message
-            if (!aiMessage.tool_calls || aiMessage.tool_calls.length === 0) {
-                lastTurnStartIndex = i
-                break
-            }
+        if (message.getType() === 'human') {
+            lastTurnStartIndex = i
+            break
         }
     }
 
-    // If no suitable AI message found, return messages as-is
+    // If no user message found, treat all messages as the last turn
     if (lastTurnStartIndex === -1) {
-        return convertedMessages
+        lastTurnStartIndex = 0
     }
 
     // For messages in the last turn, add reasoning_content from additional_kwargs


### PR DESCRIPTION
This PR fixes the turn detection logic in DeepSeek reasoning content processing.

## Bug Fixes

- Fixed incorrect turn detection in `processDeepSeekThinkMessages` function
- Previously identified turns by looking for AI messages without tool calls
- Now correctly identifies turns by locating the last user message, which aligns with DeepSeek's documentation that a turn starts with a user message
- Ensures reasoning content is properly extracted only from the current turn

## Changes

- Updated `packages/shared-adapter/src/utils.ts` to use user messages as turn boundaries
- Improved handling when no user message is found (treats all messages as the last turn)