### PR TITLE
feat(core): 可选地将合并转发聊天记录 ID 附加到上下文，并追加[聊天记录]标记

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -11,6 +11,7 @@ export interface Config {
     msgCooldown: number
     randomReplyFrequency: Computed<Awaitable<number>>
     includeQuoteReply: boolean
+    attachForwardMsgIdToContext: boolean
     isLog: boolean
 
     isReplyWithAt: boolean
@@ -76,7 +77,8 @@ export const Config: Schema<Config> = Schema.intersect([
             .max(1)
             .step(0.01)
             .default(0)
-            .computed()
+            .computed(),
+        attachForwardMsgIdToContext: Schema.boolean().default(false)
     }),
 
     Schema.object({

--- a/packages/core/src/locales/en-US.schema.yml
+++ b/packages/core/src/locales/en-US.schema.yml
@@ -16,6 +16,7 @@ $inner:
       randomReplyFrequency: Set random reply frequency (0-100, where 0 means never and 100 means always).
       forwardMsgMinLength: Set minimum length of forwarded messages (characters).
       includeQuoteReply: Include quoted message content in replies.
+      attachForwardMsgIdToContext: Attach forward message record IDs to context. When enabled, a "[聊天记录]" marker message will be appended if forward records are detected.
 
     - $desc: Response Options
       sendThinkingMessage: Send waiting message during processing.

--- a/packages/core/src/locales/zh-CN.schema.yml
+++ b/packages/core/src/locales/zh-CN.schema.yml
@@ -15,6 +15,7 @@ $inner:
       allowChatWithRoomName: 是否允许使用房间名前缀触发对话。注意：启用此选项可能会显著影响 ChatLuna 的性能，建议配合过滤器仅在特定群组中启用。
       randomReplyFrequency: 设置随机回复的频率。
       includeQuoteReply: 是否在回复内容中包含引用消息的内容。
+      attachForwardMsgIdToContext: 是否将合并转发聊天记录消息的 ID 附加到上下文中。启用后，检测到聊天记录会额外追加一条 [聊天记录] 消息。
 
     - $desc: 对话响应选项
       sendThinkingMessage: 是否在请求处理过程中发送等待消息。

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -13,6 +13,10 @@ import { ModelCapabilities } from 'koishi-plugin-chatluna/llm-core/platform/type
 import type {} from 'koishi-plugin-chatluna-storage-service'
 import { Message } from 'koishi-plugin-chatluna'
 import { MessageContent, MessageContentComplex } from '@langchain/core/messages'
+import {
+    isForwardMessageElement,
+    pickForwardMessageId
+} from 'koishi-plugin-chatluna/utils/koishi'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
     const forwardHistoryInternalKey = '__chatluna_forwardHistory'
@@ -496,43 +500,6 @@ function addMessageContent(message: Message, content: MessageContent) {
             ? [{ type: 'text', text: content }]
             : content)
     ]
-}
-
-function pickForwardMessageId(element: h): string | null {
-    const attrs = (element.attrs ?? {}) as Record<string, unknown>
-
-    // Only use the common message id field used across other message APIs.
-    // Keep both snake_case and camelCase for adapter compatibility.
-    for (const key of ['message_id', 'messageId']) {
-        const normalizedId = normalizeForwardMessageId(attrs[key])
-        if (normalizedId) return normalizedId
-    }
-
-    return null
-}
-
-function isForwardMessageElement(element: h): boolean {
-    if (!element) return false
-    if (element.type === 'forward') return true
-    if (element.type !== 'message') return false
-
-    const attrs = element.attrs ?? {}
-    if (['true', '1'].includes(String(attrs['forward']))) return true
-
-    return false
-}
-
-function normalizeForwardMessageId(value: unknown): string | null {
-    if (typeof value === 'number' && Number.isFinite(value)) {
-        return String(value)
-    }
-
-    if (typeof value !== 'string') {
-        return null
-    }
-
-    const trimmed = value.trim()
-    return trimmed.length > 0 ? trimmed : null
 }
 
 declare module '../../chains/chain' {

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -15,19 +15,7 @@ import { Message } from 'koishi-plugin-chatluna'
 import { MessageContent, MessageContentComplex } from '@langchain/core/messages'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
-    const forwardHistoryState = new WeakMap<
-        Message,
-        { ids: Set<string>; hasForwardHistory: boolean }
-    >()
-
-    function ensureForwardHistoryState(message: Message) {
-        const existing = forwardHistoryState.get(message)
-        if (existing) return existing
-
-        const initial = { ids: new Set<string>(), hasForwardHistory: false }
-        forwardHistoryState.set(message, initial)
-        return initial
-    }
+    const forwardHistoryInternalKey = '__chatluna_forwardHistory'
 
     chain
         .middleware('read_chat_message', async (session, context) => {
@@ -55,18 +43,36 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 )
 
             if (config.attachForwardMsgIdToContext) {
-                const state = forwardHistoryState.get(transformedMessage)
+                const additionalKwargs =
+                    (transformedMessage.additional_kwargs ?? {}) as Record<
+                        string,
+                        unknown
+                    >
+                const state = additionalKwargs[forwardHistoryInternalKey] as
+                    | { ids?: string[]; hasForwardHistory?: boolean }
+                    | undefined
+
                 if (state?.hasForwardHistory) {
                     if (!transformedMessage.additional_kwargs) {
                         transformedMessage.additional_kwargs = {}
                     }
 
-                    if (state.ids.size > 0) {
+                    if (Array.isArray(state.ids) && state.ids.length > 0) {
                         transformedMessage.additional_kwargs.forwardMessageIds =
-                            Array.from(state.ids)
+                            state.ids
                     }
 
                     addMessageContent(transformedMessage, '[聊天记录]')
+                }
+
+                // Internal-only state, should not leak outside this middleware.
+                if (transformedMessage.additional_kwargs) {
+                    const kwargs =
+                        transformedMessage.additional_kwargs as Record<
+                            string,
+                            unknown
+                        >
+                    delete kwargs[forwardHistoryInternalKey]
                 }
             }
 
@@ -111,12 +117,26 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         async (session, element, message) => {
             if (!config.attachForwardMsgIdToContext) return
 
-            const state = ensureForwardHistoryState(message)
-            state.hasForwardHistory = true
+            if (!message.additional_kwargs) message.additional_kwargs = {}
+            const additionalKwargs = message.additional_kwargs as Record<
+                string,
+                unknown
+            >
+            const state = additionalKwargs[forwardHistoryInternalKey] as
+                | { ids: string[]; hasForwardHistory: boolean }
+                | undefined
+
+            const current = state ?? { ids: [], hasForwardHistory: false }
+            current.hasForwardHistory = true
+
             const normalizedId = pickForwardMessageId(element)
             if (normalizedId) {
-                state.ids.add(normalizedId)
+                if (!current.ids.includes(normalizedId)) {
+                    current.ids.push(normalizedId)
+                }
             }
+
+            additionalKwargs[forwardHistoryInternalKey] = current
         }
     )
 
@@ -126,12 +146,26 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             if (!config.attachForwardMsgIdToContext) return
             if (!isForwardMessageElement(element)) return
 
-            const state = ensureForwardHistoryState(message)
-            state.hasForwardHistory = true
+            if (!message.additional_kwargs) message.additional_kwargs = {}
+            const additionalKwargs = message.additional_kwargs as Record<
+                string,
+                unknown
+            >
+            const state = additionalKwargs[forwardHistoryInternalKey] as
+                | { ids: string[]; hasForwardHistory: boolean }
+                | undefined
+
+            const current = state ?? { ids: [], hasForwardHistory: false }
+            current.hasForwardHistory = true
+
             const normalizedId = pickForwardMessageId(element)
             if (normalizedId) {
-                state.ids.add(normalizedId)
+                if (!current.ids.includes(normalizedId)) {
+                    current.ids.push(normalizedId)
+                }
             }
+
+            additionalKwargs[forwardHistoryInternalKey] = current
         }
     )
 

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -34,7 +34,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             let message =
                 context.command != null ? context.message : session.elements
 
-            message = message as h.Element[] | string
+            message = message as h[] | string
 
             if (typeof message === 'string') {
                 message = [h.text(message)]
@@ -464,7 +464,7 @@ function addMessageContent(message: Message, content: MessageContent) {
     ]
 }
 
-function pickForwardMessageId(element: h.Element): string | null {
+function pickForwardMessageId(element: h): string | null {
     const attrs = (element.attrs ?? {}) as Record<string, unknown>
 
     // Only use the common message id field used across other message APIs.
@@ -477,7 +477,7 @@ function pickForwardMessageId(element: h.Element): string | null {
     return null
 }
 
-function isForwardMessageElement(element: h.Element): boolean {
+function isForwardMessageElement(element: h): boolean {
     if (!element) return false
     if (element.type === 'forward') return true
     if (element.type !== 'message') return false
@@ -485,12 +485,7 @@ function isForwardMessageElement(element: h.Element): boolean {
     const attrs = element.attrs ?? {}
     if (['true', '1'].includes(String(attrs['forward']))) return true
 
-    return (
-        attrs['forward_id'] != null ||
-        attrs['forwardId'] != null ||
-        attrs['res_id'] != null ||
-        attrs['resId'] != null
-    )
+    return false
 }
 
 function normalizeForwardMessageId(value: unknown): string | null {

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -26,6 +26,14 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 message = [h.text(message)]
             }
 
+            const hasForwardHistory =
+                config.attachForwardMsgIdToContext &&
+                hasForwardMessageElement(message as h[])
+
+            const forwardMessageIds = hasForwardHistory
+                ? collectForwardMessageIds(message as h[])
+                : []
+
             const room = context.options.room
 
             const transformedMessage =
@@ -39,6 +47,19 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                         includeQuoteReply: config.includeQuoteReply
                     }
                 )
+
+            if (hasForwardHistory) {
+                if (!transformedMessage.additional_kwargs) {
+                    transformedMessage.additional_kwargs = {}
+                }
+
+                if (forwardMessageIds.length > 0) {
+                    transformedMessage.additional_kwargs.forwardMessageIds =
+                        forwardMessageIds
+                }
+
+                addMessageContent(transformedMessage, '[聊天记录]')
+            }
 
             if (
                 transformedMessage.content.length < 1 &&
@@ -403,6 +424,95 @@ function addMessageContent(message: Message, content: MessageContent) {
             ? [{ type: 'text', text: content }]
             : content)
     ]
+}
+
+function hasForwardMessageElement(elements: h[]): boolean {
+    return elements.some((element) => {
+        if (!element) return false
+        if (isForwardMessageElement(element)) return true
+
+        const children = (element as unknown as { children?: unknown }).children
+        return (
+            Array.isArray(children) &&
+            children.length > 0 &&
+            hasForwardMessageElement(children as h[])
+        )
+    })
+}
+
+function collectForwardMessageIds(elements: h[]): string[] {
+    const forwardMessageIds = new Set<string>()
+
+    const visit = (element: h) => {
+        if (!element) return
+
+        if (isForwardMessageElement(element)) {
+            const attrs = element.attrs ?? {}
+            for (const key of [
+                'id',
+                'message_id',
+                'messageId',
+                'res_id',
+                'resId',
+                'forward_id',
+                'forwardId'
+            ]) {
+                const normalizedId = normalizeForwardMessageId(
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    (attrs as any)[key]
+                )
+                if (normalizedId) {
+                    forwardMessageIds.add(normalizedId)
+                }
+            }
+        }
+
+        const children = (element as unknown as { children?: unknown }).children
+        if (Array.isArray(children) && children.length > 0) {
+            ;(children as h[]).forEach(visit)
+        }
+    }
+
+    elements.forEach(visit)
+    return Array.from(forwardMessageIds)
+}
+
+function isForwardMessageElement(element: h): boolean {
+    if (!element) return false
+    if (element.type === 'forward') return true
+    if (element.type !== 'message') return false
+
+    const attrs = element.attrs ?? {}
+    const forward = attrs['forward']
+
+    if (
+        forward === true ||
+        forward === 'true' ||
+        forward === 1 ||
+        forward === '1'
+    ) {
+        return true
+    }
+
+    return (
+        attrs['forward_id'] != null ||
+        attrs['forwardId'] != null ||
+        attrs['res_id'] != null ||
+        attrs['resId'] != null
+    )
+}
+
+function normalizeForwardMessageId(value: unknown): string | null {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return String(value)
+    }
+
+    if (typeof value !== 'string') {
+        return null
+    }
+
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
 }
 
 declare module '../../chains/chain' {

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -15,24 +15,30 @@ import { Message } from 'koishi-plugin-chatluna'
 import { MessageContent, MessageContentComplex } from '@langchain/core/messages'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
+    const forwardHistoryState = new WeakMap<
+        Message,
+        { ids: Set<string>; hasForwardHistory: boolean }
+    >()
+
+    function ensureForwardHistoryState(message: Message) {
+        const existing = forwardHistoryState.get(message)
+        if (existing) return existing
+
+        const initial = { ids: new Set<string>(), hasForwardHistory: false }
+        forwardHistoryState.set(message, initial)
+        return initial
+    }
+
     chain
         .middleware('read_chat_message', async (session, context) => {
             let message =
                 context.command != null ? context.message : session.elements
 
-            message = message as h[] | string
+            message = message as h.Element[] | string
 
             if (typeof message === 'string') {
                 message = [h.text(message)]
             }
-
-            const hasForwardHistory =
-                config.attachForwardMsgIdToContext &&
-                hasForwardMessageElement(message as h[])
-
-            const forwardMessageIds = hasForwardHistory
-                ? collectForwardMessageIds(message as h[])
-                : []
 
             const room = context.options.room
 
@@ -48,17 +54,20 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                     }
                 )
 
-            if (hasForwardHistory) {
-                if (!transformedMessage.additional_kwargs) {
-                    transformedMessage.additional_kwargs = {}
-                }
+            if (config.attachForwardMsgIdToContext) {
+                const state = forwardHistoryState.get(transformedMessage)
+                if (state?.hasForwardHistory) {
+                    if (!transformedMessage.additional_kwargs) {
+                        transformedMessage.additional_kwargs = {}
+                    }
 
-                if (forwardMessageIds.length > 0) {
-                    transformedMessage.additional_kwargs.forwardMessageIds =
-                        forwardMessageIds
-                }
+                    if (state.ids.size > 0) {
+                        transformedMessage.additional_kwargs.forwardMessageIds =
+                            Array.from(state.ids)
+                    }
 
-                addMessageContent(transformedMessage, '[聊天记录]')
+                    addMessageContent(transformedMessage, '[聊天记录]')
+                }
             }
 
             if (
@@ -93,6 +102,35 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                     message,
                     `<at ${name != null ? `name="${name}"` : ''} id="${id}"/>`
                 )
+            }
+        }
+    )
+
+    ctx.chatluna.messageTransformer.intercept(
+        'forward',
+        async (session, element, message) => {
+            if (!config.attachForwardMsgIdToContext) return
+
+            const state = ensureForwardHistoryState(message)
+            state.hasForwardHistory = true
+            const normalizedId = pickForwardMessageId(element)
+            if (normalizedId) {
+                state.ids.add(normalizedId)
+            }
+        }
+    )
+
+    ctx.chatluna.messageTransformer.intercept(
+        'message',
+        async (session, element, message) => {
+            if (!config.attachForwardMsgIdToContext) return
+            if (!isForwardMessageElement(element)) return
+
+            const state = ensureForwardHistoryState(message)
+            state.hasForwardHistory = true
+            const normalizedId = pickForwardMessageId(element)
+            if (normalizedId) {
+                state.ids.add(normalizedId)
             }
         }
     )
@@ -426,73 +464,26 @@ function addMessageContent(message: Message, content: MessageContent) {
     ]
 }
 
-function hasForwardMessageElement(elements: h[]): boolean {
-    return elements.some((element) => {
-        if (!element) return false
-        if (isForwardMessageElement(element)) return true
+function pickForwardMessageId(element: h.Element): string | null {
+    const attrs = (element.attrs ?? {}) as Record<string, unknown>
 
-        const children = (element as unknown as { children?: unknown }).children
-        return (
-            Array.isArray(children) &&
-            children.length > 0 &&
-            hasForwardMessageElement(children as h[])
-        )
-    })
-}
-
-function collectForwardMessageIds(elements: h[]): string[] {
-    const forwardMessageIds = new Set<string>()
-
-    const visit = (element: h) => {
-        if (!element) return
-
-        if (isForwardMessageElement(element)) {
-            const attrs = element.attrs ?? {}
-            for (const key of [
-                'id',
-                'message_id',
-                'messageId',
-                'res_id',
-                'resId',
-                'forward_id',
-                'forwardId'
-            ]) {
-                const normalizedId = normalizeForwardMessageId(
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                    (attrs as any)[key]
-                )
-                if (normalizedId) {
-                    forwardMessageIds.add(normalizedId)
-                }
-            }
-        }
-
-        const children = (element as unknown as { children?: unknown }).children
-        if (Array.isArray(children) && children.length > 0) {
-            ;(children as h[]).forEach(visit)
-        }
+    // Only use the common message id field used across other message APIs.
+    // Keep both snake_case and camelCase for adapter compatibility.
+    for (const key of ['message_id', 'messageId']) {
+        const normalizedId = normalizeForwardMessageId(attrs[key])
+        if (normalizedId) return normalizedId
     }
 
-    elements.forEach(visit)
-    return Array.from(forwardMessageIds)
+    return null
 }
 
-function isForwardMessageElement(element: h): boolean {
+function isForwardMessageElement(element: h.Element): boolean {
     if (!element) return false
     if (element.type === 'forward') return true
     if (element.type !== 'message') return false
 
     const attrs = element.attrs ?? {}
-    const forward = attrs['forward']
-
-    if (
-        forward === true ||
-        forward === 'true' ||
-        forward === 1 ||
-        forward === '1'
-    ) {
-        return true
-    }
+    if (['true', '1'].includes(String(attrs['forward']))) return true
 
     return (
         attrs['forward_id'] != null ||

--- a/packages/core/src/utils/koishi.ts
+++ b/packages/core/src/utils/koishi.ts
@@ -145,3 +145,40 @@ export function transformToMarkdown(
     const result = render(marked.lexer(source), platform)
     return result
 }
+
+export function pickForwardMessageId(element: h): string | null {
+    const attrs = (element.attrs ?? {}) as Record<string, unknown>
+
+    // Only use the common message id field used across other message APIs.
+    // Keep both snake_case and camelCase for adapter compatibility.
+    for (const key of ['message_id', 'messageId']) {
+        const normalizedId = normalizeForwardMessageId(attrs[key])
+        if (normalizedId) return normalizedId
+    }
+
+    return null
+}
+
+export function isForwardMessageElement(element: h): boolean {
+    if (!element) return false
+    if (element.type === 'forward') return true
+    if (element.type !== 'message') return false
+
+    const attrs = element.attrs ?? {}
+    if (['true', '1'].includes(String(attrs['forward']))) return true
+
+    return false
+}
+
+export function normalizeForwardMessageId(value: unknown): string | null {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return String(value)
+    }
+
+    if (typeof value !== 'string') {
+        return null
+    }
+
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+}


### PR DESCRIPTION
## 背景
在使用 Napcat/合并转发聊天记录时，ChatLuna 的输入消息转换链路可能会过滤掉转发记录元素，导致上下文中无法保留“存在聊天记录”这一信息。

## 改动
- 新增配置项 `attachForwardMsgIdToContext`（位于“对话行为选项”末尾，默认关闭）。
- 开启后：
  - 检测到消息元素中存在合并转发/转发记录元素时，会递归收集可能的消息 ID 字段（`id`、`message_id`、`messageId`、`res_id`、`resId`、`forward_id`、`forwardId`）。
  - 将收集到的 ID 数组写入 `inputMessage.additional_kwargs.forwardMessageIds`。
  - 向输入消息内容中追加一段文本标记 `[聊天记录]`，避免在过滤后消息为空而被中间件直接丢弃。

## 兼容性
- 默认关闭，不影响现有行为。
- 仅在检测到转发记录元素时才追加标记和附加 IDs。