### PR TITLE
[Fix] Change default thinking level to high for Gemini models

### DIFF
--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.18",
+  "version": "1.3.19",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -422,7 +422,7 @@ export function prepareModelConfig(
                 thinkingLevel = level
             }
         } else {
-            // Default to THINKING_LEVEL_UNSPECIFIED for gemini-3 if no level specified
+            // Default to 'high' thinking level for gemini-3 if no level specified
             thinkingLevel = 'high'
         }
     } else {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -391,7 +391,7 @@ export function prepareModelConfig(
 ) {
     let model = params.model
     let enabledThinking: boolean | undefined = null
-    let thinkingLevel: string = 'THINKING_LEVEL_UNSPECIFIED'
+    let thinkingLevel: string = 'high'
     let imageSize: string | undefined
 
     if (model.includes('-thinking') && model.includes('gemini-2.5')) {
@@ -423,7 +423,7 @@ export function prepareModelConfig(
             }
         } else {
             // Default to THINKING_LEVEL_UNSPECIFIED for gemini-3 if no level specified
-            thinkingLevel = 'THINKING_LEVEL_UNSPECIFIED'
+            thinkingLevel = 'high'
         }
     } else {
         thinkingLevel = undefined


### PR DESCRIPTION
This PR fixes the default thinking level configuration for Gemini 2.5/3 thinking models.

## Bug fixes

- Changed default `thinkingLevel` from `THINKING_LEVEL_UNSPECIFIED` to `high` for better reasoning output in Gemini thinking models

## Other Changes

- Bump adapter-gemini version to 1.3.19