### PR TITLE
fix(adapters): handle image fetch failures gracefully

### DIFF
--- a/packages/adapter-claude/src/utils.ts
+++ b/packages/adapter-claude/src/utils.ts
@@ -153,11 +153,12 @@ async function processImageContent(
     try {
         url = await fetchImageUrl(plugin, message)
     } catch (e) {
-        url =
+        const rawUrl =
             typeof message.image_url === 'string'
                 ? message.image_url
                 : message.image_url.url
-        logger.warn(`Failed to fetch image url: ${url}`, e)
+        logger.warn(`Failed to fetch image url: ${rawUrl}`, e)
+        return null
     }
 
     const mineType = url.match(/^data:([^;]+);base64,/)?.[1] ?? 'image/jpeg'
@@ -177,7 +178,7 @@ async function processMessageContent(
     plugin: ChatLunaPlugin,
     content: MessageContentComplex[]
 ) {
-    return Promise.all(
+    const mappedContent = await Promise.all(
         content.map(async (message) => {
             if (message.type === 'text') {
                 return {
@@ -190,6 +191,8 @@ async function processMessageContent(
             }
         })
     )
+
+    return mappedContent.filter((message) => message != null)
 }
 
 export function messageTypeToClaudeRole(

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -219,11 +219,12 @@ async function processGeminiImageContent(
     try {
         url = await fetchImageUrl(plugin, part)
     } catch (e) {
-        url =
+        const rawUrl =
             typeof part.image_url === 'string'
                 ? part.image_url
                 : part.image_url.url
-        logger.warn(`Failed to fetch image url: ${url}`, e)
+        logger.warn(`Failed to fetch image url: ${rawUrl}`, e)
+        return null
     }
 
     const mineType = url.match(/^data:([^;]+);base64,/)?.[1] ?? 'image/jpeg'
@@ -239,7 +240,7 @@ async function processGeminiContentParts(
     content: MessageContentComplex[],
     thoughtData: Record<string, any>
 ) {
-    return Promise.all(
+    const mappedParts = await Promise.all(
         content.map(async (part) => {
             if (isMessageContentText(part)) {
                 return { text: part.text, ...thoughtData }
@@ -250,6 +251,8 @@ async function processGeminiContentParts(
             return part as any
         })
     )
+
+    return mappedParts.filter((part) => part != null)
 }
 
 export function partAsType<T extends ChatPart>(part: ChatPart): T {

--- a/packages/adapter-hunyuan/src/requester.ts
+++ b/packages/adapter-hunyuan/src/requester.ts
@@ -52,8 +52,9 @@ export class HunyuanRequester
                 'chat/completions',
                 {
                     model: params.model,
-                    messages: langchainMessageToHunyuanMessage(
+                    messages: await langchainMessageToHunyuanMessage(
                         params.input,
+                        this._plugin,
                         params.model
                     ),
                     tools:

--- a/packages/adapter-hunyuan/src/utils.ts
+++ b/packages/adapter-hunyuan/src/utils.ts
@@ -4,6 +4,7 @@ import {
     ChatMessageChunk,
     FunctionMessageChunk,
     HumanMessageChunk,
+    MessageContentImageUrl,
     MessageType,
     SystemMessageChunk,
     ToolMessage,
@@ -16,8 +17,12 @@ import {
     ChatCompletionResponseMessageRoleEnum,
     ChatCompletionTool
 } from './types'
-import { removeAdditionalProperties } from '@chatluna/v1-shared-adapter'
+import {
+    fetchImageUrl,
+    removeAdditionalProperties
+} from '@chatluna/v1-shared-adapter'
 import { isZodSchemaV3 } from '@langchain/core/utils/types'
+import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 
 export function formatToolsToHunyuanTools(
     tools: StructuredTool[]
@@ -51,10 +56,11 @@ export function formatToolToHunyuanTool(
     }
 }
 
-export function langchainMessageToHunyuanMessage(
+export async function langchainMessageToHunyuanMessage(
     messages: BaseMessage[],
+    plugin: ChatLunaPlugin,
     model: string
-): ChatCompletionResponseMessage[] {
+): Promise<ChatCompletionResponseMessage[]> {
     const mappedMessage: ChatCompletionResponseMessage[] = []
 
     for (const rawMessage of messages) {
@@ -102,15 +108,32 @@ export function langchainMessageToHunyuanMessage(
                 }
             ]
 
-            for (const image of images) {
-                msg.content.push({
-                    type: 'image_url',
-                    image_url: {
-                        url: image,
-                        detail: 'low'
+            const imageContents = await Promise.all(
+                images.map(async (image) => {
+                    try {
+                        const url = await fetchImageUrl(plugin, {
+                            type: 'image_url',
+                            image_url: { url: image }
+                        } as MessageContentImageUrl)
+                        return {
+                            type: 'image_url',
+                            image_url: {
+                                url,
+                                detail: 'low'
+                            }
+                        } as const
+                    } catch {
+                        return null
                     }
                 })
-            }
+            )
+
+            msg.content.push(
+                ...imageContents.filter(
+                    (content): content is MessageContentImageUrl =>
+                        content != null
+                )
+            )
         }
 
         mappedMessage.push(msg)

--- a/packages/adapter-ollama/src/utils.ts
+++ b/packages/adapter-ollama/src/utils.ts
@@ -43,7 +43,9 @@ export async function langchainMessageToOllamaMessage(
             const result = {
                 role: messageTypeToOllamaRole(rawMessage.getType()),
                 content: getMessageContent(rawMessage.content),
-                images
+                images: images?.filter(
+                    (image): image is string => image != null
+                )
             }
 
             if (result.images == null) {
@@ -110,11 +112,12 @@ async function processOllamaImageContent(
     try {
         url = await fetchImageUrl(plugin, part)
     } catch (e) {
-        url =
+        const rawUrl =
             typeof part.image_url === 'string'
                 ? part.image_url
                 : part.image_url.url
-        logger.warn(`Failed to fetch image url: ${url}`, e)
+        logger.warn(`Failed to fetch image url: ${rawUrl}`, e)
+        return null
     }
 
     return url

--- a/packages/adapter-qwen/src/utils.ts
+++ b/packages/adapter-qwen/src/utils.ts
@@ -5,6 +5,7 @@ import {
     ChatMessageChunk,
     FunctionMessageChunk,
     HumanMessageChunk,
+    MessageContentImageUrl,
     MessageType,
     SystemMessageChunk,
     ToolMessage,
@@ -130,17 +131,34 @@ export async function langchainMessageToQWenMessage(
                 }
             ]
 
-            for (const image of images) {
-                msg.content.push({
-                    type: 'image_url',
-                    image_url: {
-                        url: image,
-                        detail: 'low'
+            const imageContents = await Promise.all(
+                images.map(async (image) => {
+                    try {
+                        const url = await fetchImageUrl(plugin, {
+                            type: 'image_url',
+                            image_url: { url: image }
+                        } as MessageContentImageUrl)
+                        return {
+                            type: 'image_url',
+                            image_url: {
+                                url,
+                                detail: 'low'
+                            }
+                        } as const
+                    } catch {
+                        return null
                     }
                 })
-            }
+            )
+
+            msg.content.push(
+                ...imageContents.filter(
+                    (content): content is MessageContentImageUrl =>
+                        content != null
+                )
+            )
         } else if (Array.isArray(msg.content) && msg.content.length > 0) {
-            msg.content = await Promise.all(
+            const mappedContent = await Promise.all(
                 msg.content.map(async (content) => {
                     if (!isMessageContentImageUrl(content)) return content
 
@@ -154,10 +172,12 @@ export async function langchainMessageToQWenMessage(
                             }
                         } as const
                     } catch {
-                        return content
+                        return null
                     }
                 })
             )
+
+            msg.content = mappedContent.filter((content) => content != null)
         }
 
         result.push(msg)

--- a/packages/adapter-zhipu/src/utils.ts
+++ b/packages/adapter-zhipu/src/utils.ts
@@ -5,6 +5,7 @@ import {
     ChatMessageChunk,
     FunctionMessageChunk,
     HumanMessageChunk,
+    MessageContentImageUrl,
     MessageType,
     SystemMessageChunk,
     ToolMessage,
@@ -71,17 +72,34 @@ export async function langchainMessageToZhipuMessage(
             ]
 
             // base 64??
-            for (const image of images) {
-                msg.content.push({
-                    type: 'image_url',
-                    image_url: {
-                        url: image
-                        // detail: 'low'
+            const imageContents = await Promise.all(
+                images.map(async (image) => {
+                    try {
+                        const url = await fetchImageUrl(plugin, {
+                            type: 'image_url',
+                            image_url: { url: image }
+                        } as MessageContentImageUrl)
+                        return {
+                            type: 'image_url',
+                            image_url: {
+                                url
+                                // detail: 'low'
+                            }
+                        } as const
+                    } catch {
+                        return null
                     }
                 })
-            }
+            )
+
+            msg.content.push(
+                ...imageContents.filter(
+                    (content): content is MessageContentImageUrl =>
+                        content != null
+                )
+            )
         } else if (Array.isArray(msg.content) && msg.content.length > 0) {
-            msg.content = await Promise.all(
+            const mappedContent = await Promise.all(
                 msg.content.map(async (content) => {
                     if (!isMessageContentImageUrl(content)) return content
 
@@ -95,10 +113,12 @@ export async function langchainMessageToZhipuMessage(
                             }
                         } as const
                     } catch {
-                        return content
+                        return null
                     }
                 })
             )
+
+            msg.content = mappedContent.filter((content) => content != null)
         } else if (model.includes('tools')) {
             msg.content = [
                 {

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -106,17 +106,34 @@ export async function langchainMessageToOpenAIMessage(
                 }
             ]
 
-            for (const image of images) {
-                msg.content.push({
-                    type: 'image_url',
-                    image_url: {
-                        url: image,
-                        detail: 'low'
+            const imageContents = await Promise.all(
+                images.map(async (image) => {
+                    try {
+                        const url = await fetchImageUrl(plugin, {
+                            type: 'image_url',
+                            image_url: { url: image }
+                        } as MessageContentImageUrl)
+                        return {
+                            type: 'image_url',
+                            image_url: {
+                                url,
+                                detail: 'low'
+                            }
+                        } as const
+                    } catch {
+                        return null
                     }
                 })
-            }
+            )
+
+            msg.content.push(
+                ...imageContents.filter(
+                    (content): content is MessageContentImageUrl =>
+                        content != null
+                )
+            )
         } else if (Array.isArray(msg.content) && msg.content.length > 0) {
-            msg.content = await Promise.all(
+            const mappedContent = await Promise.all(
                 msg.content.map(async (content) => {
                     if (!isMessageContentImageUrl(content)) return content
 
@@ -130,10 +147,12 @@ export async function langchainMessageToOpenAIMessage(
                             }
                         }
                     } catch {
-                        return content
+                        return null
                     }
                 })
             )
+
+            msg.content = mappedContent.filter((content) => content != null)
         }
 
         result.push(msg)


### PR DESCRIPTION
## Summary

This PR improves error handling across all adapters when image fetching fails, ensuring that broken or inaccessible image URLs don't break message processing.

## Bug fixes

- **Image fetch failures no longer break message processing**: Returns null from image processing functions when fetch errors occur
- **Graceful degradation**: Failed image content entries are filtered out, allowing chats to continue with text content
- **Consistent error handling**: Added try-catch blocks around image URL fetching in Claude, Gemini, Ollama, Qwen, and Zhipu adapters
- **Hunyuan async handling**: Converted langchainMessageToHunyuanMessage to async to properly handle image processing

## Other Changes

- Filter null values from processed content arrays across all adapters
- Improved logging to use rawUrl variable instead of potentially undefined url
- Better type safety with explicit null filtering in image content arrays