### PR TITLE
feat(adapter-claude): add platform name, model pull toggle, and additional models config

### DIFF
--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -119,9 +119,7 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
         return additionalModels.concat(
             fetchedModels.filter(
                 (model) =>
-                    !additionalModels.some(
-                        (m) => m.name === model.name
-                    )
+                    !additionalModels.some((m) => m.name === model.name)
             )
         )
     }

--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -119,9 +119,9 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
         return additionalModels.concat(
             fetchedModels.filter(
                 (model) =>
-                    additionalModels.findIndex(
+                    !additionalModels.some(
                         (m) => m.name === model.name
-                    ) === -1
+                    )
             )
         )
     }

--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -118,8 +118,7 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
 
         return additionalModels.concat(
             fetchedModels.filter(
-                (model) =>
-                    !additionalModels.some((m) => m.name === model.name)
+                (model) => !additionalModels.some((m) => m.name === model.name)
             )
         )
     }

--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -56,6 +56,7 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
             'claude-sonnet-4-5-20250929',
             'claude-opus-4-5-20251101',
             'claude-opus-4-6',
+            'claude-sonnet-4-6',
             'claude-opus-4-1-20250805',
             'claude-haiku-4-5-20251001',
             'claude-3-5-haiku-20241022'

--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -22,6 +22,7 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
         public plugin: ChatLunaPlugin
     ) {
         super(ctx, plugin.platformConfigPool)
+        this.platform = _config.platform
 
         this._requester = new ClaudeRequester(
             ctx,
@@ -32,6 +33,20 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
     }
 
     async refreshModels(): Promise<ModelInfo[]> {
+        const additionalModels = this._config.additionalModels.map(
+            ({ model, contextSize, modelCapabilities }) =>
+                ({
+                    name: model,
+                    type: ModelType.llm,
+                    capabilities: modelCapabilities,
+                    maxTokens: contextSize ?? 200_000
+                }) as ModelInfo
+        )
+
+        if (!this._config.pullModels) {
+            return additionalModels
+        }
+
         const fallbackModels = [
             'claude-3-5-sonnet-20241022',
             'claude-3-7-sonnet-20250219',
@@ -45,6 +60,8 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
             'claude-haiku-4-5-20251001',
             'claude-3-5-haiku-20241022'
         ]
+
+        let fetchedModels: ModelInfo[] = []
 
         try {
             // Anthropic lists newer models first; we keep the API order.
@@ -68,7 +85,7 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
 
             const uniqueModels = Array.from(new Set(modelIds))
             if (uniqueModels.length > 0) {
-                return uniqueModels.map((model) => ({
+                fetchedModels = uniqueModels.map((model) => ({
                     name: model,
                     // Use a fixed max context length (200K) for Claude models.
                     maxTokens: 200_000,
@@ -86,16 +103,27 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
             )
         }
 
-        return fallbackModels.map((model) => ({
-            name: model,
-            // Use a fixed max context length (200K) for Claude models.
-            maxTokens: 200_000,
-            capabilities: [
-                ModelCapabilities.ToolCall,
-                ModelCapabilities.ImageInput
-            ],
-            type: ModelType.llm
-        }))
+        if (fetchedModels.length === 0) {
+            fetchedModels = fallbackModels.map((model) => ({
+                name: model,
+                // Use a fixed max context length (200K) for Claude models.
+                maxTokens: 200_000,
+                capabilities: [
+                    ModelCapabilities.ToolCall,
+                    ModelCapabilities.ImageInput
+                ],
+                type: ModelType.llm
+            }))
+        }
+
+        return additionalModels.concat(
+            fetchedModels.filter(
+                (model) =>
+                    additionalModels.findIndex(
+                        (m) => m.name === model.name
+                    ) === -1
+            )
+        )
     }
 
     protected _createModel(model: string): ChatLunaChatModel {

--- a/packages/adapter-claude/src/index.ts
+++ b/packages/adapter-claude/src/index.ts
@@ -64,7 +64,7 @@ export const Config: Schema<Config> = Schema.intersect([
         pullModels: Schema.boolean().default(true),
         additionalModels: Schema.array(
             Schema.object({
-                model: Schema.string(),
+                model: Schema.string().required(),
                 modelCapabilities: Schema.array(
                     Schema.union([
                         ModelCapabilities.ToolCall,

--- a/packages/adapter-claude/src/index.ts
+++ b/packages/adapter-claude/src/index.ts
@@ -67,8 +67,8 @@ export const Config: Schema<Config> = Schema.intersect([
                 model: Schema.string().required(),
                 modelCapabilities: Schema.array(
                     Schema.union([
-                        ModelCapabilities.ToolCall,
-                        ModelCapabilities.ImageInput
+                        Schema.const(ModelCapabilities.ToolCall),
+                        Schema.const(ModelCapabilities.ImageInput)
                     ])
                 )
                     .default([
@@ -76,7 +76,7 @@ export const Config: Schema<Config> = Schema.intersect([
                         ModelCapabilities.ImageInput
                     ])
                     .role('checkbox'),
-                contextSize: Schema.number().default(200000)
+                contextSize: Schema.number().min(1).default(200000)
             })
         )
             .default([])

--- a/packages/adapter-claude/src/index.ts
+++ b/packages/adapter-claude/src/index.ts
@@ -3,16 +3,19 @@ import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
 import { Context, Logger, Schema } from 'koishi'
 import { ClaudeClient } from './client'
+import { ModelCapabilities } from 'koishi-plugin-chatluna/llm-core/platform/types'
 
 export let logger: Logger
 export function apply(ctx: Context, config: Config) {
     logger = createLogger(ctx, 'chatluna-claude-adapter')
 
     ctx.on('ready', async () => {
+        const platform = config.platform
+
         const plugin = new ChatLunaPlugin<ClientConfig, Config>(
             ctx,
             config,
-            'claude'
+            platform
         )
 
         plugin.parseConfig((config) =>
@@ -24,7 +27,7 @@ export function apply(ctx: Context, config: Config) {
                     return {
                         apiKey: apiKey[0],
                         apiEndpoint: apiKey[1],
-                        platform: 'claude',
+                        platform,
                         chatLimit: config.chatTimeLimit,
                         timeout: config.timeout,
                         maxRetries: config.maxRetries,
@@ -41,6 +44,13 @@ export function apply(ctx: Context, config: Config) {
 
 export interface Config extends ChatLunaPlugin.Config {
     apiKeys: [string, string, boolean][]
+    platform: string
+    pullModels: boolean
+    additionalModels: {
+        model: string
+        modelCapabilities: ModelCapabilities[]
+        contextSize: number
+    }[]
     maxContextRatio: number
     temperature: number
     presencePenalty: number
@@ -49,6 +59,29 @@ export interface Config extends ChatLunaPlugin.Config {
 
 export const Config: Schema<Config> = Schema.intersect([
     ChatLunaPlugin.Config,
+    Schema.object({
+        platform: Schema.string().default('claude'),
+        pullModels: Schema.boolean().default(true),
+        additionalModels: Schema.array(
+            Schema.object({
+                model: Schema.string(),
+                modelCapabilities: Schema.array(
+                    Schema.union([
+                        ModelCapabilities.ToolCall,
+                        ModelCapabilities.ImageInput
+                    ])
+                )
+                    .default([
+                        ModelCapabilities.ToolCall,
+                        ModelCapabilities.ImageInput
+                    ])
+                    .role('checkbox'),
+                contextSize: Schema.number().default(200000)
+            })
+        )
+            .default([])
+            .role('table')
+    }),
     Schema.object({
         apiKeys: Schema.array(
             Schema.tuple([

--- a/packages/adapter-claude/src/locales/en-US.schema.yml
+++ b/packages/adapter-claude/src/locales/en-US.schema.yml
@@ -1,5 +1,19 @@
 $inner:
   - {}
+  - $desc: 'Adapter Configuration'
+    platform: 'Adapter platform name'
+    pullModels: 'Auto-fetch model list. If disabled, use only specified models'
+    additionalModels:
+        $desc: 'Additional models'
+        $inner:
+            model: 'Model name'
+            contextSize: 'Context size'
+            modelCapabilities:
+              $desc: Model supported capabilities
+              $inner:
+                  - Tool calling
+                  - Visual image input
+
   - $desc: 'API Configuration'
     apiKeys:
       $inner:

--- a/packages/adapter-claude/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-claude/src/locales/zh-CN.schema.yml
@@ -1,5 +1,19 @@
 $inner:
   - {}
+  - $desc: 适配器配置
+    platform: 设置适配器平台名称。
+    pullModels: 是否自动拉取模型列表。关闭后将仅使用下方指定的模型。
+    additionalModels:
+        $desc: 额外模型列表
+        $inner:
+            model: 模型名称。
+            contextSize: 模型上下文大小。
+            modelCapabilities:
+              $desc: 模型支持的能力
+              $inner:
+                  - 工具调用
+                  - 图片视觉输入
+
   - $desc: 请求选项
     apiKeys:
       $inner:


### PR DESCRIPTION
## Summary
- 新增适配器平台名称配置（默认 claude）
- 新增是否自动拉取模型列表开关（关闭后仅使用手动指定的模型）
- 新增额外模型列表配置，支持指定模型名称、能力和上下文大小