### PR TITLE
chore(release): bump version to 1.3.5

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-dify-adapter",
     "description": "dify adapter for chatluna",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4",
+        "koishi-plugin-chatluna": "^1.3.5",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -60,7 +60,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4",
+        "koishi-plugin-chatluna": "^1.3.5",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4",
+        "koishi-plugin-chatluna": "^1.3.5",
         "koishi-plugin-chatluna-storage-service": "^0.0.11"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "resolutions": {
         "@langchain/core": "0.3.62",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.4"
+        "koishi-plugin-chatluna": "^1.3.5"
     }
 }


### PR DESCRIPTION
This PR bumps the core package version to 1.3.5 and updates all dependent packages accordingly.

## Changes

- Core package version: 1.3.4 → 1.3.5
- Dify adapter version: 1.3.0 → 1.3.1
- Updated peer dependencies in all adapter, extension, renderer, and service packages to reference ^1.3.5