### PR TITLE
[Fix] simplify message splitting logic and cleanup voice renderers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.16",
+  "version": "1.3.18",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/renders/mixed-voice.ts
+++ b/packages/core/src/renders/mixed-voice.ts
@@ -1,6 +1,5 @@
 import { Message, RenderMessage, RenderOptions } from '../types'
 import { Renderer } from './default'
-import { marked, Token } from 'marked'
 import { logger } from 'koishi-plugin-chatluna'
 import { h, Schema } from 'koishi'
 import type {} from 'koishi-plugin-puppeteer'
@@ -79,9 +78,7 @@ export class MixedVoiceRenderer extends Renderer {
     }
 
     private _splitMessage(messages: h[]): string[] {
-        return messages
-            .flatMap((message) => message.toString())
-            .filter(Boolean)
+        return messages.flatMap((message) => message.toString()).filter(Boolean)
     }
 
     private _renderToVoice(text: string, options: RenderOptions) {
@@ -102,27 +99,4 @@ export class MixedVoiceRenderer extends Renderer {
         'zh-CN': '同时输出语音和文本',
         'en-US': 'Output both voice and text'
     })
-}
-
-function renderToken(token: Token): string {
-    if (
-        token.type === 'text' ||
-        //     token.type === "space" ||
-        token.type === 'heading' ||
-        token.type === 'em' ||
-        token.type === 'strong' ||
-        token.type === 'del' ||
-        token.type === 'codespan' ||
-        token.type === 'list_item' ||
-        token.type === 'blockquote'
-        //   || token.type === "code"
-    ) {
-        return token.text
-    }
-
-    return token.raw
-}
-
-function renderTokens(tokens: Token[]): string[] {
-    return tokens.map(renderToken)
 }

--- a/packages/core/src/renders/mixed-voice.ts
+++ b/packages/core/src/renders/mixed-voice.ts
@@ -80,20 +80,7 @@ export class MixedVoiceRenderer extends Renderer {
 
     private _splitMessage(messages: h[]): string[] {
         return messages
-            .flatMap((message) => {
-                if (message.type !== 'text') {
-                    return []
-                }
-                const tokens = renderTokens(
-                    marked.lexer(message.attrs['content'])
-                )
-
-                if (tokens.length === 0 || tokens[0].length === 0) {
-                    return message.attrs['content']
-                }
-
-                return tokens
-            })
+            .flatMap((message) => message.toString())
             .filter(Boolean)
     }
 

--- a/packages/core/src/renders/text.ts
+++ b/packages/core/src/renders/text.ts
@@ -17,9 +17,7 @@ export class TextRenderer extends Renderer {
         )
 
         if (options.split) {
-            transformed = transformed.map((element) => {
-                return h('message', element)
-            })
+            transformed = transformed.map((element) => h('message', element))
         }
 
         if (transformed[0]?.type === 'p') {

--- a/packages/core/src/renders/voice.ts
+++ b/packages/core/src/renders/voice.ts
@@ -1,6 +1,5 @@
 import { Message, RenderMessage, RenderOptions } from '../types'
 import { Renderer } from './default'
-import { marked, Token } from 'marked'
 import { logger } from 'koishi-plugin-chatluna'
 import { h, Schema } from 'koishi'
 import type {} from '@initencounter/vits'
@@ -46,9 +45,7 @@ export class VoiceRenderer extends Renderer {
     }
 
     private _splitMessage(messages: h[]): string[] {
-        return messages
-            .flatMap((message) => message.toString())
-            .filter(Boolean)
+        return messages.flatMap((message) => message.toString()).filter(Boolean)
     }
 
     private _renderToVoice(text: string, options: RenderOptions) {
@@ -69,27 +66,4 @@ export class VoiceRenderer extends Renderer {
         'zh-CN': '将回复渲染为语音',
         'en-US': 'Render as voice'
     })
-}
-
-function renderToken(token: Token): string {
-    if (
-        token.type === 'text' ||
-        //     token.type === "space" ||
-        token.type === 'heading' ||
-        token.type === 'em' ||
-        token.type === 'strong' ||
-        token.type === 'del' ||
-        token.type === 'codespan' ||
-        token.type === 'list_item' ||
-        token.type === 'blockquote'
-        //   || token.type === "code"
-    ) {
-        return token.text
-    }
-
-    return token.raw
-}
-
-function renderTokens(tokens: Token[]): string[] {
-    return tokens.map(renderToken)
 }

--- a/packages/core/src/renders/voice.ts
+++ b/packages/core/src/renders/voice.ts
@@ -47,20 +47,7 @@ export class VoiceRenderer extends Renderer {
 
     private _splitMessage(messages: h[]): string[] {
         return messages
-            .flatMap((message) => {
-                if (message.type !== 'text') {
-                    return []
-                }
-                const tokens = renderTokens(
-                    marked.lexer(message.attrs['content'] ?? '')
-                )
-
-                if (tokens.length === 0 || tokens[0].length === 0) {
-                    return message.attrs['content'] ?? ''
-                }
-
-                return tokens
-            })
+            .flatMap((message) => message.toString())
             .filter(Boolean)
     }
 


### PR DESCRIPTION
This pr simplifies the message splitting logic in voice renderers by using `message.toString()` and removes unused dependencies and helper functions.

## New Features

None

## Bug fixes

- Simplified and improved the reliability of message splitting in `VoiceRenderer` and `MixedVoiceRenderer`.

## Other Changes

- Removed unused `marked` and `Token` imports and related helper functions (`renderToken`, `renderTokens`).
- Cleaned up formatting in `TextRenderer`, `VoiceRenderer`, and `MixedVoiceRenderer`.
- Bumped `koishi-plugin-chatluna` (core) version to 1.3.18.