### PR TITLE
[Fix] Catch errors from after-chat hooks to avoid process crash

### DIFF
--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -59,8 +59,9 @@ export class ChatInterface {
     private async handleChatError(
         arg: ChatLunaLLMCallArg,
         wrapper: ChatLunaLLMChainWrapper | undefined,
-        error: unknown
-    ): Promise<never> {
+        error: unknown,
+        throwError = true
+    ): Promise<never | void> {
         await this.ctx.parallel(
             'chatluna/after-chat-error',
             error as unknown as Error,
@@ -70,6 +71,11 @@ export class ChatInterface {
             this,
             wrapper
         )
+
+        if (!throwError) {
+            return
+        }
+
         if (
             error instanceof ChatLunaError &&
             error.errorCode === ChatLunaErrorCode.API_UNSAFE_CONTENT
@@ -233,19 +239,7 @@ export class ChatInterface {
                 arg.session
             )
         } catch (error) {
-            logger.warn(
-                'Unhandled error in after-chat hook, ignored to keep process alive'
-            )
-            logger.warn(error)
-            await this.ctx.parallel(
-                'chatluna/after-chat-error',
-                error as unknown as Error,
-                arg.conversationId,
-                arg.message,
-                arg.variables,
-                this,
-                wrapper
-            )
+            await this.handleChatError(arg, wrapper, error, false)
         }
 
         return { message: displayResponse }

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -222,15 +222,31 @@ export class ChatInterface {
         }
 
         // Process response
-        this.ctx.parallel(
-            'chatluna/after-chat',
-            arg.conversationId,
-            arg.message,
-            displayResponse as AIMessage,
-            { ...arg.variables, chatCount: this._chatCount },
-            this,
-            arg.session
-        )
+        try {
+            await this.ctx.parallel(
+                'chatluna/after-chat',
+                arg.conversationId,
+                arg.message,
+                displayResponse as AIMessage,
+                { ...arg.variables, chatCount: this._chatCount },
+                this,
+                arg.session
+            )
+        } catch (error) {
+            logger.warn(
+                'Unhandled error in after-chat hook, ignored to keep process alive'
+            )
+            logger.warn(error)
+            await this.ctx.parallel(
+                'chatluna/after-chat-error',
+                error as unknown as Error,
+                arg.conversationId,
+                arg.message,
+                arg.variables,
+                this,
+                wrapper
+            )
+        }
 
         return { message: displayResponse }
     }

--- a/packages/core/src/middlewares/room/clear_room.ts
+++ b/packages/core/src/middlewares/room/clear_room.ts
@@ -13,7 +13,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             let targetRoom = context.options.room
 
-            if (context.options.room_resolve != null) {
+            if (targetRoom == null && context.options.room_resolve != null) {
                 // 尝试完整搜索一次
 
                 const rooms = await getAllJoinedConversationRoom(


### PR DESCRIPTION
## Summary

The `chatluna/after-chat` hook is invoked without `await` or error handling.  
Exceptions thrown inside plugin hooks can result in unhandled promise rejections,
which may cause the Node.js process to exit and trigger Koishi restarts.

## Fix

Add `.catch()` when executing the `after-chat` hook to:

- log errors
- prevent unhandled promise rejections
- isolate plugin failures from the core runtime
