### PR TITLE
fix: resolve Dify 404 error in multi-user group chats

### DIFF
--- a/packages/adapter-dify/src/requester.ts
+++ b/packages/adapter-dify/src/requester.ts
@@ -397,11 +397,15 @@ export class DifyRequester extends ModelRequester<DifyClientConfig> {
     }
 
     private resolveDifyUser(params: ModelRequestParams): string {
-        return (
-            (params.variables?.['user_id'] as string) ||
-            (params.variables?.['user'] as string) ||
-            'chatluna'
-        )
+        if (this.ctx.chatluna.config.autoCreateRoomFromUser === true) {
+            return (
+                (params.variables?.['user_id'] as string) ||
+                (params.variables?.['user'] as string) ||
+                'chatluna'
+            )
+        } else {
+            return 'chatluna'
+        }
     }
 
     private async prepareFiles(

--- a/packages/adapter-dify/src/requester.ts
+++ b/packages/adapter-dify/src/requester.ts
@@ -725,7 +725,8 @@ export class DifyRequester extends ModelRequester<DifyClientConfig> {
             await this._plugin
                 .fetch(this.concatUrl('/conversations/' + difyConversationId), {
                     headers: this._buildHeaders(config.apiKey),
-                    method: 'DELETE'
+                    method: 'DELETE',
+                    body: JSON.stringify({ user: 'chatluna' })
                 })
                 .then(async (res) => {
                     if (res.ok) {

--- a/packages/core/src/middlewares/chat/message_delay.ts
+++ b/packages/core/src/middlewares/chat/message_delay.ts
@@ -9,6 +9,7 @@ import {
     ChatChain
 } from '../../chains/chain'
 import { randomUUID } from 'crypto'
+import { MessageContentComplex } from '@langchain/core/messages'
 
 let logger: Logger
 
@@ -256,12 +257,23 @@ function mergeMessages(messages: Message[]): Message {
     if (messages.length === 1) return messages[0]
 
     const base = messages[0]
+    const mergedContent: MessageContentComplex[] = []
+
+    for (const msg of messages) {
+        const content = msg.content
+
+        if (typeof content === 'string') {
+            // 字符串内容转换为 text 格式
+            mergedContent.push({ type: 'text', text: content })
+        } else if (Array.isArray(content)) {
+            // 已经是 MessageContentComplex[] 数组，直接合并
+            mergedContent.push(...content)
+        }
+    }
+
     return {
         ...base,
-        content: messages
-            .map((msg) => msg.content)
-            .filter(Boolean)
-            .join('\n\n'),
+        content: mergedContent,
         additional_kwargs: messages.reduce(
             (acc, msg) => ({
                 ...acc,

--- a/packages/core/src/middlewares/chat/message_delay.ts
+++ b/packages/core/src/middlewares/chat/message_delay.ts
@@ -262,6 +262,10 @@ function mergeMessages(messages: Message[]): Message {
     for (const msg of messages) {
         const content = msg.content
 
+        if (mergedContent.length > 0) {
+            mergedContent.push({ type: 'text', text: '\n' })
+        }
+
         if (typeof content === 'string') {
             mergedContent.push({ type: 'text', text: content })
         } else if (Array.isArray(content)) {

--- a/packages/core/src/middlewares/chat/message_delay.ts
+++ b/packages/core/src/middlewares/chat/message_delay.ts
@@ -263,10 +263,8 @@ function mergeMessages(messages: Message[]): Message {
         const content = msg.content
 
         if (typeof content === 'string') {
-            // 字符串内容转换为 text 格式
             mergedContent.push({ type: 'text', text: content })
         } else if (Array.isArray(content)) {
-            // 已经是 MessageContentComplex[] 数组，直接合并
             mergedContent.push(...content)
         }
     }


### PR DESCRIPTION
When multiple users speak in a group chat room with autoCreateRoomFromUser disabled, all users now use 'chatluna' as the Dify user identifier to avoid conversation permission conflicts.

Close #731 