### PR TITLE
[Feature] support configurable infinite context threshold and manual compression

### DIFF
--- a/packages/core/src/commands/room.ts
+++ b/packages/core/src/commands/room.ts
@@ -106,6 +106,16 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             })
         })
 
+    ctx.command('chatluna.room.compress [room:text]').action(
+        async ({ session }, room) => {
+            await chain.receiveCommand(session, 'compress_room', {
+                room_resolve: {
+                    name: room
+                }
+            })
+        }
+    )
+
     ctx.command('chatluna.room.set')
         .option('name', '-n <name:string>')
         .option('preset', '-p <preset:string>')

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -29,6 +29,7 @@ export interface Config {
     messageQueue: boolean
     messageQueueDelay: number
     infiniteContext: boolean
+    infiniteContextThreshold: number
     rawOnCensor: boolean
     autoUpdateRoomMode: 'disable' | 'all' | 'manual'
 
@@ -110,6 +111,11 @@ export const Config: Schema<Config> = Schema.intersect([
 
     Schema.object({
         infiniteContext: Schema.boolean().default(true),
+        infiniteContextThreshold: Schema.percent()
+            .min(0.5)
+            .max(0.95)
+            .step(0.01)
+            .default(0.85),
         autoDelete: Schema.boolean().default(false),
         autoDeleteTimeout: Schema.number()
             .default((Time.day * 10) / Time.second)

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -406,6 +406,21 @@ export class ChatInterface {
         await this._chain?.value?.model.clearContext(this._input.conversationId)
     }
 
+    async compressContext(): Promise<boolean> {
+        const wrapper = await this.getChatLunaLLMChainWrapper()
+        if (!wrapper) {
+            return false
+        }
+
+        const manager = this._ensureInfiniteContextManager()
+        if (!manager) {
+            return false
+        }
+
+        await manager.compressIfNeeded(wrapper)
+        return true
+    }
+
     private async _initEmbeddings(service: PlatformService) {
         const [platform, modelName] = parseRawModelName(this._input.embeddings)
 
@@ -527,7 +542,8 @@ export class ChatInterface {
             this._infiniteContextManager = new InfiniteContextManager({
                 chatHistory: this._chatHistory,
                 conversationId: this._input.conversationId,
-                preset: this._input.preset
+                preset: this._input.preset,
+                threshold: this.ctx.chatluna.config.infiniteContextThreshold
             })
         }
 

--- a/packages/core/src/llm-core/chat/infinite_context.ts
+++ b/packages/core/src/llm-core/chat/infinite_context.ts
@@ -18,6 +18,7 @@ export interface InfiniteContextManagerOptions {
     chatHistory: KoishiChatMessageHistory
     conversationId: string
     preset?: ComputedRef<PresetTemplate>
+    threshold?: number
 }
 
 export class InfiniteContextManager {
@@ -61,7 +62,9 @@ export class InfiniteContextManager {
             stats.reduce((sum, current) => sum + current.tokens, 0)
         )
 
-        const threshold = Math.floor(maxTokenLimit * 0.85)
+        const threshold = Math.floor(
+            maxTokenLimit * (this.options.threshold ?? 0.85)
+        )
 
         const stats = await this._calculateMessageTokenStats(model, messages)
         const totalTokens =

--- a/packages/core/src/locales/en-US.schema.yml
+++ b/packages/core/src/locales/en-US.schema.yml
@@ -40,6 +40,7 @@ $inner:
 
     - $desc: History Management
       infiniteContext: Enable automatic Infinite Context compression when history nears the model limit. Preserves critical topics and instructions while discarding noise.
+      infiniteContextThreshold: Set the threshold (percentage) for triggering Infinite Context compression. Compression will be triggered when the token count of conversation history reaches this percentage of the model's context limit.
       autoDelete: Enable automatic deletion of inactive rooms.
       autoDeleteTimeout: Set inactivity threshold for room deletion (seconds).
 

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -103,6 +103,14 @@ commands:
                 messages:
                     success: 'Chat history cleared for room {0}.'
                     no-room: 'Room not found.'
+            compress:
+                description: 'Manually compress room chat history using Infinite Context.'
+                arguments:
+                    room: 'Target room'
+                messages:
+                    success: 'Chat history for room {0} has been compressed.'
+                    no_room: 'Room not found.'
+                    failed: 'Failed to compress chat history for room {0}: {1}'
             set:
                 description: 'Set room properties.'
                 options:

--- a/packages/core/src/locales/zh-CN.schema.yml
+++ b/packages/core/src/locales/zh-CN.schema.yml
@@ -40,6 +40,7 @@ $inner:
 
     - $desc: 历史记录选项
       infiniteContext: 启用「无限上下文」，当对话接近模型的上下文上限时自动压缩旧消息，保留关键话题和指令并丢弃无关内容。
+      infiniteContextThreshold: 设置无限上下文的触发阈值（百分比）。当对话历史的 token 数量达到模型上下文上限的该百分比时，将触发压缩。
       autoDelete: 是否自动删除长期未使用的房间。
       autoDeleteTimeout: 设置自动删除未使用房间的时间阈值（单位：秒）。
 

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -103,6 +103,14 @@ commands:
                 messages:
                     success: '已清除房间 {0} 的聊天记录。'
                     no-room: '未找到指定的房间。'
+            compress:
+                description: '手动压缩房间的聊天记录（使用无限上下文）。'
+                arguments:
+                    room: '目标房间。'
+                messages:
+                    success: '已压缩房间 {0} 的聊天记录。'
+                    no_room: '未找到指定的房间。'
+                    failed: '压缩房间 {0} 的聊天记录失败：{1}'
             set:
                 description: '设置房间的属性。'
                 options:

--- a/packages/core/src/middleware.ts
+++ b/packages/core/src/middleware.ts
@@ -39,6 +39,7 @@ import { apply as list_all_preset } from './middlewares/preset/list_all_preset'
 import { apply as set_preset } from './middlewares/preset/set_preset'
 import { apply as check_room } from './middlewares/room/check_room'
 import { apply as clear_room } from './middlewares/room/clear_room'
+import { apply as compress_room } from './middlewares/room/compress_room'
 import { apply as create_room } from './middlewares/room/create_room'
 import { apply as delete_room } from './middlewares/room/delete_room'
 import { apply as invite_room } from './middlewares/room/invite_room'
@@ -106,6 +107,7 @@ export async function middleware(ctx: Context, config: Config) {
             set_preset,
             check_room,
             clear_room,
+            compress_room,
             create_room,
             delete_room,
             invite_room,

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -255,6 +255,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                         fileName
                     )
 
+                    element.attrs['chatluna_file_url'] = file.url
+
                     addMessageContent(message, `File: ${file.name} ${file.url}`)
                 }
             )

--- a/packages/core/src/middlewares/room/compress_room.ts
+++ b/packages/core/src/middlewares/room/compress_room.ts
@@ -1,0 +1,62 @@
+import { Context } from 'koishi'
+import { Config } from '../../config'
+import { ChainMiddlewareRunStatus, ChatChain } from '../../chains/chain'
+import { getAllJoinedConversationRoom } from '../../chains/rooms'
+
+export function apply(ctx: Context, config: Config, chain: ChatChain) {
+    chain
+        .middleware('compress_room', async (session, context) => {
+            const { command } = context
+
+            if (command !== 'compress_room')
+                return ChainMiddlewareRunStatus.SKIPPED
+
+            let targetRoom = context.options.room
+
+            if (targetRoom == null && context.options.room_resolve != null) {
+                // 尝试完整搜索一次
+
+                const rooms = await getAllJoinedConversationRoom(
+                    ctx,
+                    session,
+                    true
+                )
+
+                const roomId = parseInt(context.options.room_resolve?.name)
+
+                targetRoom = rooms.find(
+                    (room) =>
+                        room.roomName === context.options.room_resolve?.name ||
+                        room.roomId === roomId
+                )
+            }
+
+            if (targetRoom == null) {
+                context.message = session.text('.no_room')
+                return ChainMiddlewareRunStatus.STOP
+            }
+
+            try {
+                await ctx.chatluna.compressContext(targetRoom)
+                context.message = session.text('.success', [
+                    targetRoom.roomName
+                ])
+            } catch (error) {
+                ctx.logger.error(error)
+                context.message = session.text('.failed', [
+                    targetRoom.roomName,
+                    error.message
+                ])
+            }
+
+            return ChainMiddlewareRunStatus.STOP
+        })
+        .after('lifecycle-handle_command')
+        .before('lifecycle-request_model')
+}
+
+declare module '../../chains/chain' {
+    interface ChainMiddlewareName {
+        compress_room: never
+    }
+}

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -989,17 +989,48 @@ class ChatInterfaceWrapper {
     }
 
     async compressContext(room: ConversationRoom) {
-        const { conversationId } = room
+        const { conversationId, model: fullModelName } = room
         const requestId = randomUUID()
+        const modelRequestId = randomUUID()
+
+        const [platform] = parseRawModelName(fullModelName)
+        const client = await this._platformService.getClient(platform)
+
+        if (client.value == null) {
+            await this._service.awaitLoadPlatform(platform)
+        }
+
+        if (client.value == null) {
+            throw new ChatLunaError(
+                ChatLunaErrorCode.UNKNOWN_ERROR,
+                new Error(`Platform ${platform} is not available`)
+            )
+        }
+
+        const config = client.value.configPool.getConfig(true).value
 
         try {
-            await this._conversationQueue.add(conversationId, requestId)
-            await this._conversationQueue.wait(conversationId, requestId, 0)
+            await Promise.all([
+                this._conversationQueue.add(conversationId, requestId),
+                this._modelQueue.add(platform, modelRequestId)
+            ])
+
+            await Promise.all([
+                this._conversationQueue.wait(conversationId, requestId, 0),
+                this._modelQueue.wait(
+                    platform,
+                    modelRequestId,
+                    config.concurrentMaxSize
+                )
+            ])
 
             const chatInterface = await this.query(room, true)
             return await chatInterface.compressContext()
         } finally {
-            await this._conversationQueue.remove(conversationId, requestId)
+            await Promise.all([
+                this._conversationQueue.remove(conversationId, requestId),
+                this._modelQueue.remove(platform, modelRequestId)
+            ])
         }
     }
 

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -234,6 +234,13 @@ export class ChatLunaService extends Service {
         return chatBridger.clearChatHistory(room)
     }
 
+    async compressContext(room: ConversationRoom) {
+        const chatBridger =
+            this._chatInterfaceWrapper ?? this._createChatInterfaceWrapper()
+
+        return chatBridger.compressContext(room)
+    }
+
     getCachedInterfaceWrapper() {
         return this._chatInterfaceWrapper
     }
@@ -977,6 +984,21 @@ class ChatInterfaceWrapper {
             await chatInterface.clearChatHistory()
         } finally {
             this._conversations.delete(conversationId)
+            await this._conversationQueue.remove(conversationId, requestId)
+        }
+    }
+
+    async compressContext(room: ConversationRoom) {
+        const { conversationId } = room
+        const requestId = randomUUID()
+
+        try {
+            await this._conversationQueue.add(conversationId, requestId)
+            await this._conversationQueue.wait(conversationId, requestId, 0)
+
+            const chatInterface = await this.query(room, true)
+            return await chatInterface.compressContext()
+        } finally {
             await this._conversationQueue.remove(conversationId, requestId)
         }
     }


### PR DESCRIPTION
This pr introduces configurable thresholds for Infinite Context compression and adds a manual compression command to the room management.

## New Features

- **Configurable Infinite Context Threshold**: Users can now set the `infiniteContextThreshold` in configuration (range: 50% - 95%, default 85%) to control when history compression is triggered.
- **Manual Compression Command**: Added `chatluna.room.compress` command to manually trigger context compression for a specified room.
- **Improved File Message Handling**: Enhanced `read_chat_message` to preserve and include file URLs in message attributes.

## Bug fixes

N/A

## Other Changes

- Updated `InfiniteContextManager` to honor the configurable threshold.
- Added i18n support (zh-CN, en-US) for the new configuration setting and the compress command.
- Integrated the new `compress_room` middleware into the core middleware stack.