### PR TITLE
[Refactor] Improve ChatLunaService type safety

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.14",
+  "version": "1.3.15",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -58,7 +58,7 @@ import { Embeddings } from '@langchain/core/embeddings'
 import { RunnableConfig } from '@langchain/core/runnables'
 import { randomUUID } from 'crypto'
 
-export class ChatLunaService extends Service {
+export class ChatLunaService extends Service<Config> {
     private _plugins: Record<string, ChatLunaPlugin> = {}
     private _chatInterfaceWrapper: ChatInterfaceWrapper
     private readonly _chain: ChatChain
@@ -69,17 +69,20 @@ export class ChatLunaService extends Service {
     private readonly _renderer: DefaultRenderer
     private readonly _promptRenderer: ChatLunaPromptRenderService
 
+    public config: Config
+
     constructor(
         public readonly ctx: Context,
-        public currentConfig: Config
+        config: Config
     ) {
         super(ctx, 'chatluna')
-        this._chain = new ChatChain(ctx, currentConfig)
-        this._keysCache = new Cache(this.ctx, currentConfig, 'chatluna/keys')
-        this._preset = new PresetService(ctx, currentConfig)
+        this.config = config
+        this._chain = new ChatChain(ctx, config)
+        this._keysCache = new Cache(this.ctx, config, 'chatluna/keys')
+        this._preset = new PresetService(ctx, config)
         this._platformService = new PlatformService(ctx)
-        this._messageTransformer = new MessageTransformer(currentConfig)
-        this._renderer = new DefaultRenderer(ctx, currentConfig)
+        this._messageTransformer = new MessageTransformer(config)
+        this._renderer = new DefaultRenderer(ctx, config)
         this._promptRenderer = new ChatLunaPromptRenderService()
 
         this._createTempDir()


### PR DESCRIPTION
This PR improves the type safety and code consistency of the ChatLunaService class.

## Other Changes

- Add explicit generic type parameter `<Config>` to Service class extending
- Rename `currentConfig` parameter to `config` for better naming consistency
- Add public `config` property to ChatLunaService for cleaner API
- Update all constructor parameter references from `currentConfig` to `config` throughout the initialization