### PR TITLE
[Fix] move '无' option to top of model/vector store selection lists

### DIFF
--- a/packages/core/src/utils/schema.ts
+++ b/packages/core/src/utils/schema.ts
@@ -134,9 +134,10 @@ function getModelNames(
     const models = service.listAllModels(type)
 
     return computed(() =>
-        models.value
-            .map((model) => model.platform + '/' + model.name)
-            .concat('无')
+        ['无']
+            .concat(
+                models.value.map((model) => model.platform + '/' + model.name)
+            )
             .map((model) => Schema.const(model).description(model))
     )
 }
@@ -145,8 +146,8 @@ function getVectorStores(ctx: Context, service: PlatformService) {
     const vectorStoreNamesRef = service.vectorStores
 
     return computed(() =>
-        vectorStoreNamesRef.value
-            .concat('无')
+        ['无']
+            .concat(vectorStoreNamesRef.value)
             .map((name) => Schema.const(name).description(name))
     )
 }


### PR DESCRIPTION
This PR improves the UX of model and vector store selection dropdowns by moving the '无' (none) option to the top of the list.

## Bug fixes

- Fixed the position of '无' option in model selection dropdown - now appears first instead of last
- Fixed the position of '无' option in vector store selection dropdown - now appears first instead of last