### PR TITLE
[Feature] Refactor adapter-qwen to use shared utilities and fix missing tool_call_ids

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -47,7 +47,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-doubao/src/requester.ts
+++ b/packages/adapter-doubao/src/requester.ts
@@ -64,12 +64,12 @@ export class DoubaoRequester
             enabledThinking = true
         }
 
-        const baseRequest = buildChatCompletionParams(
+        const baseRequest = (await buildChatCompletionParams(
             { ...params, model },
             this._plugin,
             false,
             false
-        ) as ReturnType<typeof buildChatCompletionParams> & {
+        )) as Awaited<ReturnType<typeof buildChatCompletionParams>> & {
             thinking?: {
                 type: 'enabled' | 'disabled'
             }

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -63,7 +63,7 @@
   ],
   "dependencies": {
     "@anatine/zod-openapi": "^2.2.8",
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "openapi3-ts": "^4.5.0",
     "zod": "3.25.76",

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80"
   },
   "devDependencies": {

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/src/requester.ts
+++ b/packages/adapter-qwen/src/requester.ts
@@ -4,10 +4,9 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
-import { SSEEvent, sseIterable } from 'koishi-plugin-chatluna/utils/sse'
+import { sseIterable } from 'koishi-plugin-chatluna/utils/sse'
 import { Config } from '.'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
-import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
 import {
     ClientConfig,
     ClientConfigPool
@@ -19,20 +18,11 @@ import {
     ModelRequestParams
 } from 'koishi-plugin-chatluna/llm-core/platform/api'
 import {
-    convertDeltaToMessageChunk,
-    formatToolsToQWenTools,
-    langchainMessageToQWenMessage
-} from './utils'
-import {
-    ChatCompletionResponse,
-    ChatCompletionResponseMessageRoleEnum
-} from './types'
-import {
+    buildChatCompletionParams,
     createEmbeddings,
-    createRequestContext
+    createRequestContext,
+    processStreamResponse
 } from '@chatluna/v1-shared-adapter'
-import { AIMessageChunk } from '@langchain/core/messages'
-import { logger } from 'koishi-plugin-chatluna'
 
 export class QWenRequester
     extends ModelRequester
@@ -50,9 +40,16 @@ export class QWenRequester
     async *completionStreamInternal(
         params: ModelRequestParams
     ): AsyncGenerator<ChatGenerationChunk> {
-        let model = params.model
+        const requestContext = createRequestContext(
+            this.ctx,
+            this._config.value,
+            this._pluginConfig,
+            this._plugin,
+            this
+        )
 
-        let enabledThinking: boolean | undefined = null
+        let model = params.model
+        let enabledThinking: boolean | undefined
 
         if (model.includes('thinking')) {
             enabledThinking = !model.includes('-non-thinking')
@@ -62,165 +59,43 @@ export class QWenRequester
             model = model.replace('-default', '-thinking')
         }
 
-        const requestParams = {
-            model,
-            messages: await langchainMessageToQWenMessage(
-                params.input,
-                this._plugin,
-                model
-            ),
-            tools:
-                params.tools != null && !params.model.includes('vl')
-                    ? formatToolsToQWenTools(params.tools)
-                    : undefined,
-            stream: true,
-            stream_options: {
-                include_usage: true
+        const baseRequest = (await buildChatCompletionParams(
+            {
+                ...params,
+                model,
+                tools: model.includes('vl') ? undefined : params.tools
             },
-            top_p: params.topP,
-            temperature: params.temperature,
-            enable_search: params.model.includes('vl')
-                ? undefined
-                : this._pluginConfig.enableSearch,
-            enabled_thinking: enabledThinking
+            this._plugin,
+            false,
+            false
+        )) as Awaited<ReturnType<typeof buildChatCompletionParams>> & {
+            enabled_thinking?: boolean
+            enable_search?: boolean
+            parallel_tool_calls?: boolean
+        }
+
+        if (enabledThinking != null) {
+            baseRequest.enabled_thinking = enabledThinking
+        }
+
+        baseRequest.parallel_tool_calls = true
+
+        if (!model.includes('vl')) {
+            baseRequest.enable_search = this._pluginConfig.enableSearch
         }
 
         try {
-            const response = await this.post(
-                'chat/completions',
-                requestParams,
-                {
-                    signal: params.signal
-                }
-            )
+            const response = await this.post('chat/completions', baseRequest, {
+                signal: params.signal
+            })
 
-            let iterator: AsyncGenerator<SSEEvent, string, unknown>
+            const iterator = sseIterable(response)
+            const streamChunks = processStreamResponse(requestContext, iterator)
 
-            try {
-                iterator = sseIterable(response)
-            } catch (e) {
-                if (
-                    e instanceof ChatLunaError &&
-                    e.message.includes('data_inspection_failed')
-                ) {
-                    throw new ChatLunaError(
-                        ChatLunaErrorCode.API_UNSAFE_CONTENT,
-                        e
-                    )
-                }
-
-                throw e
-            }
-
-            const defaultRole: ChatCompletionResponseMessageRoleEnum =
-                'assistant'
-
-            let reasoningContent = ''
-            let isSetReasoningTime = false
-            let reasoningTime = 0
-
-            for await (const event of iterator) {
-                const chunk = event.data
-
-                if (chunk === '[DONE]') {
-                    return
-                }
-
-                let data: ChatCompletionResponse
-
-                try {
-                    data = JSON.parse(chunk)
-                } catch (err) {
-                    throw new ChatLunaError(
-                        ChatLunaErrorCode.API_REQUEST_FAILED,
-                        new Error(
-                            'error when calling qwen completion, Result: ' +
-                                chunk
-                        )
-                    )
-                }
-
-                const choice = data.choices?.[0]
-
-                if (data.usage) {
-                    yield new ChatGenerationChunk({
-                        message: new AIMessageChunk({
-                            content: '',
-                            response_metadata: {
-                                tokenUsage: {
-                                    promptTokens: data.usage.prompt_tokens,
-                                    completionTokens:
-                                        data.usage.completion_tokens,
-                                    totalTokens: data.usage.total_tokens
-                                }
-                            }
-                        }),
-                        text: ''
-                    })
-                }
-
-                if (!choice) {
-                    continue
-                }
-
-                const delta = choice.delta
-                const messageChunk = convertDeltaToMessageChunk(
-                    delta,
-                    defaultRole
-                )
-
-                if (delta.reasoning_content) {
-                    reasoningContent = (reasoningContent +
-                        delta.reasoning_content) as string
-
-                    if (reasoningTime === 0) {
-                        reasoningTime = Date.now()
-                    }
-                }
-
-                if (
-                    (delta.reasoning_content == null ||
-                        delta.reasoning_content === '') &&
-                    delta.content &&
-                    delta.content.length > 0 &&
-                    reasoningTime > 0 &&
-                    !isSetReasoningTime
-                ) {
-                    reasoningTime = Date.now() - reasoningTime
-                    messageChunk.additional_kwargs.reasoning_time =
-                        reasoningTime
-                    isSetReasoningTime = true
-                }
-
-                const generationChunk = new ChatGenerationChunk({
-                    message: messageChunk,
-                    text: messageChunk.content as string
-                })
-
-                yield generationChunk
-
-                if (choice.finish_reason === 'stop') {
-                    break
-                }
-            }
-
-            if (reasoningContent.length > 0) {
-                logger.debug(
-                    'reasoningContent: ' +
-                        reasoningContent +
-                        ', reasoningTime: ' +
-                        reasoningTime / 1000 +
-                        's'
-                )
+            for await (const chunk of streamChunks) {
+                yield chunk
             }
         } catch (e) {
-            if (this.ctx.chatluna.currentConfig.isLog) {
-                await trackLogToLocal(
-                    'Request',
-                    JSON.stringify(requestParams),
-                    this.logger
-                )
-            }
             if (e instanceof ChatLunaError) {
                 throw e
             } else {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "1.0.25",
+    "@chatluna/v1-shared-adapter": "1.0.26",
     "@langchain/core": "^0.3.80",
     "zod-to-json-schema": "3.23.5"
   },

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.25",
+    "@chatluna/v1-shared-adapter": "^1.0.26",
     "@langchain/core": "^0.3.80",
     "jsonwebtoken": "^9.0.2",
     "zod": "3.25.76",

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chatluna/v1-shared-adapter",
   "description": "chatluna shared adapter",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -42,7 +42,7 @@ export async function langchainMessageToOpenAIMessage(
         const role = messageTypeToOpenAIRole(rawMessage.getType())
 
         const msg = {
-            content: rawMessage.content,
+            content: rawMessage.content === '' ? null : rawMessage.content,
             name:
                 role === 'assistant' || role === 'tool'
                     ? rawMessage.name
@@ -50,7 +50,7 @@ export async function langchainMessageToOpenAIMessage(
             role,
             //  function_call: rawMessage.additional_kwargs.function_call,
 
-            tool_call_id: (rawMessage as ToolMessage).tool_call_id
+            tool_call_id: (rawMessage as ToolMessage).tool_call_id || undefined
         } as ChatCompletionResponseMessage
 
         if (msg.tool_calls == null) {
@@ -90,6 +90,7 @@ export async function langchainMessageToOpenAIMessage(
                 lowerModel?.includes('qwen2.5-omni') ||
                 lowerModel?.includes('qwen-omni') ||
                 lowerModel?.includes('qwen2-vl') ||
+                lowerModel?.includes('qwen3.5') ||
                 lowerModel?.includes('qvq') ||
                 normalizedModel?.includes('o1') ||
                 normalizedModel?.includes('o4') ||
@@ -153,6 +154,49 @@ export async function langchainMessageToOpenAIMessage(
         }
 
         result.push(msg)
+    }
+
+    // Fix missing tool_call_ids: match assistant tool_calls with following tool messages
+    for (let i = 0; i < result.length; i++) {
+        if (result[i].role !== 'assistant') continue
+
+        const assistantMsg = result[i]
+        const toolMessages: ChatCompletionResponseMessage[] = []
+
+        for (
+            let j = i + 1;
+            j < result.length && result[j].role === 'tool';
+            j++
+        ) {
+            toolMessages.push(result[j])
+        }
+
+        if (toolMessages.length === 0) continue
+
+        if (!assistantMsg.tool_calls) {
+            assistantMsg.tool_calls = []
+        }
+
+        for (let k = 0; k < toolMessages.length; k++) {
+            if (!assistantMsg.tool_calls[k]) {
+                assistantMsg.tool_calls[k] = {
+                    id: `call_${k}`,
+                    type: 'function',
+                    function: {
+                        name: toolMessages[k].name || 'unknown',
+                        arguments: '{}'
+                    }
+                }
+            }
+
+            if (!assistantMsg.tool_calls[k].id) {
+                assistantMsg.tool_calls[k].id = `call_${k}`
+            }
+
+            if (!toolMessages[k].tool_call_id) {
+                toolMessages[k].tool_call_id = assistantMsg.tool_calls[k].id
+            }
+        }
     }
 
     if (removeSystemMessage) {


### PR DESCRIPTION
This PR refactors the qwen adapter to use shared utilities from `@chatluna/v1-shared-adapter` and fixes missing `tool_call_id` issues in message conversion.

## New Features

- Adapter-qwen now uses `buildChatCompletionParams` and `processStreamResponse` from shared-adapter, consistent with other adapters like doubao

## Bug Fixes

- Fix assistant messages with empty content (`''`) not being converted to `null` in `langchainMessageToOpenAIMessage`
- Fix empty `tool_call_id` on tool messages not being cleaned up
- Auto-generate `tool_call_id` when missing by matching assistant `tool_calls` with following tool messages by order

## Other Changes

- Remove unused qwen-specific message/tool conversion utilities (`langchainMessageToQWenMessage`, `formatToolsToQWenTools`, `convertDeltaToMessageChunk`) from requester imports
- Bump `@chatluna/v1-shared-adapter` to 1.0.26 across all adapters