### PR TITLE
[Fix] Disable thinking parameters for non-Gemini 3 models

### DIFF
--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.13",
+    "version": "1.3.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -442,6 +442,9 @@ export function prepareModelConfig(
         imageGeneration =
             params.model.includes('gemini-2.0-flash-exp') ||
             params.model.includes('image')
+
+        thinkingBudget = undefined
+        thinkingLevel = undefined
     }
 
     return {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -440,8 +440,7 @@ export function prepareModelConfig(
 
     if (imageGeneration) {
         imageGeneration =
-            params.model.includes('gemini-2.0-flash-exp') ||
-            params.model.includes('image')
+            model.includes('gemini-2.0-flash-exp') || model.includes('image')
 
         thinkingBudget = undefined
         thinkingLevel = undefined


### PR DESCRIPTION
This PR fixes issues with the Gemini adapter where thinking parameters were incorrectly sent to models that don't support them.

## Bug Fixes

- Disable `thinkingBudget` and `thinkingLevel` parameters for non-Gemini 3 models to prevent API errors
- Fix variable inconsistency by using `model` instead of `params.model` for image generation detection

## Other Changes

- Bump version to 1.3.15