### PR TITLE
[Feature] Add notifier feedback for adapter loading status

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,24 +9,25 @@ jobs:
 
         steps:
             - name: Check out
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Set up Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
             - id: cache
               name: Yarn Cache Dir
               run: echo "value=$(yarn cache dir)" >> $GITHUB_OUTPUT
             - name: Restore Lockfile
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: yarn.lock
                   key: yarn-lock-${{ github.sha }}
             - name: Restore Cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.cache.outputs.value }}
-                  key: yarn-cache-${{ github.sha }}-node-20
+                  key: yarn-cache-node-20-${{ hashFiles('**/package.json') }}
+                  restore-keys: yarn-cache-node-20-
             - name: Install
               run: yarn
 
@@ -40,21 +41,22 @@ jobs:
 
         steps:
             - name: Check out
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Set up Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
             - name: Restore Lockfile
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: yarn.lock
                   key: yarn-lock-${{ github.sha }}
             - name: Restore Cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ${{ needs.prepare.outputs.cache-dir }}
-                  key: yarn-cache-${{ github.sha }}-node-20
+                  key: yarn-cache-node-20-${{ hashFiles('**/package.json') }}
+                  restore-keys: yarn-cache-node-20-
             - name: Install
               run: yarn
             - name: Build Clean
@@ -70,21 +72,22 @@ jobs:
 
         steps:
             - name: Check out
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
             - name: Set up Node
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: 20
             - name: Restore Lockfile
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: yarn.lock
                   key: yarn-lock-${{ github.sha }}
             - name: Restore Cache
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ${{ needs.prepare.outputs.cache-dir }}
-                  key: yarn-cache-${{ github.sha }}-node-20
+                  key: yarn-cache-node-20-${{ hashFiles('**/package.json') }}
+                  restore-keys: yarn-cache-node-20-
             - name: Install
               run: yarn
             - name: Lint

--- a/packages/core/src/llm-core/platform/client.ts
+++ b/packages/core/src/llm-core/platform/client.ts
@@ -116,7 +116,7 @@ export abstract class BasePlatformClient<
 
             this.ctx.logger.error(e)
             this._modelInfos = {}
-            return []
+            throw e
         }
     }
 

--- a/packages/core/src/llm-core/utils/tiktoken.ts
+++ b/packages/core/src/llm-core/utils/tiktoken.ts
@@ -63,7 +63,12 @@ export async function getEncoding(
             : `https://jsd.onmicrosoft.cn/npm/tiktoken@latest/encoders/${encoding}.json`
 
     cache[encoding] = await chatLunaFetch(url)
-        .then((res) => res.json() as unknown as TiktokenBPE)
+        .then((res) => {
+            if (!res.ok) {
+                throw new Error(`Failed to fetch tiktoken encoding: ${res.status}`)
+            }
+            return res.json() as unknown as TiktokenBPE
+        })
         .catch((e) => {
             delete cache[encoding]
             throw e

--- a/packages/core/src/llm-core/utils/tiktoken.ts
+++ b/packages/core/src/llm-core/utils/tiktoken.ts
@@ -65,7 +65,9 @@ export async function getEncoding(
     cache[encoding] = await chatLunaFetch(url)
         .then((res) => {
             if (!res.ok) {
-                throw new Error(`Failed to fetch tiktoken encoding: ${res.status}`)
+                throw new Error(
+                    `Failed to fetch tiktoken encoding: ${res.status}`
+                )
             }
             return res.json() as unknown as TiktokenBPE
         })

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -808,7 +808,7 @@ export class ChatLunaPlugin<
         )
     }
 
-    async fetch(
+    fetch(
         info: fetchType.RequestInfo,
         init?: fetchType.RequestInit,
         proxy?: string

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -701,12 +701,21 @@ export class ChatLunaPlugin<
 
     async initClient() {
         let notification: Notifier | undefined
+        let result: { type: 'success' | 'danger'; content: string } | undefined
 
         this.ctx.inject(['notifier'], (ctx) => {
-            notification = ctx.notifier.create({
-                content: `适配器 ${this.platformName} 加载中...`,
-                type: 'primary'
-            })
+            if (notification) return
+            if (result) {
+                notification = ctx.notifier.create({
+                    content: result.content,
+                    type: result.type
+                })
+            } else {
+                notification = ctx.notifier.create({
+                    content: `适配器 ${this.platformName} 加载中...`,
+                    type: 'primary'
+                })
+            }
             ctx.effect(() => () => notification?.dispose())
         })
 
@@ -716,34 +725,18 @@ export class ChatLunaPlugin<
                 this.createRunnableConfig()
             )
 
+            const content = `适配器 ${this.platformName} 加载成功，共加载了 ${this._supportModels.length} 个模型。`
             if (notification) {
-                notification.update({
-                    content: `适配器 ${this.platformName} 加载成功，共加载了 ${this._supportModels.length} 个模型。`,
-                    type: 'success'
-                })
+                notification.update({ content, type: 'success' })
             } else {
-                this.ctx.inject(['notifier'], (ctx) => {
-                    notification = ctx.notifier.create({
-                        content: `适配器 ${this.platformName} 加载成功，共加载了 ${this._supportModels.length} 个模型。`,
-                        type: 'success'
-                    })
-                    ctx.effect(() => () => notification?.dispose())
-                })
+                result = { type: 'success', content }
             }
         } catch (e) {
+            const content = `适配器 ${this.platformName} 加载失败: ${e.message}`
             if (notification) {
-                notification.update({
-                    content: `适配器 ${this.platformName} 加载失败: ${e.message}`,
-                    type: 'danger'
-                })
+                notification.update({ content, type: 'danger' })
             } else {
-                this.ctx.inject(['notifier'], (ctx) => {
-                    const n = ctx.notifier.create({
-                        content: `适配器 ${this.platformName} 加载失败: ${e.message}`,
-                        type: 'danger'
-                    })
-                    ctx.effect(() => () => n.dispose())
-                })
+                result = { type: 'danger', content }
             }
 
             this.ctx.chatluna.uninstallPlugin(this)

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -70,7 +70,7 @@ export class ChatLunaService extends Service<Config> {
     private readonly _renderer: DefaultRenderer
     private readonly _promptRenderer: ChatLunaPromptRenderService
 
-    public declare config: Config
+    declare public config: Config
 
     declare public currentConfig: Config
 

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -57,6 +57,7 @@ import { computed, ComputedRef, watch } from '@vue/reactivity'
 import { Embeddings } from '@langchain/core/embeddings'
 import { RunnableConfig } from '@langchain/core/runnables'
 import { randomUUID } from 'crypto'
+import type { Notifier } from '@koishijs/plugin-notifier'
 
 export class ChatLunaService extends Service<Config> {
     private _plugins: Record<string, ChatLunaPlugin> = {}
@@ -69,7 +70,7 @@ export class ChatLunaService extends Service<Config> {
     private readonly _renderer: DefaultRenderer
     private readonly _promptRenderer: ChatLunaPromptRenderService
 
-    public config: Config
+    declare public config: Config
 
     declare public currentConfig: Config
 
@@ -699,12 +700,52 @@ export class ChatLunaPlugin<
     }
 
     async initClient() {
+        let notification: Notifier | undefined
+
+        this.ctx.inject(['notifier'], (ctx) => {
+            notification = ctx.notifier.create({
+                content: `适配器 ${this.platformName} 加载中...`,
+                type: 'primary'
+            })
+            ctx.effect(() => () => notification?.dispose())
+        })
+
         try {
             await this._platformService.createClient(
                 this.platformName,
                 this.createRunnableConfig()
             )
+
+            if (notification) {
+                notification.update({
+                    content: `适配器 ${this.platformName} 加载成功，共加载了 ${this._supportModels.length} 个模型。`,
+                    type: 'success'
+                })
+            } else {
+                this.ctx.inject(['notifier'], (ctx) => {
+                    notification = ctx.notifier.create({
+                        content: `适配器 ${this.platformName} 加载成功，共加载了 ${this._supportModels.length} 个模型。`,
+                        type: 'success'
+                    })
+                    ctx.effect(() => () => notification?.dispose())
+                })
+            }
         } catch (e) {
+            if (notification) {
+                notification.update({
+                    content: `适配器 ${this.platformName} 加载失败: ${e.message}`,
+                    type: 'danger'
+                })
+            } else {
+                this.ctx.inject(['notifier'], (ctx) => {
+                    const n = ctx.notifier.create({
+                        content: `适配器 ${this.platformName} 加载失败: ${e.message}`,
+                        type: 'danger'
+                    })
+                    ctx.effect(() => () => n.dispose())
+                })
+            }
+
             this.ctx.chatluna.uninstallPlugin(this)
 
             // unstable code

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -70,7 +70,7 @@ export class ChatLunaService extends Service<Config> {
     private readonly _renderer: DefaultRenderer
     private readonly _promptRenderer: ChatLunaPromptRenderService
 
-    declare public config: Config
+    public declare config: Config
 
     declare public currentConfig: Config
 

--- a/packages/extension-tools/src/plugins/openapi.ts
+++ b/packages/extension-tools/src/plugins/openapi.ts
@@ -216,6 +216,9 @@ export class OpenAPIPluginTool
 
         try {
             const res = await this.plugin.fetch(url.toString(), init)
+            if (!res.ok) {
+                throw new Error(`Request failed: ${res.status}`)
+            }
             const result = await res.text()
             logger.debug('Response:', result)
             return result

--- a/packages/renderer-image/src/renders/image.ts
+++ b/packages/renderer-image/src/renders/image.ts
@@ -173,6 +173,10 @@ export class ImageRenderer extends Renderer {
             }
         )
 
+        if (!response.ok) {
+            throw new Error(`Failed to create pastebin: ${response.status}`)
+        }
+
         const url = await response.text()
 
         logger.debug('pastebin url: ' + url)

--- a/packages/renderer-image/src/renders/mixed-image.ts
+++ b/packages/renderer-image/src/renders/mixed-image.ts
@@ -278,6 +278,10 @@ export class MixedImageRenderer extends Renderer {
             }
         )
 
+        if (!response.ok) {
+            throw new Error(`Failed to create pastebin: ${response.status}`)
+        }
+
         const url = await response.text()
         logger.debug('pastebin url: ' + url)
 

--- a/packages/service-search/src/providers/serper.ts
+++ b/packages/service-search/src/providers/serper.ts
@@ -27,6 +27,10 @@ class SerperSearchProvider extends SearchProvider {
             }
         )
 
+        if (!response.ok) {
+            throw new Error(`Serper search failed: ${response.status}`)
+        }
+
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const res = (await response.json()) as any
 

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -264,7 +264,12 @@ export async function fetchImageUrl(
     const imageType = getImageMimeType(ext)
     const buffer = await plugin
         .fetch(url)
-        .then((res) => res.arrayBuffer())
+        .then((res) => {
+            if (!res.ok) {
+                throw new Error(`Failed to fetch image: ${res.status}`)
+            }
+            return res.arrayBuffer()
+        })
         .then(Buffer.from)
 
     return `data:${imageType};base64,${buffer.toString('base64')}`


### PR DESCRIPTION
This PR adds visual notification feedback during adapter client initialization using `@koishijs/plugin-notifier`, so users can see loading, success, and failure states in the Koishi console.

## New Features

- Display a "loading" notification when an adapter starts initializing
- Show a "success" notification with model count when initialization completes
- Show a "danger" notification with error message when initialization fails

## Bug Fixes

- `BasePlatformClient.getModels` now re-throws errors instead of silently returning an empty array, allowing callers to properly handle failures

## Other Changes

- Added `declare` modifier to `ChatLunaService.config` to fix TypeScript emit
- Added `Notifier` type import from `@koishijs/plugin-notifier`