### PR TITLE
chore(release): bump version to 1.3.14

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-azure-openai-adapter",
   "description": "azure openai adapter for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -46,7 +46,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-claude-adapter",
   "description": "claude adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -47,7 +47,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-deepseek-adapter",
   "description": "deepseek adapter for chatluna",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-dify-adapter",
   "description": "dify adapter for chatluna",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.19",
+  "version": "1.3.20",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   ],
   "dependencies": {
     "@anatine/zod-openapi": "^2.2.8",
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "openapi3-ts": "^4.5.0",
     "zod": "3.25.76",
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11",
+    "koishi-plugin-chatluna": "^1.3.14",
     "koishi-plugin-chatluna-storage-service": "^1.0.1"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -106,7 +106,7 @@ export class GeminiRequester
 
             yield* this._processResponseStream(response)
         } catch (e) {
-            if (this.ctx.chatluna.config.isLog) {
+            if (this.ctx.chatluna.currentConfig.isLog) {
                 await trackLogToLocal(
                     'Request',
                     JSON.stringify(chatGenerationParams),
@@ -146,7 +146,7 @@ export class GeminiRequester
 
             return await this._processResponse(response)
         } catch (e) {
-            if (this.ctx.chatluna.config.isLog) {
+            if (this.ctx.chatluna.currentConfig.isLog) {
                 await trackLogToLocal(
                     'Request',
                     JSON.stringify(chatGenerationParams),

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-hunyuan-adapter",
   "description": "hunyuan adapter for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-hunyuan/src/utils.ts
+++ b/packages/adapter-hunyuan/src/utils.ts
@@ -129,10 +129,7 @@ export async function langchainMessageToHunyuanMessage(
             )
 
             msg.content.push(
-                ...imageContents.filter(
-                    (content): content is MessageContentImageUrl =>
-                        content != null
-                )
+                ...imageContents.filter((content) => content != null)
             )
         }
 

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-ollama-adapter",
   "description": "ollama adapter for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80"
   },
   "devDependencies": {
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-like-adapter",
   "description": "openai style api adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-adapter",
   "description": "openai adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/src/requester.ts
+++ b/packages/adapter-qwen/src/requester.ts
@@ -211,7 +211,7 @@ export class QWenRequester
                 )
             }
         } catch (e) {
-            if (this.ctx.chatluna.config.isLog) {
+            if (this.ctx.chatluna.currentConfig.isLog) {
                 await trackLogToLocal(
                     'Request',
                     JSON.stringify(requestParams),

--- a/packages/adapter-qwen/src/utils.ts
+++ b/packages/adapter-qwen/src/utils.ts
@@ -152,10 +152,7 @@ export async function langchainMessageToQWenMessage(
             )
 
             msg.content.push(
-                ...imageContents.filter(
-                    (content): content is MessageContentImageUrl =>
-                        content != null
-                )
+                ...imageContents.filter((content) => content != null)
             )
         } else if (Array.isArray(msg.content) && msg.content.length > 0) {
             const mappedContent = await Promise.all(

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-rmkv-adapter",
   "description": "rwkv adapter for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "1.0.21",
+    "@chatluna/v1-shared-adapter": "1.0.22",
     "@langchain/core": "^0.3.80",
     "zod-to-json-schema": "3.23.5"
   },
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-spark-adapter",
   "description": "spark adapter for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-wenxin-adapter",
   "description": "wenxin adapter for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-zhipu-adapter",
   "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.21",
+    "@chatluna/v1-shared-adapter": "^1.0.22",
     "@langchain/core": "^0.3.80",
     "jsonwebtoken": "^9.0.2",
     "zod": "3.25.76",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/src/utils.ts
+++ b/packages/adapter-zhipu/src/utils.ts
@@ -93,10 +93,7 @@ export async function langchainMessageToZhipuMessage(
             )
 
             msg.content.push(
-                ...imageContents.filter(
-                    (content): content is MessageContentImageUrl =>
-                        content != null
-                )
+                ...imageContents.filter((content) => content != null)
             )
         } else if (Array.isArray(msg.content) && msg.content.length > 0) {
             const mappedContent = await Promise.all(

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -140,7 +140,7 @@ export class ChatInterface {
         wrapper: ChatLunaLLMChainWrapper
     ): Promise<ChainValues> {
         try {
-            if (this.ctx.chatluna.config.infiniteContext) {
+            if (this.ctx.chatluna.currentConfig.infiniteContext) {
                 const manager = this._ensureInfiniteContextManager()
                 await manager?.compressIfNeeded(wrapper)
             }
@@ -183,7 +183,7 @@ export class ChatInterface {
         if (messageContent.trim().length > 0) {
             await this.chatHistory.addMessage(arg.message)
             let saveMessage = responseMessage
-            if (!this.ctx.chatluna.config.rawOnCensor) {
+            if (!this.ctx.chatluna.currentConfig.rawOnCensor) {
                 saveMessage = displayResponse
             }
 
@@ -543,7 +543,8 @@ export class ChatInterface {
                 chatHistory: this._chatHistory,
                 conversationId: this._input.conversationId,
                 preset: this._input.preset,
-                threshold: this.ctx.chatluna.config.infiniteContextThreshold
+                threshold:
+                    this.ctx.chatluna.currentConfig.infiniteContextThreshold
             })
         }
 

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -71,15 +71,15 @@ export class ChatLunaService extends Service {
 
     constructor(
         public readonly ctx: Context,
-        public config: Config
+        public currentConfig: Config
     ) {
         super(ctx, 'chatluna')
-        this._chain = new ChatChain(ctx, config)
-        this._keysCache = new Cache(this.ctx, config, 'chatluna/keys')
-        this._preset = new PresetService(ctx, config)
+        this._chain = new ChatChain(ctx, currentConfig)
+        this._keysCache = new Cache(this.ctx, currentConfig, 'chatluna/keys')
+        this._preset = new PresetService(ctx, currentConfig)
         this._platformService = new PlatformService(ctx)
-        this._messageTransformer = new MessageTransformer(config)
-        this._renderer = new DefaultRenderer(ctx, config)
+        this._messageTransformer = new MessageTransformer(currentConfig)
+        this._renderer = new DefaultRenderer(ctx, currentConfig)
         this._promptRenderer = new ChatLunaPromptRenderService()
 
         this._createTempDir()
@@ -921,7 +921,7 @@ class ChatInterfaceWrapper {
             if (
                 reasoningContent != null &&
                 reasoningContent.length > 0 &&
-                this._service.config.showThoughtMessage
+                this._service.currentConfig.showThoughtMessage
             ) {
                 additionalReplyMessages.push({
                     content: `Thought for ${reasoningTime / 1000} seconds: \n\n${reasoningContent}`
@@ -1107,7 +1107,7 @@ class ChatInterfaceWrapper {
     private async _createChatInterface(
         room: ConversationRoom
     ): Promise<ChatHubChatBridgerInfo> {
-        const config = this._service.config
+        const config = this._service.currentConfig
 
         const chatInterface = new ChatInterface(this._service.ctx.root, {
             chatMode: room.chatMode,

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11",
+    "koishi-plugin-chatluna": "^1.3.14",
     "koishi-plugin-chatluna-storage-service": "^1.0.1"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11",
+    "koishi-plugin-chatluna": "^1.3.14",
     "koishi-plugin-chatluna-storage-service": "^1.0.1"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.2",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chatluna/v1-shared-adapter",
   "description": "chatluna shared adapter",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.11"
+    "koishi-plugin-chatluna": "^1.3.14"
   }
 }

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -318,7 +318,7 @@ export async function* completionStream<
         const iterator = sseIterable(response)
         yield* processStreamResponse(requestContext, iterator)
     } catch (e) {
-        if (requestContext.ctx.chatluna.config.isLog) {
+        if (requestContext.ctx.chatluna.currentConfig.isLog) {
             await trackLogToLocal(
                 'Request',
                 JSON.stringify(chatCompletionParams),
@@ -365,7 +365,7 @@ export async function completion<
 
         return await processResponse(requestContext, response)
     } catch (e) {
-        if (requestContext.ctx.chatluna.config.isLog) {
+        if (requestContext.ctx.chatluna.currentConfig.isLog) {
             await trackLogToLocal(
                 'Request',
                 JSON.stringify(chatCompletionParams),

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -127,10 +127,7 @@ export async function langchainMessageToOpenAIMessage(
             )
 
             msg.content.push(
-                ...imageContents.filter(
-                    (content): content is MessageContentImageUrl =>
-                        content != null
-                )
+                ...imageContents.filter((content) => content != null)
             )
         } else if (Array.isArray(msg.content) && msg.content.length > 0) {
             const mappedContent = await Promise.all(


### PR DESCRIPTION
## Summary

This PR bumps all package versions to 1.3.14, including core version updates and adapter dependency updates to reflect recent fixes and improvements.

## Bug fixes

- Image fetch failures no longer break message processing (PR #701)
- Log file operations are now non-blocking (PR #700)
- Adapter config logging uses currentConfig instead of static config

## Other Changes

- Core: 1.3.13 -> 1.3.14
- Shared adapter: 1.0.21 -> 1.0.22
- All adapter packages bumped to latest patch versions
- All peerDependencies updated to use new core and shared-adapter versions