### PR TITLE
[Fix] fix image model initialization and tool ref passing

### DIFF
--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-image-service",
   "description": "image service for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/service-image/src/index.ts
+++ b/packages/service-image/src/index.ts
@@ -2,7 +2,6 @@ import { Context, Logger, Schema } from 'koishi'
 import { ClientConfig } from 'koishi-plugin-chatluna/llm-core/platform/config'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
-import { parseRawModelName } from 'koishi-plugin-chatluna/llm-core/utils/count_tokens'
 import { Message } from 'koishi-plugin-chatluna'
 import { modelSchema } from 'koishi-plugin-chatluna/utils/schema'
 import { ModelCapabilities } from 'koishi-plugin-chatluna/llm-core/platform/types'
@@ -29,10 +28,8 @@ export function apply(ctx: Context, config: Config) {
     ctx.on('ready', async () => {
         modelSchema(ctx)
 
-        const [platform, modelName] = parseRawModelName(config.model)
         const imageUnderstandModel = await ctx.chatluna.createChatModel(
-            platform,
-            modelName
+            config.model
         )
 
         toolApply(ctx, config, plugin, imageUnderstandModel)
@@ -85,7 +82,7 @@ export function apply(ctx: Context, config: Config) {
 
                 if (imageUnderstandModel.value == null) {
                     logger.warn(
-                        `The model ${modelName} is not loaded, please check your chat adapter`
+                        `The model ${config.model} is not loaded, please check your chat adapter`
                     )
                     return false
                 }
@@ -96,7 +93,7 @@ export function apply(ctx: Context, config: Config) {
                     )
                 ) {
                     logger.warn(
-                        `The model ${modelName} in image-service does not support image input, please check your chat adapter`
+                        `The model ${config.model} in image-service does not support image input, please check your chat adapter`
                     )
                     return false
                 }
@@ -160,8 +157,6 @@ export function apply(ctx: Context, config: Config) {
 
         ctx.effect(() => disposable)
     })
-
-    logger.debug(`${plugin.platformName} loaded`)
 }
 
 export interface Config extends ChatLunaPlugin.Config {

--- a/packages/service-image/src/tool.ts
+++ b/packages/service-image/src/tool.ts
@@ -21,7 +21,7 @@ export function apply(
     ctx: Context,
     config: Config,
     plugin: ChatLunaPlugin,
-    imageModelRef: ComputedRef<ChatLunaChatModel | undefined>
+    imageModelRef2: ComputedRef<ChatLunaChatModel | undefined>
 ) {
     if (!config.enableImageTool) {
         return
@@ -32,7 +32,7 @@ export function apply(
             return true
         },
         createTool() {
-            return new ReadImageTool(ctx, config, imageModelRef)
+            return new ReadImageTool(ctx, config, () => imageModelRef2)
         }
     })
 }
@@ -46,7 +46,7 @@ export class ReadImageTool extends Tool {
     constructor(
         private readonly ctx: Context,
         private readonly config: Config,
-        private readonly imageModelRef: ComputedRef<
+        private readonly imageModelRef: () => ComputedRef<
             ChatLunaChatModel | undefined
         >
     ) {
@@ -60,7 +60,7 @@ export class ReadImageTool extends Tool {
             return 'No image url provided.'
         }
 
-        const model = this.imageModelRef.value
+        const model = this.imageModelRef().value
         if (model == null) {
             logger.warn(
                 'Image model is not loaded, please check your chat adapter.'


### PR DESCRIPTION
This pr fixes issues with image model initialization and ensures the image tool correctly references the model.

## Bug fixes

- Fix image model initialization logic to use correct config parameter
- Fix `imageModelRef` passing in `ReadImageTool` to prevent stale references

## Other Changes

- Bump `koishi-plugin-chatluna-image-service` version to 1.3.4