### PR TITLE
feat(adapters): add new model variants and improve reasoning effort handling

### DIFF
--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -40,6 +40,7 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
             'claude-sonnet-4-20250514',
             'claude-sonnet-4-5-20250929',
             'claude-opus-4-5-20251101',
+            'claude-opus-4-6',
             'claude-opus-4-1-20250805',
             'claude-haiku-4-5-20251001',
             'claude-3-5-haiku-20241022'

--- a/packages/adapter-doubao/src/client.ts
+++ b/packages/adapter-doubao/src/client.ts
@@ -42,6 +42,10 @@ export class DouBaoClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
 
     async refreshModels(): Promise<ModelInfo[]> {
         const rawModels: [string, number | undefined][] = [
+            ['doubao-seed-2-0-pro-260215', 256000],
+            ['doubao-seed-2-0-lite-260215', 256000],
+            ['doubao-seed-2-0-mini-260215', 256000],
+            ['doubao-seed-2-0-code-preview-260215', 256000],
             ['doubao-seed-1-8-251228', 256000],
             ['doubao-seed-1-6-flash-250715', 256000],
             ['doubao-seed-1-6-251015', 256000],
@@ -74,33 +78,34 @@ export class DouBaoClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         const reasoningEffortModels = [
             'doubao-seed-1-6-lite-251015',
             'doubao-seed-1-6-251015',
-            'doubao-seed-1-8-251228'
+            'doubao-seed-1-8-251228',
+            'doubao-seed-2-0'
         ]
 
         const imageInputSupportModels = [
             'doubao-seed-1-6',
             'vision',
-            'doubao-seed-1-8'
+            'doubao-seed-1-8',
+            'doubao-seed-2-0'
         ]
 
-        const expandedModels: [string, number | undefined][] = []
-        const seen = new Set<string>()
-
-        const push = (model: string, token?: number) => {
-            if (seen.has(model)) return
-            seen.add(model)
-            expandedModels.push([model, token])
-        }
-
-        for (const [model, token] of rawModels) {
-            push(model, token)
-
-            if (!reasoningEffortModels.includes(model)) continue
-
-            for (const variant of expandReasoningEffortModelVariants(model)) {
-                push(variant, token)
+        const expandedModels = rawModels.flatMap(([model, token]) => {
+            const result: [string, number | undefined][] = [[model, token]]
+            if (reasoningEffortModels.includes(model)) {
+                for (const variant of expandReasoningEffortModelVariants(
+                    model,
+                    [
+                        'minimal-thinking',
+                        'low-thinking',
+                        'medium-thinking',
+                        'high-thinking'
+                    ]
+                )) {
+                    result.push([variant, token])
+                }
             }
-        }
+            return result
+        })
 
         return expandedModels.map(([model, token]) => {
             return {

--- a/packages/adapter-qwen/src/client.ts
+++ b/packages/adapter-qwen/src/client.ts
@@ -17,7 +17,7 @@ import {
 import { Config, logger } from '.'
 import { QWenRequester } from './requester'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
-import { supportImageInput } from '@chatluna/v1-shared-adapter'
+import { expandReasoningEffortModelVariants } from '@chatluna/v1-shared-adapter'
 
 export class QWenClient extends PlatformModelAndEmbeddingsClient {
     platform = 'qwen'
@@ -49,6 +49,8 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
             ['qwen-plus-character', 32768],
             ['qwen-max', 30720],
             ['qwen-max-latest', 131_072],
+            ['qwen3.5-plus', 1_000_000],
+            ['qwen3.5-plus-2026-02-15', 1_000_000],
             ['qwen3-max', 262_144],
             ['qwen3-max-2026-01-23-thinking', 262_144],
             ['qwen3-max-2026-01-23-non-thinking', 262_144],
@@ -110,6 +112,32 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
             ['text-embedding-v3', 8192]
         ] as [string, number][]
 
+        const reasoningEffortModels = [
+            'qwen3.5-plus',
+            'qwen3.5-plus-2026-02-15'
+        ]
+
+        const imageInputSupportModels = [
+            'vl',
+            'omni',
+            'vision',
+            'qvq',
+            'qwen3.5'
+        ]
+
+        const expandedModels = rawModels.flatMap(([model, token]) => {
+            const result: [string, number | undefined][] = [[model, token]]
+            if (reasoningEffortModels.includes(model)) {
+                for (const variant of expandReasoningEffortModelVariants(
+                    model,
+                    ['non-thinking', 'thinking']
+                )) {
+                    result.push([variant, token])
+                }
+            }
+            return result
+        })
+
         const additionalModels = this._config.additionalModels.map(
             ({ model, modelType, contextSize, modelCapabilities }) =>
                 ({
@@ -123,7 +151,7 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
                 }) as ModelInfo
         )
 
-        return rawModels
+        return expandedModels
             .map(([model, token]) => {
                 return {
                     name: model,
@@ -141,7 +169,9 @@ export class QWenClient extends PlatformModelAndEmbeddingsClient {
                             model.includes('Kimi-K2') ||
                             model.includes('deepseek')) &&
                             ModelCapabilities.ToolCall,
-                        supportImageInput(model) && ModelCapabilities.ImageInput
+                        imageInputSupportModels.some((pattern) =>
+                            model.includes(pattern)
+                        ) && ModelCapabilities.ImageInput
                     ].filter(Boolean)
                 } as ModelInfo
             })

--- a/packages/adapter-zhipu/src/client.ts
+++ b/packages/adapter-zhipu/src/client.ts
@@ -79,7 +79,8 @@ export class ZhipuClient extends PlatformModelAndEmbeddingsClient<ClientConfig> 
             ['GLM-4.6V-Flash', 128000],
             ['GLM-4.6', 200_000],
             ['GLM-4.7', 200_000],
-            ['GLM-4.7-FlashX', 200_000]
+            ['GLM-4.7-FlashX', 200_000],
+            ['GLM-5', 200_000]
             //   ['GLM-4-AllTools', 128000]
         ] as [string, number][]
 

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -19,8 +19,11 @@ export const reasoningEffortModelSuffixes = [
     'thinking'
 ] as const
 
-export function expandReasoningEffortModelVariants(model: string): string[] {
-    return reasoningEffortModelSuffixes.map((suffix) => `${model}-${suffix}`)
+export function expandReasoningEffortModelVariants(
+    model: string,
+    suffixes: readonly string[] = reasoningEffortModelSuffixes
+): string[] {
+    return suffixes.map((suffix) => `${model}-${suffix}`)
 }
 
 export function parseOpenAIModelNameWithReasoningEffort(modelName: string): {


### PR DESCRIPTION
## Summary

Add support for new model variants across multiple adapters and enhance the reasoning effort model variant expansion functionality with customizable suffix configurations.

## New Features

- Added Claude Opus 4.6 to claude adapter
- Added Doubao 2.0 model variants:
  - doubao-seed-2-0-pro-260215
  - doubao-seed-2-0-lite-260215
  - doubao-seed-2-0-mini-260215
  - doubao-seed-2-0-code-preview-260215
- Added Qwen 3.5-plus model variants:
  - qwen3.5-plus
  - qwen3.5-plus-2026-02-15
- Added GLM-5 model to zhipu adapter
- Enhanced `expandReasoningEffortModelVariants()` to accept custom suffix configurations

## Other Changes

- Refactored Doubao model expansion logic using `flatMap` for improved readability
- Refactored Qwen model expansion logic to support custom thinking variants
- Updated Qwen adapter import from `supportImageInput` to `expandReasoningEffortModelVariants`
- Improved image input support detection in Qwen adapter using pattern matching