### PR TITLE
[Fix] prevent image handling for thought parts in Gemini adapter

### DIFF
--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.16",
+    "version": "1.3.17",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -579,7 +579,7 @@ export class GeminiRequester
                 }
             }
             messageContent = messagePart.text
-        } else if (imagePart && messagePart.thought !== true) {
+} else if (imagePart && !messagePart.thought) {
             const storageService = this.ctx.chatluna_storage
             if (!storageService) {
                 messagePart.text = `![image](data:${imagePart.inlineData.mimeType ?? 'image/png'};base64,${imagePart.inlineData.data})`

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -579,7 +579,7 @@ export class GeminiRequester
                 }
             }
             messageContent = messagePart.text
-        } else if (imagePart) {
+        } else if (imagePart && messagePart.thought !== true) {
             const storageService = this.ctx.chatluna_storage
             if (!storageService) {
                 messagePart.text = `![image](data:${imagePart.inlineData.mimeType ?? 'image/png'};base64,${imagePart.inlineData.data})`


### PR DESCRIPTION
This PR prevents the Gemini adapter from attempting to handle images when the message part is marked as a thought.

## New Features

None

## Bug fixes

- Prevent image handling logic from executing for thought parts in Gemini adapter.

## Other Changes

- Bumped `packages/adapter-gemini` version to `1.3.17`.