### PR TITLE
woc这次应该对了宝宝

### DIFF
--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -702,6 +702,7 @@ commands:
                     success: 'Default set to {0}. Restarting plugin to apply.'
 
 chatluna:
+    quote_said: 'said'
     aborted: 'Current conversation generation stopped successfully.'
     thinking_message: 'Processing... {0} messages in queue. Please wait.'
     block_message: ''

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -703,6 +703,7 @@ commands:
                     success: '已将默认向量数据库设置为 {0}，(将自动重启插件应用更改)'
 
 chatluna:
+    quote_said: '说'
     aborted: '已成功停止当前对话的生成。'
     thinking_message: '我还在思考中，前面还有 {0} 条消息等着我回复呢，稍等一下~'
     block_message: ''

--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -90,6 +90,21 @@ export class MessageTransformer {
                 extractImages(message.content).length > 0 ||
                 quoteImages.length > 0
 
+            // 构建引用消息的完整格式：时间 + 发言人 + 内容
+            const quoteUsername =
+                session.quote.user?.name || session.quote.user?.id || 'Unknown'
+            const quoteTimestamp = session.quote.timestamp
+                ? new Date(session.quote.timestamp).toLocaleString('zh-CN', {
+                      year: 'numeric',
+                      month: '2-digit',
+                      day: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                      second: '2-digit',
+                      hour12: false
+                  })
+                : ''
+
             if (hasImages) {
                 if (typeof message.content === 'string') {
                     message.content =
@@ -100,7 +115,7 @@ export class MessageTransformer {
 
                 if (quoteText && quoteText !== '[image]') {
                     const currentText = extractText(message.content)
-                    const quotedContent = `Referenced message: "${quoteText}"\n\nUser's message: ${currentText}`
+                    const quotedContent = `Referenced message: [${quoteTimestamp} ${quoteUsername} 说："${quoteText}"]\n\nUser's message: ${currentText}`
 
                     message.content = message.content.filter(
                         (item) => item.type !== 'text'
@@ -114,7 +129,7 @@ export class MessageTransformer {
                 message.content = [...quoteImages, ...message.content]
             } else if (quoteText && quoteText !== '[image]') {
                 const currentText = extractText(message.content)
-                message.content = `Referenced message: "${quoteText}"\n\nUser's message: ${currentText}`
+                message.content = `Referenced message: [${quoteTimestamp} ${quoteUsername} 说："${quoteText}"]\n\nUser's message: ${currentText}`
             }
         }
 

--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -104,6 +104,10 @@ export class MessageTransformer {
                       hour12: false
                   })
                 : ''
+            const quoteSaid = session.text('chatluna.quote_said')
+            const quoteHeader = quoteTimestamp
+                ? `${quoteTimestamp} ${quoteUsername}`
+                : quoteUsername
 
             if (hasImages) {
                 if (typeof message.content === 'string') {
@@ -115,7 +119,7 @@ export class MessageTransformer {
 
                 if (quoteText && quoteText !== '[image]') {
                     const currentText = extractText(message.content)
-                    const quotedContent = `Referenced message: [${quoteTimestamp} ${quoteUsername} 说："${quoteText}"]\n\nUser's message: ${currentText}`
+                    const quotedContent = `Referenced message: [${quoteHeader} ${quoteSaid}："${quoteText}"]\n\nUser's message: ${currentText}`
 
                     message.content = message.content.filter(
                         (item) => item.type !== 'text'
@@ -129,7 +133,7 @@ export class MessageTransformer {
                 message.content = [...quoteImages, ...message.content]
             } else if (quoteText && quoteText !== '[image]') {
                 const currentText = extractText(message.content)
-                message.content = `Referenced message: [${quoteTimestamp} ${quoteUsername} 说："${quoteText}"]\n\nUser's message: ${currentText}`
+                message.content = `Referenced message: [${quoteHeader} ${quoteSaid}："${quoteText}"]\n\nUser's message: ${currentText}`
             }
         }
 


### PR DESCRIPTION
feat: 增强引用消息格式，添加时间和发言人信息
## 改动内容

增强了 `includeQuoteReply` 功能，在引用消息被拼接到大模型请求中时，添加更丰富的上下文信息。

### 变更前
Referenced message: "引用的消息内容"

User's message: 用户的消息内容

### 变更后
Referenced message: [2026/01/03 14:30:25 用户名 说："引用的消息内容"]

User's message: 用户的消息内容

## 改进点

- 添加引用消息的发送时间戳（格式：YYYY/MM/DD HH:mm:ss）
- 添加引用消息的发言人信息（用户名或 ID）
- 为大模型提供更完整的对话上下文，有助于模型更好地理解引用关系

## 影响范围

- `packages/core/src/services/message_transform.ts`