### PR TITLE
refactor(core): extract inline token rendering logic

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.11",
+  "version": "1.3.12",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/utils/koishi.ts
+++ b/packages/core/src/utils/koishi.ts
@@ -28,47 +28,7 @@ export function forkScopeToDisposable(scope: ForkScope): PromiseLikeDisposable {
 
 const tagRegExp = /<(\/?)([^!\s>/]+)([^>]*?)\s*(\/?)>/
 
-function renderToken(token: Token, platform?: string): h | h[] {
-    let children: h[] = []
-    if (token['tokens'] && token['tokens'].length > 0) {
-        children = render(token['tokens'], platform)
-    }
-
-    if (token.type === 'list' && platform === 'discord') {
-        return h(token.ordered ? 'ol' : 'ul', render(token.items, platform))
-    }
-
-    if (children.length > 0) {
-        if (token.type === 'paragraph') {
-            return h('p', children)
-        } else if (token.type === 'em') {
-            return h('em', children)
-        } else if (token.type === 'strong') {
-            return h('strong', children)
-        } else if (token.type === 'del') {
-            return h('del', children)
-        } else if (token.type === 'link') {
-            return h('a', { href: token.href }, children)
-        } else if (token.type === 'list_item') {
-            if (!token.loose) {
-                children = render(
-                    token.tokens[0]?.['tokens'] ?? token.tokens,
-                    platform
-                )
-            }
-
-            children = token.loose ? [h('p', children)] : children
-
-            if (platform === 'discord') {
-                return h('li', children)
-            }
-
-            return children
-        }
-
-        return children
-    }
-
+function renderInlineToken(token: Token, platform?: string): h | undefined {
     if (token.type === 'code') {
         return h(
             platform === 'discord' || platform === 'telegram'
@@ -101,6 +61,54 @@ function renderToken(token: Token, platform?: string): h | h[] {
             const src = cap[3].match(/src="([^"]+)"/)
             if (src) return h.image(src[1])
         }
+    }
+}
+
+function renderToken(token: Token, platform?: string): h | h[] {
+    let children: h[] = []
+    if (token['tokens'] && token['tokens'].length > 0) {
+        children = render(token['tokens'], platform)
+    }
+
+    if (token.type === 'list' && platform === 'discord') {
+        return h(token.ordered ? 'ol' : 'ul', render(token.items, platform))
+    }
+
+    if (children.length > 0) {
+        if (token.type === 'paragraph') {
+            return h('p', children)
+        } else if (token.type === 'em') {
+            return h('em', children)
+        } else if (token.type === 'strong') {
+            return h('strong', children)
+        } else if (token.type === 'del') {
+            return h('del', children)
+        } else if (token.type === 'link') {
+            return h('a', { href: token.href }, children)
+        } else if (token.type !== 'list_item') {
+            return children
+        } else if (token.type === 'list_item') {
+            if (!token.loose) {
+                children = render(
+                    token.tokens[0]?.['tokens'] ?? token.tokens,
+                    platform
+                )
+            }
+
+            children = token.loose ? [h('p', children)] : children
+
+            if (platform === 'discord') {
+                return h('li', children)
+            }
+
+            return children
+        }
+
+        const inlineToken = renderInlineToken(token, platform)
+        if (inlineToken) return inlineToken
+    } else {
+        const inlineToken = renderInlineToken(token, platform)
+        if (inlineToken) return inlineToken
     }
 
     return h('text', { content: token.raw })


### PR DESCRIPTION
## Summary

This PR refactors the markdown token rendering logic by extracting inline token rendering into a separate `renderInlineToken` function. This improves code organization and reduces duplication in the main `renderToken` function.

## Other Changes

- Extracted inline token handling (code, codespan, image, blockquote, text, html) into `renderInlineToken` function
- Consolidated token type checks for better maintainability
- No functional changes to rendering behavior