### PR TITLE
[Feature] Add Gemini 3 thinking levels and improve model detection

### DIFF
--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.11",
+    "version": "1.3.12",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -47,6 +47,12 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
     }
 
     async refreshModels(config?: RunnableConfig): Promise<ModelInfo[]> {
+        const thinkingModel = ['gemini-2.5-pro', 'gemini-2.5-flash']
+
+        const thinkingLevelModel = ['gemini-3-pro']
+
+        const imageResolutionModel = ['gemini-3-pro-image']
+
         try {
             const rawModels = await this._requester.getModels(config)
 
@@ -73,12 +79,6 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                         ModelCapabilities.ToolCall
                     ]
                 } satisfies ModelInfo
-
-                const thinkingModel = ['gemini-2.5-pro', 'gemini-2.5-flash']
-
-                const thinkingLevelModel = ['gemini-3.0-pro']
-
-                const imageResolutionModel = ['gemini-3.0-pro-image']
 
                 if (
                     imageResolutionModel.some((name) =>
@@ -115,6 +115,8 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                 ) {
                     models.push(
                         { ...info, name: model.name + '-low-thinking' },
+                        { ...info, name: model.name + '-high-thinking' },
+                        { ...info, name: model.name + '-tiny-thinking' },
                         info
                     )
                 } else {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -407,23 +407,29 @@ export function prepareModelConfig(
         thinkingBudget = 128
     }
 
-    if (model.includes('-thinking') && model.includes('gemini-3.0')) {
+    if (model.includes('gemini-3')) {
         enabledThinking = true
-        const match = model.match(/-(low|medium|high)-thinking/)
-        if (match) {
-            thinkingLevel = match[1]
-            model = model.replace(`-${match[1]}-thinking`, '')
-        } else {
-            // Default to THINKING_LEVEL_UNSPECIFIED for gemini-3.0 if no level specified
-            thinkingLevel = 'THINKING_LEVEL_UNSPECIFIED'
-            model = model.replace('-thinking', '')
-        }
         thinkingBudget = undefined
+        const match = model.match(/-(low|medium|high|tiny)-thinking/)
+
+        if (match && match[1]) {
+            model = model.replace(`-${match[1]}-thinking`, '')
+        }
+
+        if (match && match[1] !== 'tiny') {
+            thinkingLevel = match[1]
+        } else if (match[1] === 'tiny') {
+            thinkingLevel = undefined
+            thinkingBudget = 128
+        } else {
+            // Default to THINKING_LEVEL_UNSPECIFIED for gemini-3 if no level specified
+            thinkingLevel = 'THINKING_LEVEL_UNSPECIFIED'
+        }
     } else {
         thinkingLevel = undefined
     }
 
-    // Extract imageSize from model name suffix (e.g., gemini-3.0-pro-image-2K)
+    // Extract imageSize from model name suffix (e.g., gemini-3-pro-image-2K)
     const imageSizeMatch = model.match(/-(2K|4K)$/)
     if (imageSizeMatch) {
         imageSize = imageSizeMatch[1]


### PR DESCRIPTION
This PR adds support for Gemini 3 thinking level variants and improves the model detection logic in the Gemini adapter.

## New Features

- Add support for tiny-thinking, low-thinking, and high-thinking variants for Gemini 3 Pro models
- Tiny thinking mode uses budget 128 for resource-constrained scenarios
- Enhanced thinking level extraction to handle all four thinking modes

## Other Changes

- Refactor model name patterns from `gemini-3.0` to `gemini-3` for better version matching
- Move model type constant arrays outside the iteration loop for improved performance
- Bump adapter-gemini version from 1.3.11 to 1.3.12