### PR TITLE
[Feature] support file message transformation for OneBot platform

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -254,7 +254,8 @@
         "@types/js-yaml": "^4.0.9",
         "@types/qrcode": "^1.5.5",
         "@types/useragent": "^2",
-        "atsc": "^2.1.0"
+        "atsc": "^2.1.0",
+        "koishi-plugin-adapter-onebot": "^6.8.0"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -1,8 +1,9 @@
-import { Context, h } from 'koishi'
+import { Context, h, Session } from 'koishi'
 import { ChainMiddlewareRunStatus, ChatChain } from '../../chains/chain'
 import { Config } from '../../config'
 import { logger } from '../../index'
 import type {} from '@initencounter/sst'
+import type { OneBotBot } from 'koishi-plugin-adapter-onebot'
 import {
     getImageType,
     getMessageContent,
@@ -221,6 +222,90 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             )
         )
     })
+
+    ctx.inject(['chatluna_storage'], (ctx) => {
+        logger.debug('chatluna_storage service loaded.')
+
+        ctx.effect(() =>
+            ctx.chatluna.messageTransformer.intercept(
+                'file',
+                async (session, element, message) => {
+                    const fileName =
+                        element.attrs['file'] ?? element.attrs['name']
+
+                    const src = element.attrs['src']
+
+                    let buffer: Awaited<ReturnType<typeof readFile>>
+
+                    if (src.startsWith('http')) {
+                        buffer = await readFile(ctx, src)
+                    } else {
+                        buffer = await readPlatformFile(ctx, session, element)
+                    }
+
+                    const file = await ctx.chatluna_storage.createTempFile(
+                        buffer.buffer,
+                        fileName
+                    )
+
+                    addMessageContent(message, `File: ${file.name} ${file.url}`)
+                }
+            )
+        )
+    })
+}
+
+async function readPlatformFile(ctx: Context, session: Session, element: h) {
+    const fileId = element.attrs['fileId']
+
+    let fileUrl: string
+
+    if (session.platform === 'onebot') {
+        const bot = session.bot as OneBotBot<Context>
+
+        if (session.isDirect) {
+            fileUrl = await bot.internal.getPrivateFileUrl(
+                session.userId,
+                fileId
+            )
+        } else {
+            fileUrl = await bot.internal.getGroupFileUrl(
+                session.guildId,
+                fileId,
+                element['busId']
+            )
+        }
+    }
+
+    return await readFile(ctx, fileUrl)
+}
+
+async function readFile(ctx: Context, url: string) {
+    try {
+        const response = await ctx.http(url, {
+            responseType: 'arraybuffer',
+            method: 'get',
+            headers: {
+                'User-Agent':
+                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36'
+            }
+        })
+
+        const buffer = Buffer.from(response.data)
+
+        const base64 = buffer.toString('base64')
+
+        return {
+            base64Source: base64,
+            buffer
+        }
+    } catch (error) {
+        logger.error(`Failed to read file from ${url}:`, error)
+        return {
+            base64Source: null,
+            buffer: null
+        }
+    }
 }
 
 async function readImage(ctx: Context, url: string) {

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -243,6 +243,13 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                         buffer = await readPlatformFile(ctx, session, element)
                     }
 
+                    if (!buffer?.buffer) {
+                        logger.warn(
+                            `Failed to read file for element: ${element.toString()}`
+                        )
+                        return
+                    }
+
                     const file = await ctx.chatluna_storage.createTempFile(
                         buffer.buffer,
                         fileName
@@ -275,6 +282,11 @@ async function readPlatformFile(ctx: Context, session: Session, element: h) {
                 element['busId']
             )
         }
+    }
+
+    if (!fileUrl) {
+        logger.warn(`Failed to get file URL for element: ${element.toString()}`)
+        return
     }
 
     return await readFile(ctx, fileUrl)


### PR DESCRIPTION
This PR introduces file message transformation support specifically for the OneBot platform, allowing the system to handle file elements in chat messages.

## New Features

- **OneBot File Support**: Implemented `readPlatformFile` to fetch file URLs from OneBot (both private and group chats).
- **File Interceptor**: Added a file interceptor to the message transformer that downloads files and stores them via `chatluna_storage`.
- **Message Content Enhancement**: Automatically appends the filename and stored URL to the chat message content.

## Bug fixes

None

## Other Changes

- Added `koishi-plugin-adapter-onebot` to `packages/core` devDependencies for type support.