### PR TITLE
feat(adapter-qwen): add stream_options to include token usage tracking

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,8 @@
       "Read(//g/projects/koishi_projects/koishi-new/external/chatluna-group-analysis/src/service/**)",
       "Read(//g/projects/koishi_projects/koishi-new/external/chatluna-character/src/plugins/**)",
       "WebFetch(domain:localhost)",
-      "Bash(gh pr view:*)"
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)"
     ]
   }
 }

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-qwen/src/requester.ts
+++ b/packages/adapter-qwen/src/requester.ts
@@ -74,6 +74,9 @@ export class QWenRequester
                     ? formatToolsToQWenTools(params.tools)
                     : undefined,
             stream: true,
+            stream_options: {
+                include_usage: true
+            },
             top_p: params.topP,
             temperature: params.temperature,
             enable_search: params.model.includes('vl')


### PR DESCRIPTION
## Summary

This PR adds stream_options configuration to the QWen adapter to enable token usage tracking in streaming responses.

## New Features

- Enable `include_usage` in `stream_options` for streaming API responses to track token consumption

## Other Changes

- Bump adapter-qwen version from 1.3.5 to 1.3.6
- Update local development settings to allow gh pr diff command

## Technical Details

The `stream_options` configuration with `include_usage: true` allows the API to return token usage information even in streaming mode, enabling accurate monitoring of token consumption during API calls.