### PR TITLE
[Fix] add logger.warn for model not found in all adapters

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-azure-openai-adapter",
   "description": "azure openai adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-azure-openai/src/client.ts
+++ b/packages/adapter-azure-openai/src/client.ts
@@ -88,6 +88,10 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient<AzureOpenAICl
         const info = this._modelInfos[model]
 
         if (info == null) {
+            pluginLogger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-deepseek-adapter",
   "description": "deepseek adapter for chatluna",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -78,6 +78,10 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
         const info = this._modelInfos[model]
 
         if (info == null) {
+            pluginLogger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-dify-adapter",
   "description": "dify adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-dify/src/client.ts
+++ b/packages/adapter-dify/src/client.ts
@@ -9,7 +9,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { Config } from '.'
+import { Config, logger } from '.'
 import { DifyRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { PlatformModelClient } from 'koishi-plugin-chatluna/llm-core/platform/client'
@@ -57,6 +57,10 @@ export class DifyClient extends PlatformModelClient<DifyClientConfig> {
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-doubao/src/client.ts
+++ b/packages/adapter-doubao/src/client.ts
@@ -15,7 +15,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { Config } from '.'
+import { Config, logger } from '.'
 import { DoubaoRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { expandReasoningEffortModelVariants } from '@chatluna/v1-shared-adapter'
@@ -129,6 +129,10 @@ export class DouBaoClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.21",
+  "version": "1.3.22",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -152,6 +152,10 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-hunyuan-adapter",
   "description": "hunyuan adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-hunyuan/src/client.ts
+++ b/packages/adapter-hunyuan/src/client.ts
@@ -15,7 +15,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { Config } from '.'
+import { Config, logger } from '.'
 import { HunyuanRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 
@@ -76,6 +76,10 @@ export class HunyuanClient extends PlatformModelAndEmbeddingsClient<ClientConfig
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-ollama-adapter",
   "description": "ollama adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-ollama/src/client.ts
+++ b/packages/adapter-ollama/src/client.ts
@@ -14,7 +14,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { Config } from '.'
+import { Config, logger } from '.'
 import { OllamaRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 
@@ -76,6 +76,10 @@ export class OllamaClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-like-adapter",
   "description": "openai style api adapter for chatluna",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-openai-like/src/client.ts
+++ b/packages/adapter-openai-like/src/client.ts
@@ -14,7 +14,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { Config } from '.'
+import { Config, logger } from '.'
 import { OpenAIRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import {
@@ -115,6 +115,10 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(
                 ChatLunaErrorCode.MODEL_NOT_FOUND,
                 new Error(

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-adapter",
   "description": "openai adapter for chatluna",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-openai/src/client.ts
+++ b/packages/adapter-openai/src/client.ts
@@ -102,6 +102,10 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         const info = this._modelInfos[model]
 
         if (info == null) {
+            pluginLogger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-qwen/src/client.ts
+++ b/packages/adapter-qwen/src/client.ts
@@ -14,7 +14,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { Config } from '.'
+import { Config, logger } from '.'
 import { QWenRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { supportImageInput } from '@chatluna/v1-shared-adapter'
@@ -154,6 +154,10 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-qwen/src/index.ts
+++ b/packages/adapter-qwen/src/index.ts
@@ -1,9 +1,13 @@
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
-import { Context, Schema } from 'koishi'
+import { Context, Logger, Schema } from 'koishi'
 import { QWenClient } from './client'
 import { ModelCapabilities } from 'koishi-plugin-chatluna/llm-core/platform/types'
+import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
+
+export let logger: Logger
 
 export function apply(ctx: Context, config: Config) {
+    logger = createLogger(ctx, 'chatluna-qwen-adapter')
     ctx.on('ready', async () => {
         const plugin = new ChatLunaPlugin(ctx, config, 'qwen')
 

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-rmkv-adapter",
   "description": "rwkv adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-rwkv/src/client.ts
+++ b/packages/adapter-rwkv/src/client.ts
@@ -10,7 +10,7 @@ import {
     ModelType
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { Context } from 'koishi'
-import { Config } from '.'
+import { Config, logger } from '.'
 import {
     ChatLunaError,
     ChatLunaErrorCode
@@ -69,6 +69,10 @@ export class RWKVClient extends PlatformModelAndEmbeddingsClient<ClientConfig> {
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-rwkv/src/index.ts
+++ b/packages/adapter-rwkv/src/index.ts
@@ -1,8 +1,12 @@
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
-import { Context, Schema } from 'koishi'
+import { Context, Logger, Schema } from 'koishi'
 import { RWKVClient } from './client'
+import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
+
+export let logger: Logger
 
 export function apply(ctx: Context, config: Config) {
+    logger = createLogger(ctx, 'chatluna-rwkv-adapter')
     ctx.on('ready', async () => {
         const plugin = new ChatLunaPlugin(ctx, config, 'rwkv')
 

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-spark-adapter",
   "description": "spark adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-spark/src/client.ts
+++ b/packages/adapter-spark/src/client.ts
@@ -10,7 +10,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { Config } from '.'
+import { Config, logger } from '.'
 import { SparkRequester } from './requester'
 import { SparkClientConfig } from './types'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
@@ -68,6 +68,10 @@ export class SparkClient extends PlatformModelClient<SparkClientConfig> {
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-spark/src/index.ts
+++ b/packages/adapter-spark/src/index.ts
@@ -1,9 +1,13 @@
-import { Context, Schema } from 'koishi'
+import { Context, Logger, Schema } from 'koishi'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { SparkClient } from './client'
 import { SparkClientConfig } from './types'
+import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
+
+export let logger: Logger
 
 export function apply(ctx: Context, config: Config) {
+    logger = createLogger(ctx, 'chatluna-spark-adapter')
     ctx.on('ready', async () => {
         const plugin = new ChatLunaPlugin<SparkClientConfig, Config>(
             ctx,

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-wenxin-adapter",
   "description": "wenxin adapter for chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-wenxin/src/client.ts
+++ b/packages/adapter-wenxin/src/client.ts
@@ -11,7 +11,7 @@ import {
     ModelType
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { Context } from 'koishi'
-import { Config } from '.'
+import { Config, logger } from '.'
 import {
     ChatLunaError,
     ChatLunaErrorCode
@@ -111,6 +111,10 @@ export class WenxinClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         const info = this._modelInfos[model]
 
         if (info == null) {
+            logger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-zhipu-adapter",
   "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-zhipu/src/client.ts
+++ b/packages/adapter-zhipu/src/client.ts
@@ -115,6 +115,10 @@ export class ZhipuClient extends PlatformModelAndEmbeddingsClient<ClientConfig> 
         const info = this._modelInfos[model]
 
         if (info == null) {
+            pluginLogger.warn(
+                `Model ${model} not found`,
+                JSON.stringify(this._modelInfos)
+            )
             throw new ChatLunaError(ChatLunaErrorCode.MODEL_NOT_FOUND)
         }
 


### PR DESCRIPTION
This pr adds `logger.warn` logging before throwing `MODEL_NOT_FOUND` error in all adapter `_createModel` methods, making it easier to debug model lookup failures.

## Bug fixes

- Log model name and available `modelInfos` when model lookup fails in `_createModel` across all 14 adapters
- Added missing `logger` export in `adapter-qwen`, `adapter-rwkv`, `adapter-spark` index files

## Other Changes

- Bump patch versions for all affected adapters