### PR TITLE
[Fix] Prioritize Gemini image resolution model detection

### DIFF
--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -60,6 +60,8 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
             const models: ModelInfo[] = []
 
             for (const model of rawModels) {
+                const modelNameLower = model.name.toLowerCase()
+
                 const info = {
                     name: model.name,
                     maxTokens: model.inputTokenLimit,
@@ -80,7 +82,7 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
 
                 if (
                     imageResolutionModel.some((name) =>
-                        model.name.toLowerCase().includes(name)
+                        modelNameLower.includes(name)
                     )
                 ) {
                     models.push(
@@ -91,8 +93,8 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 } else if (
                     thinkingModel.some(
                         (name) =>
-                            model.name.toLowerCase().includes(name) &&
-                            !model.name.toLowerCase().includes('image')
+                            modelNameLower.includes(name) &&
+                            !modelNameLower.includes('image')
                     )
                 ) {
                     if (!model.name.includes('-thinking')) {
@@ -107,8 +109,8 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 } else if (
                     thinkingLevelModel.some(
                         (name) =>
-                            model.name.toLowerCase().includes(name) &&
-                            !model.name.toLowerCase().includes('image')
+                            modelNameLower.includes(name) &&
+                            !modelNameLower.includes('image')
                     )
                 ) {
                     models.push(

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -79,6 +79,16 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 const imageResolutionModel = ['gemini-3.0-pro-image']
 
                 if (
+                    imageResolutionModel.some((name) =>
+                        model.name.toLowerCase().includes(name)
+                    )
+                ) {
+                    models.push(
+                        { ...info, name: model.name + '-2K' },
+                        { ...info, name: model.name + '-4K' },
+                        info
+                    )
+                } else if (
                     thinkingModel.some(
                         (name) =>
                             model.name.toLowerCase().includes(name) &&
@@ -103,16 +113,6 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 ) {
                     models.push(
                         { ...info, name: model.name + '-low-thinking' },
-                        info
-                    )
-                } else if (
-                    imageResolutionModel.some((name) =>
-                        model.name.toLowerCase().includes(name)
-                    )
-                ) {
-                    models.push(
-                        { ...info, name: model.name + '-2K' },
-                        { ...info, name: model.name + '-4K' },
                         info
                     )
                 } else {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,7 +38,7 @@ export const inject2 = {
 export let logger: Logger
 
 export const usage = `
-## chatluna v1.3 beta
+## chatluna v1.3
 
 ChatLuna 插件交流 QQ 群：282381753 （有问题或出现 Bug 先加群问）
 

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -84,6 +84,12 @@ export interface ChatLunaModelCallOptions extends BaseChatModelCallOptions {
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     variables_hide?: Record<string, any>
+
+    /**
+     * Override request params for this request only.
+     */
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    overrideRequestParams?: Record<string, any>
 }
 
 export interface ChatLunaModelInput extends ChatLunaModelCallOptions {
@@ -138,6 +144,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             'logitBias',
             'id',
             'variables_hide',
+            'overrideRequestParams',
             'stream',
             'tools'
         ]
@@ -179,6 +186,10 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             maxTokens: options?.maxTokens ?? this._options.maxTokens,
             maxTokenLimit,
             variables: options?.['variables_hide'] ?? {},
+            overrideRequestParams:
+                options?.overrideRequestParams ??
+                this._options.overrideRequestParams ??
+                {},
             stop: options?.stop ?? this._options.stop,
             stream: options?.stream ?? this._options.stream,
             tools: options?.tools ?? this._options.tools,


### PR DESCRIPTION
This PR fixes the model detection logic for Gemini 3.0 image generation models and adds request parameter override support.

## Bug Fixes

- Fixed incorrect model variant generation for Gemini 3.0 Pro Image models by reordering condition checks
- Previously, image resolution models were being checked after thinking models, causing them to be incorrectly processed as thinking model variants
- Now image resolution check is prioritized, ensuring `-2K` and `-4K` variants are correctly created for image generation models

## Other Changes

- Added `overrideRequestParams` option to `ChatLunaModelCallOptions` for flexible per-request parameter customization