### PR TITLE
chore(release): bump version to 1.3.21

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-claude-adapter",
   "description": "claude adapter for chatluna",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -47,7 +47,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   ],
   "dependencies": {
     "@anatine/zod-openapi": "^2.2.8",
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "openapi3-ts": "^4.5.0",
     "zod": "3.25.76",
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20",
+    "koishi-plugin-chatluna": "^1.3.21",
     "koishi-plugin-chatluna-storage-service": "^1.0.1"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80"
   },
   "devDependencies": {
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "1.0.24",
+    "@chatluna/v1-shared-adapter": "1.0.25",
     "@langchain/core": "^0.3.80",
     "zod-to-json-schema": "3.23.5"
   },
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-zhipu-adapter",
   "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.24",
+    "@chatluna/v1-shared-adapter": "^1.0.25",
     "@langchain/core": "^0.3.80",
     "jsonwebtoken": "^9.0.2",
     "zod": "3.25.76",
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.20",
+  "version": "1.3.21",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20",
+    "koishi-plugin-chatluna": "^1.3.21",
     "koishi-plugin-chatluna-storage-service": "^1.0.1"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-plugin-common",
   "description": "plugin service for agent mode of chatluna",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20",
+    "koishi-plugin-chatluna": "^1.3.21",
     "koishi-plugin-chatluna-storage-service": "^1.0.1"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-image-renderer",
   "description": "image renderer for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/service-image/package.json
+++ b/packages/service-image/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-search-service",
   "description": "search support for chatluna",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.2",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chatluna/v1-shared-adapter",
   "description": "chatluna shared adapter",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.20"
+    "koishi-plugin-chatluna": "^1.3.21"
   }
 }


### PR DESCRIPTION
This PR bumps package versions to 1.3.21 for changes introduced in #722, #723, #725.

## Other Changes

- Bump `koishi-plugin-chatluna` (core) to 1.3.21
- Bump `@chatluna/v1-shared-adapter` to 1.0.25
- Bump `adapter-claude`, `adapter-zhipu` to 1.3.6
- Bump `adapter-doubao`, `adapter-qwen` to 1.3.5
- Bump `adapter-gemini` to 1.3.24
- Bump `extension-tools` (plugin-common) to 1.3.4
- Bump `renderer-image` to 1.3.2
- Bump `service-search` to 1.3.2
- Update dependency versions across all downstream packages