### PR TITLE
[Feature] Add image reading tool support

### DIFF
--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-image-service",
   "description": "image service for chatluna",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/service-image/src/index.ts
+++ b/packages/service-image/src/index.ts
@@ -13,6 +13,7 @@ import {
     processImageWithModel,
     readImage
 } from './utils'
+import { apply as toolApply } from './tool'
 
 export let logger: Logger
 
@@ -33,6 +34,8 @@ export function apply(ctx: Context, config: Config) {
             platform,
             modelName
         )
+
+        toolApply(ctx, config, plugin, imageUnderstandModel)
 
         const disposable = ctx.chatluna.messageTransformer.intercept(
             'img',
@@ -163,6 +166,7 @@ export function apply(ctx: Context, config: Config) {
 
 export interface Config extends ChatLunaPlugin.Config {
     model: string
+    enableImageTool: boolean
     imagePrompt: string
     imageInsertPrompt: string
     gifStrategy: 'first' | 'head' | 'average'
@@ -172,6 +176,7 @@ export interface Config extends ChatLunaPlugin.Config {
 export const Config: Schema<Config> = Schema.intersect([
     Schema.object({
         model: Schema.dynamic('model').default('无'),
+        enableImageTool: Schema.boolean().default(false),
         imagePrompt: Schema.string()
             .role('textarea')
             .default(

--- a/packages/service-image/src/locales/en-US.schema.yml
+++ b/packages/service-image/src/locales/en-US.schema.yml
@@ -1,6 +1,7 @@
 $inner:
     - $desc: Model Options
       model: 'Select a model that supports image input (e.g.: gpt-4o, gemini-2.0-flash)'
+      enableImageTool: Enable registering the image reading tool
       imagePrompt: Image input system prompt
       imageInsertPrompt: Image description insertion prompt
       gifStrategy:

--- a/packages/service-image/src/locales/zh-CN.schema.yml
+++ b/packages/service-image/src/locales/zh-CN.schema.yml
@@ -1,6 +1,7 @@
 $inner:
     - $desc: 模型选项
       model: '选择支持图片输入的模型（如：gpt-4o, gemini-2.0-flash)'
+      enableImageTool: 允许注册为读图工具
       imagePrompt: 图片输入的系统提示词。
       imageInsertPrompt: 图片描述插入到具体消息里的提示词。
       gifStrategy:

--- a/packages/service-image/src/tool.ts
+++ b/packages/service-image/src/tool.ts
@@ -1,0 +1,129 @@
+/* eslint-disable max-len */
+import { Tool } from '@langchain/core/tools'
+import { Context } from 'koishi'
+import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
+import { Config, logger } from '.'
+import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
+import {
+    ChatLunaToolRunnable,
+    ModelCapabilities
+} from 'koishi-plugin-chatluna/llm-core/platform/types'
+import {
+    addImageToContent,
+    addTextToContent,
+    parseGifToFrames,
+    processImageWithModel,
+    readImage
+} from './utils'
+import { ComputedRef, Message } from 'koishi-plugin-chatluna'
+
+export function apply(
+    ctx: Context,
+    config: Config,
+    plugin: ChatLunaPlugin,
+    imageModelRef: ComputedRef<ChatLunaChatModel | undefined>
+) {
+    if (!config.enableImageTool) {
+        return
+    }
+
+    plugin.registerTool('read_image', {
+        selector() {
+            return true
+        },
+        createTool() {
+            return new ReadImageTool(ctx, config, imageModelRef)
+        }
+    })
+}
+
+export class ReadImageTool extends Tool {
+    name = 'read_image'
+
+    description =
+        'Describe an image from a URL or data URI. Input should be the image URL.'
+
+    constructor(
+        private readonly ctx: Context,
+        private readonly config: Config,
+        private readonly imageModelRef: ComputedRef<
+            ChatLunaChatModel | undefined
+        >
+    ) {
+        super({})
+    }
+
+    /** @ignore */
+    async _call(input: string, _, _runConfig: ChatLunaToolRunnable) {
+        const url = input?.trim()
+        if (!url) {
+            return 'No image url provided.'
+        }
+
+        const model = this.imageModelRef.value
+        if (model == null) {
+            logger.warn(
+                'Image model is not loaded, please check your chat adapter.'
+            )
+            return 'Image model is not loaded. Please check your chat adapter.'
+        }
+
+        if (
+            !model.modelInfo.capabilities.includes(ModelCapabilities.ImageInput)
+        ) {
+            logger.warn('Image model does not support image input.')
+            return 'Image model does not support image input.'
+        }
+
+        try {
+            const imageData = await readImage(this.ctx, url)
+
+            if (
+                imageData.ext == null ||
+                imageData.buffer == null ||
+                imageData.base64Source == null
+            ) {
+                return `Failed to read image from ${url}.`
+            }
+
+            const fakeMessage: Message = {
+                content: []
+            }
+
+            if (imageData.ext === 'image/gif') {
+                const frames = await parseGifToFrames(imageData.buffer, {
+                    strategy: this.config.gifStrategy,
+                    frameCount: this.config.gifFrameCount
+                })
+
+                addTextToContent(
+                    fakeMessage,
+                    'This is a GIF image. See the frames below:'
+                )
+                for (const frame of frames) {
+                    addImageToContent(fakeMessage, frame)
+                }
+            } else {
+                addImageToContent(fakeMessage, imageData.base64Source)
+            }
+
+            const result = await processImageWithModel(
+                model,
+                this.config,
+                fakeMessage
+            )
+
+            if (!result) {
+                return `Failed to process image from ${url}.`
+            }
+
+            return result
+        } catch (error) {
+            logger.warn(
+                `Read image ${url} error, check your chat adapter`,
+                error
+            )
+            return `Read image ${url} error, please check your chat adapter.`
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new `read_image` tool to the `service-image` package, allowing models to describe images provided via URL or data URI.

## New Features

- Added `read_image` tool support in `packages/service-image/src/tool.ts`.
- Integrated tool registration in `packages/service-image/src/index.ts`.
- Added `enableImageTool` configuration option to enable/disable the tool.
- Added localization support for English and Chinese.

## Bug fixes

None

## Other Changes

- Bumped `koishi-plugin-chatluna-image-service` version to 1.3.3.