### PR TITLE
[Feature] support model thinking levels and dynamic model fetching

### DIFF
--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -7,7 +7,7 @@ import {
     ModelInfo,
     ModelType
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
-import { Config } from '.'
+import { Config, logger } from '.'
 import { ClaudeRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 
@@ -32,7 +32,7 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
     }
 
     async refreshModels(): Promise<ModelInfo[]> {
-        return [
+        const fallbackModels = [
             'claude-3-5-sonnet-20240620',
             'claude-3-opus-20240229',
             'claude-3-sonnet-20240229',
@@ -46,17 +46,58 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
             'claude-opus-4-1-20250805',
             'claude-3-5-haiku-20241022',
             'claude-3-haiku-20240307'
-        ].map((model) => {
-            return {
-                name: model,
-                maxTokens: 200_000,
-                capabilities: [
-                    ModelCapabilities.ToolCall,
-                    ModelCapabilities.ImageInput
-                ],
-                type: ModelType.llm
+        ]
+
+        try {
+            // Anthropic lists newer models first; we keep the API order.
+            const modelIds: string[] = []
+            let afterId: string | undefined
+
+            // Page through /v1/models until has_more is false.
+            while (true) {
+                const resp = await this._requester.listModels({
+                    afterId,
+                    limit: 100
+                })
+
+                for (const item of resp.data ?? []) {
+                    if (item?.id) modelIds.push(item.id)
+                }
+
+                if (!resp.has_more || !resp.last_id) break
+                afterId = resp.last_id
             }
-        })
+
+            const uniqueModels = Array.from(new Set(modelIds))
+            if (uniqueModels.length > 0) {
+                return uniqueModels.map((model) => ({
+                    name: model,
+                    // Use a fixed max context length (200K) for Claude models.
+                    maxTokens: 200_000,
+                    capabilities: [
+                        ModelCapabilities.ToolCall,
+                        ModelCapabilities.ImageInput
+                    ],
+                    type: ModelType.llm
+                }))
+            }
+        } catch (e) {
+            logger.warn(
+                'Failed to fetch model list from /v1/models, falling back to the built-in list: %s',
+                (e as Error)?.message ?? String(e)
+            )
+        }
+
+        return fallbackModels.map((model) => ({
+            name: model,
+            // Use a fixed max context length (200K) for Claude models.
+            maxTokens: 200_000,
+            capabilities: [
+                ModelCapabilities.ToolCall,
+                ModelCapabilities.ImageInput
+            ],
+            type: ModelType.llm
+        }))
     }
 
     protected _createModel(model: string): ChatLunaChatModel {

--- a/packages/adapter-claude/src/requester.ts
+++ b/packages/adapter-claude/src/requester.ts
@@ -14,7 +14,11 @@ import {
 import { Context } from 'koishi'
 import { sseIterable } from 'koishi-plugin-chatluna/utils/sse'
 import { Config, logger } from '.'
-import { ClaudeDeltaResponse, ClaudeRequest } from './types'
+import {
+    ClaudeDeltaResponse,
+    ClaudeListModelsResponse,
+    ClaudeRequest
+} from './types'
 import {
     convertDeltaToMessageChunk,
     formatToolsToClaudeTools,
@@ -130,6 +134,54 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
             logger.debug(
                 `reasoning content: ${reasoningContent}. Use time: ${reasoningTime / 1000}s`
             )
+        }
+    }
+
+    async listModels(options?: {
+        afterId?: string
+        beforeId?: string
+        limit?: number
+        anthropicBeta?: string[]
+    }): Promise<ClaudeListModelsResponse> {
+        const query = new URLSearchParams()
+
+        if (options?.afterId) query.set('after_id', options.afterId)
+        if (options?.beforeId) query.set('before_id', options.beforeId)
+        if (typeof options?.limit === 'number') {
+            query.set('limit', String(options.limit))
+        }
+
+        const url = query.size > 0 ? `models?${query.toString()}` : 'models'
+
+        // "anthropic-beta" is an optional header supported by the Models API.
+        const headers =
+            Array.isArray(options?.anthropicBeta) &&
+            options.anthropicBeta.length > 0
+                ? { 'anthropic-beta': options.anthropicBeta.join(',') }
+                : undefined
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let raw: any
+        try {
+            const response = await this.get(url, headers)
+
+            raw = await response.text()
+            if (response.status !== 200) {
+                throw new Error(
+                    `Error when listing models, Status: ${response.status} ${response.statusText}, Response: ${raw}`
+                )
+            }
+
+            return JSON.parse(raw) as ClaudeListModelsResponse
+        } catch (e) {
+            const error = new Error(
+                'Error when listing models, Response: ' + JSON.stringify(raw)
+            )
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ;(error as any).stack = (e as any)?.stack
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            ;(error as any).cause = (e as any)?.cause
+            throw error
         }
     }
 

--- a/packages/adapter-claude/src/types.ts
+++ b/packages/adapter-claude/src/types.ts
@@ -100,3 +100,17 @@ export type ChatCompletionResponseMessageRoleEnum =
     | 'assistant'
     | 'user'
     | 'tool'
+
+export interface ClaudeModelInfo {
+    id: string
+    created_at: string
+    display_name: string
+    type: 'model'
+}
+
+export interface ClaudeListModelsResponse {
+    data: ClaudeModelInfo[]
+    first_id?: string
+    has_more?: boolean
+    last_id?: string
+}

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -129,7 +129,7 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
             }
 
             if (isThinkingLevel) {
-                const suffixes = model.name.includes('3-pro')
+                const suffixes = modelNameLower.includes('3-pro')
                     ? ['-low-thinking', '-high-thinking', '-minimal-thinking']
                     : [
                           '-low-thinking',

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -117,7 +117,7 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
             }
 
             if (isThinking) {
-                if (model.name.includes('-thinking')) {
+                if (modelNameLower.includes('-thinking')) {
                     models.push(baseInfo)
                 } else {
                     pushExpanded(models, baseInfo, [

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -91,13 +91,12 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
             const baseInfo = {
                 name: model.name,
                 maxTokens: model.inputTokenLimit,
-                type: model.name.includes('embedding')
+                type: modelNameLower.includes('embedding')
                     ? ModelType.embeddings
                     : ModelType.llm,
-                capabilities: [
-                    ModelCapabilities.ImageInput,
-                    ModelCapabilities.ToolCall
-                ]
+                capabilities: modelNameLower.includes('embedding')
+                    ? []
+                    : [ModelCapabilities.ImageInput, ModelCapabilities.ToolCall]
             } satisfies ModelInfo
 
             const isImageResolution = includesAny(

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -19,6 +19,7 @@ import { Config, logger } from '.'
 import { GeminiRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { RunnableConfig } from '@langchain/core/runnables'
+import { GeminiModelInfo } from './types'
 
 export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig> {
     platform = 'gemini'
@@ -48,89 +49,104 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
 
     async refreshModels(config?: RunnableConfig): Promise<ModelInfo[]> {
         const thinkingModel = ['gemini-2.5-pro', 'gemini-2.5-flash']
-
-        const thinkingLevelModel = ['gemini-3-pro']
-
+        const thinkingLevelModel = ['gemini-3-pro', 'gemini-3-flash']
         const imageResolutionModel = ['gemini-3-pro-image']
 
-        try {
-            const rawModels = await this._requester.getModels(config)
+        const includesAny = (needles: readonly string[], haystack: string) =>
+            needles.some((name) => haystack.includes(name))
 
-            if (!rawModels.length) {
+        const pushExpanded = (
+            out: ModelInfo[],
+            base: ModelInfo,
+            suffixes: readonly string[]
+        ) => {
+            for (const suffix of suffixes) {
+                out.push({ ...base, name: base.name + suffix })
+            }
+            out.push(base)
+        }
+
+        let models: ModelInfo[] = []
+        let rawModels: GeminiModelInfo[] = []
+
+        try {
+            rawModels = await this._requester.getModels(config)
+
+            if (rawModels.length === 0) {
                 throw new ChatLunaError(
                     ChatLunaErrorCode.MODEL_INIT_ERROR,
                     new Error('No model found')
                 )
             }
 
-            const models: ModelInfo[] = []
-
-            for (const model of rawModels) {
-                const modelNameLower = model.name.toLowerCase()
-
-                const info = {
-                    name: model.name,
-                    maxTokens: model.inputTokenLimit,
-                    type: model.name.includes('embedding')
-                        ? ModelType.embeddings
-                        : ModelType.llm,
-                    capabilities: [
-                        ModelCapabilities.ImageInput,
-                        ModelCapabilities.ToolCall
-                    ]
-                } satisfies ModelInfo
-
-                if (
-                    imageResolutionModel.some((name) =>
-                        modelNameLower.includes(name)
-                    )
-                ) {
-                    models.push(
-                        { ...info, name: model.name + '-2K' },
-                        { ...info, name: model.name + '-4K' },
-                        info
-                    )
-                } else if (
-                    thinkingModel.some(
-                        (name) =>
-                            modelNameLower.includes(name) &&
-                            !modelNameLower.includes('image')
-                    )
-                ) {
-                    if (!model.name.includes('-thinking')) {
-                        models.push(
-                            { ...info, name: model.name + '-non-thinking' },
-                            { ...info, name: model.name + '-thinking' },
-                            info
-                        )
-                    } else {
-                        models.push(info)
-                    }
-                } else if (
-                    thinkingLevelModel.some(
-                        (name) =>
-                            modelNameLower.includes(name) &&
-                            !modelNameLower.includes('image')
-                    )
-                ) {
-                    models.push(
-                        { ...info, name: model.name + '-low-thinking' },
-                        { ...info, name: model.name + '-high-thinking' },
-                        { ...info, name: model.name + '-tiny-thinking' },
-                        info
-                    )
-                } else {
-                    models.push(info)
-                }
-            }
-
-            return models
         } catch (e) {
             if (e instanceof ChatLunaError) {
                 throw e
             }
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_INIT_ERROR, e)
         }
+
+        for (const model of rawModels) {
+            const modelNameLower = model.name.toLowerCase()
+
+            const baseInfo = {
+                name: model.name,
+                maxTokens: model.inputTokenLimit,
+                type: model.name.includes('embedding')
+                    ? ModelType.embeddings
+                    : ModelType.llm,
+                capabilities: [
+                    ModelCapabilities.ImageInput,
+                    ModelCapabilities.ToolCall
+                ]
+            } satisfies ModelInfo
+
+            const isImageResolution = includesAny(
+                    imageResolutionModel,
+                    modelNameLower
+            )
+            const isThinking =
+                includesAny(thinkingModel, modelNameLower) &&
+                !modelNameLower.includes('image')
+            const isThinkingLevel =
+                includesAny(thinkingLevelModel, modelNameLower) &&
+                !modelNameLower.includes('image')
+
+            if (isImageResolution) {
+                pushExpanded(models, baseInfo, ['-2K', '-4K'])
+                continue
+            }
+
+            if (isThinking) {
+                if (model.name.includes('-thinking')) {
+                    models.push(baseInfo)
+                } else {
+                    pushExpanded(models, baseInfo, [
+                          '-non-thinking',
+                          '-thinking'
+                    ])
+                }
+                continue
+            }
+
+            if (isThinkingLevel) {
+                const suffixes = model.name.includes('3-pro')
+                        ? ['-low-thinking', '-high-thinking', '-minimal-thinking']
+                        : [
+                              '-low-thinking',
+                              '-high-thinking',
+                              '-minimal-thinking',
+                              '-medium-thinking'
+                          ]
+                    pushExpanded(models, baseInfo, suffixes)
+                    continue
+                }
+
+                models.push(baseInfo)
+        }
+
+        return models
+
     }
 
     protected _createModel(

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -66,7 +66,7 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
             out.push(base)
         }
 
-        let models: ModelInfo[] = []
+        const models: ModelInfo[] = []
         let rawModels: GeminiModelInfo[] = []
 
         try {
@@ -78,7 +78,6 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                     new Error('No model found')
                 )
             }
-
         } catch (e) {
             if (e instanceof ChatLunaError) {
                 throw e
@@ -102,8 +101,8 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
             } satisfies ModelInfo
 
             const isImageResolution = includesAny(
-                    imageResolutionModel,
-                    modelNameLower
+                imageResolutionModel,
+                modelNameLower
             )
             const isThinking =
                 includesAny(thinkingModel, modelNameLower) &&
@@ -122,8 +121,8 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
                     models.push(baseInfo)
                 } else {
                     pushExpanded(models, baseInfo, [
-                          '-non-thinking',
-                          '-thinking'
+                        '-non-thinking',
+                        '-thinking'
                     ])
                 }
                 continue
@@ -131,22 +130,21 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
 
             if (isThinkingLevel) {
                 const suffixes = model.name.includes('3-pro')
-                        ? ['-low-thinking', '-high-thinking', '-minimal-thinking']
-                        : [
-                              '-low-thinking',
-                              '-high-thinking',
-                              '-minimal-thinking',
-                              '-medium-thinking'
-                          ]
-                    pushExpanded(models, baseInfo, suffixes)
-                    continue
-                }
+                    ? ['-low-thinking', '-high-thinking', '-minimal-thinking']
+                    : [
+                          '-low-thinking',
+                          '-high-thinking',
+                          '-minimal-thinking',
+                          '-medium-thinking'
+                      ]
+                pushExpanded(models, baseInfo, suffixes)
+                continue
+            }
 
-                models.push(baseInfo)
+            models.push(baseInfo)
         }
 
         return models
-
     }
 
     protected _createModel(

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -415,7 +415,7 @@ export function prepareModelConfig(
         if (match && match[1]) {
             const level = match[1]
             model = model.replace(`-${level}-thinking`, '')
-            if (level === 'minimal' && model.includes("3-pro")) {
+            if (level === 'minimal' && model.includes('3-pro')) {
                 thinkingLevel = undefined
                 thinkingBudget = 128
             } else {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -410,12 +410,12 @@ export function prepareModelConfig(
     if (model.includes('gemini-3')) {
         enabledThinking = true
         thinkingBudget = undefined
-        const match = model.match(/-(low|medium|high|tiny)-thinking/)
+        const match = model.match(/-(low|medium|high|tiny|minimal)-thinking/)
 
         if (match && match[1]) {
             const level = match[1]
             model = model.replace(`-${level}-thinking`, '')
-            if (level === 'tiny') {
+            if (level === 'minimal' && model.includes("3-pro")) {
                 thinkingLevel = undefined
                 thinkingBudget = 128
             } else {

--- a/packages/adapter-zhipu/src/client.ts
+++ b/packages/adapter-zhipu/src/client.ts
@@ -74,7 +74,11 @@ export class ZhipuClient extends PlatformModelAndEmbeddingsClient<ClientConfig> 
             ['GLM-4.5-AirX', 128000],
             ['GLM-4.5-Flash', 128000],
             ['GLM-4.5V', 128000],
-            ['GLM-4.6', 200_000]
+            ['GLM-4.6V', 128000],
+            ['GLM-4.6V-FlashX', 128000],
+            ['GLM-4.6V-Flash', 128000],
+            ['GLM-4.6', 200_000],
+            ['GLM-4.7', 200_000]
             //   ['GLM-4-AllTools', 128000]
         ] as [string, number][]
 

--- a/packages/core/src/llm-core/chat/infinite_context.ts
+++ b/packages/core/src/llm-core/chat/infinite_context.ts
@@ -359,7 +359,9 @@ export class InfiniteContextManager {
         }
 
         if (Object.keys(additionalArgs).length > 0) {
-            await this.options.chatHistory.overrideAdditionalArgs(additionalArgs)
+            await this.options.chatHistory.overrideAdditionalArgs(
+                additionalArgs
+            )
         }
 
         await this.options.chatHistory.loadConversation()

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -1,6 +1,52 @@
 import { ModelInfo } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { getModelContextSize } from 'koishi-plugin-chatluna/llm-core/utils/count_tokens'
 
+export type OpenAIReasoningEffort =
+    | 'none'
+    | 'minimal'
+    | 'low'
+    | 'medium'
+    | 'high'
+    | 'xhigh'
+
+export function parseOpenAIModelNameWithReasoningEffort(modelName: string): {
+    model: string
+    reasoningEffort?: OpenAIReasoningEffort
+} {
+    let model = modelName
+    let reasoningEffort: OpenAIReasoningEffort | undefined
+
+    const explicitMatch = model.match(
+        /-(none|minimal|low|medium|high|xhigh|tiny)-thinking$/
+    )
+
+    if (explicitMatch?.[1]) {
+        const level = explicitMatch[1]
+        model = model.replace(`-${level}-thinking`, '')
+        reasoningEffort =
+            level === 'tiny' ? 'minimal' : (level as OpenAIReasoningEffort)
+        return { model, reasoningEffort }
+    }
+
+    if (model.endsWith('-non-thinking')) {
+        model = model.slice(0, -'-non-thinking'.length)
+        reasoningEffort = 'none'
+        return { model, reasoningEffort }
+    }
+
+    if (model.endsWith('-thinking')) {
+        model = model.slice(0, -'-thinking'.length)
+        reasoningEffort = 'medium'
+        return { model, reasoningEffort }
+    }
+
+    return { model }
+}
+
+export function normalizeOpenAIModelName(modelName: string): string {
+    return parseOpenAIModelNameWithReasoningEffort(modelName).model
+}
+
 export function isEmbeddingModel(modelName: string): boolean {
     return (
         modelName.includes('embed') ||
@@ -26,7 +72,7 @@ export function getModelMaxContextSize(info: ModelInfo): number {
         return maxTokens
     }
 
-    const modelName = info.name
+    const modelName = normalizeOpenAIModelName(info.name)
 
     if (
         modelName.startsWith('gpt') ||
@@ -100,6 +146,6 @@ const imageModelMatchers = [
 ].map((pattern) => createGlobMatcher(pattern))
 
 export function supportImageInput(modelName: string) {
-    const lowerModel = modelName.toLowerCase()
+    const lowerModel = normalizeOpenAIModelName(modelName).toLowerCase()
     return imageModelMatchers.some((matcher) => matcher(lowerModel))
 }

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -436,7 +436,55 @@ export async function getModels<
         data = JSON.parse(data as string)
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return data.data.map((model: any) => model.id)
+        const rawModels = data.data.map((model: any) => model.id) as string[]
+
+        const expanded: string[] = []
+        const seen = new Set<string>()
+
+        const isOpenAIReasoningModel = (model: string) => {
+            const lower = model.toLowerCase()
+            return (
+                lower.startsWith('gpt-5') ||
+                lower.startsWith('o1') ||
+                lower.startsWith('o3') ||
+                lower.startsWith('o4')
+            )
+        }
+
+        const hasThinkingTag = (model: string) => {
+            const lower = model.toLowerCase()
+            return (
+                lower.includes('thinking') ||
+                ['minimal', 'low', 'medium', 'high', 'xhigh'].some((level) =>
+                    lower.includes(level)
+                )
+            )
+        }
+
+        const push = (model: string) => {
+            if (seen.has(model)) return
+            seen.add(model)
+            expanded.push(model)
+        }
+
+        for (const model of rawModels) {
+            push(model)
+
+            if (!isOpenAIReasoningModel(model)) continue
+            if (hasThinkingTag(model)) continue
+
+            // OpenAI-style "thinking" via model suffixes. These are virtual
+            // variants that map to request params (e.g. reasoning_effort).
+            push(`${model}-non-thinking`)
+            push(`${model}`)
+            push(`${model}-minimal-thinking`)
+            push(`${model}-low-thinking`)
+            push(`${model}-medium-thinking`)
+            push(`${model}-high-thinking`)
+            push(`${model}-xhigh-thinking`)
+        }
+
+        return expanded
     } catch (e) {
         if (e instanceof ChatLunaError) {
             throw e

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -29,6 +29,7 @@ import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import { RunnableConfig } from '@langchain/core/runnables'
 import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
 import { deepAssign } from 'koishi-plugin-chatluna/utils/object'
+import { parseOpenAIModelNameWithReasoningEffort } from './client'
 
 interface RequestContext<
     T extends ClientConfig = ClientConfig,
@@ -47,12 +48,15 @@ export async function buildChatCompletionParams(
     enableGoogleSearch: boolean,
     supportImageInput?: boolean
 ) {
+    const parsedModel = parseOpenAIModelNameWithReasoningEffort(params.model)
+    const normalizedModel = parsedModel.model
+
     const base = {
-        model: params.model,
+        model: normalizedModel,
         messages: await langchainMessageToOpenAIMessage(
             params.input,
             plugin,
-            params.model,
+            normalizedModel,
             supportImageInput
         ),
         tools:
@@ -63,7 +67,7 @@ export async function buildChatCompletionParams(
                   )
                 : undefined,
         stop: params.stop || undefined,
-        max_tokens: params.model.includes('vision')
+        max_tokens: normalizedModel.includes('vision')
             ? undefined
             : params.maxTokens,
         temperature: params.temperature === 0 ? undefined : params.temperature,
@@ -74,6 +78,12 @@ export async function buildChatCompletionParams(
         n: params.n,
         top_p: params.topP,
         prompt_cache_key: params.id,
+        prompt_cache_retention: undefined,
+        prediction: undefined,
+        reasoning_effort: parsedModel.reasoningEffort,
+        response_format: undefined,
+        safety_identifier: undefined,
+        service_tier: undefined,
         stream: true,
         logit_bias: params.logitBias,
         stream_options: {
@@ -81,12 +91,14 @@ export async function buildChatCompletionParams(
         }
     }
 
-    if (
-        params.model.includes('o1') ||
-        params.model.includes('o3') ||
-        params.model.includes('o4') ||
-        params.model.includes('gpt-5')
-    ) {
+    const lowerModel = normalizedModel.toLowerCase()
+    const isOpenAIReasoningModel =
+        lowerModel.startsWith('o1') ||
+        lowerModel.startsWith('o3') ||
+        lowerModel.startsWith('o4') ||
+        lowerModel.startsWith('gpt-5')
+
+    if (isOpenAIReasoningModel) {
         delete base.temperature
         delete base.presence_penalty
         delete base.frequency_penalty

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -25,6 +25,7 @@ import {
 } from 'koishi-plugin-chatluna/utils/string'
 import { ToolCallChunk } from '@langchain/core/messages/tool'
 import { isZodSchemaV3 } from '@langchain/core/utils/types'
+import { normalizeOpenAIModelName } from './client'
 
 export async function langchainMessageToOpenAIMessage(
     messages: BaseMessage[],
@@ -35,7 +36,8 @@ export async function langchainMessageToOpenAIMessage(
 ): Promise<ChatCompletionResponseMessage[]> {
     const result: ChatCompletionResponseMessage[] = []
 
-    const isDeepseekThinkModel = model?.includes('deepseek-reasoner')
+    const normalizedModel = model ? normalizeOpenAIModelName(model) : model
+    const isDeepseekThinkModel = normalizedModel?.includes('deepseek-reasoner')
     for (const rawMessage of messages) {
         const role = messageTypeToOpenAIRole(rawMessage.getType())
 
@@ -76,7 +78,7 @@ export async function langchainMessageToOpenAIMessage(
 
         const images = rawMessage.additional_kwargs.images as string[] | null
 
-        const lowerModel = model?.toLowerCase() ?? ''
+        const lowerModel = normalizedModel?.toLowerCase() ?? ''
         if (
             (lowerModel?.includes('vision') ||
                 lowerModel?.includes('gpt-4o') ||
@@ -89,11 +91,11 @@ export async function langchainMessageToOpenAIMessage(
                 lowerModel?.includes('qwen-omni') ||
                 lowerModel?.includes('qwen2-vl') ||
                 lowerModel?.includes('qvq') ||
-                model?.includes('o1') ||
-                model?.includes('o4') ||
-                model?.includes('o3') ||
-                model?.includes('gpt-4.1') ||
-                model?.includes('gpt-5') ||
+                normalizedModel?.includes('o1') ||
+                normalizedModel?.includes('o4') ||
+                normalizedModel?.includes('o3') ||
+                normalizedModel?.includes('gpt-4.1') ||
+                normalizedModel?.includes('gpt-5') ||
                 supportImageInput) &&
             images != null
         ) {


### PR DESCRIPTION
This PR introduces support for thinking levels (reasoning effort) across multiple adapters and implements dynamic model fetching for the Claude adapter. It also expands the available model lists with virtual variants to allow users to easily select different reasoning configurations.

## New Features

- **Gemini Adapter**: 
  - Added support for thinking levels in Gemini 3 models.
  - Introduced virtual model suffixes like `-minimal-thinking`, `-low-thinking`, etc.
  - Improved model list expansion with `-2K`/`-4K` resolution variants for supported models.
- **Claude Adapter**:
  - Implemented dynamic model fetching via the Anthropic `/v1/models` API.
  - Added fallback to a built-in list if the API call fails.
- **Shared Adapter (OpenAI-compatible)**:
  - Added support for `reasoning_effort` parameter.
  - Implemented model name normalization to strip thinking suffixes before sending to the upstream API.
  - Automatically expands model lists with thinking variants for reasoning models (o1, o3, o4, gpt-5).
- **Zhipu Adapter**:
  - Added support for newer models: `GLM-4.6V`, `GLM-4.6V-Flash`, `GLM-4.7`, etc.

## Bug fixes

- Refined model capabilities detection and context size lookups to handle normalized model names.
- Fixed reasoning models (o1 series) to correctly bypass unsupported parameters like temperature and penalties.

## Other Changes

- Improved code structure and indentation in `adapter-gemini`.
- Added helper functions for model name parsing and normalization in `shared-adapter`.

Close #661