### PR TITLE
fix(core): refine room resolution logic in clear_room middleware

### DIFF
--- a/packages/core/src/middlewares/room/clear_room.ts
+++ b/packages/core/src/middlewares/room/clear_room.ts
@@ -13,7 +13,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             let targetRoom = context.options.room
 
-            if (context.options.room_resolve != null) {
+            if (targetRoom == null && context.options.room_resolve != null) {
                 // 尝试完整搜索一次
 
                 const rooms = await getAllJoinedConversationRoom(


### PR DESCRIPTION
Fixes #659

### Background

When running `chatluna.room.clear` in a private chat **without specifying a room name**, the command may incorrectly return “room not found” error

even though the user already has a resolved default room

### Root Cause

The `resolve_room` middleware has already successfully resolved the default room and written it to:

```ts
context.options.room

```
However, in clear_room middleware, the following condition is used:

```ts
if (context.options.room_resolve != null) {
}
```
As long as room_resolve exists (even when name is undefined), the middleware always attempts a second room lookup.
This lookup fails and overwrites the already resolved targetRoom, resulting in a “room not found” error.


### Fix

Update the condition in `clear_room` to only re-resolve the room **when `targetRoom` is still null**.

This avoids overriding the default room already resolved by `resolve_room` and aligns the behavior with `delete_room` middleware.
