### PR TITLE
[Fix] Truncate base64 image URLs in prompt logging to fix Koishi Desktop

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-azure-openai-adapter",
   "description": "azure openai adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -46,7 +46,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-claude-adapter",
   "description": "claude adapter for chatluna",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -47,7 +47,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-deepseek-adapter",
   "description": "deepseek adapter for chatluna",
-  "version": "1.3.8",
+  "version": "1.3.9",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-dify-adapter",
   "description": "dify adapter for chatluna",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-doubao-adapter",
   "description": "doubao adapter for chatluna",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-google-gemini-adapter",
   "description": "google-gemini adapter for chatluna",
-  "version": "1.3.24",
+  "version": "1.3.25",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
   ],
   "dependencies": {
     "@anatine/zod-openapi": "^2.2.8",
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "openapi3-ts": "^4.5.0",
     "zod": "3.25.76",

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-hunyuan-adapter",
   "description": "hunyuan adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-ollama-adapter",
   "description": "ollama adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80"
   },
   "devDependencies": {

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-like-adapter",
   "description": "openai style api adapter for chatluna",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-openai-adapter",
   "description": "openai adapter for chatluna",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-qwen-adapter",
   "description": "qwen adapter for chatluna",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-rmkv-adapter",
   "description": "rwkv adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -45,7 +45,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "1.0.26",
+    "@chatluna/v1-shared-adapter": "1.0.27",
     "@langchain/core": "^0.3.80",
     "zod-to-json-schema": "3.23.5"
   },

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-spark-adapter",
   "description": "spark adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-wenxin-adapter",
   "description": "wenxin adapter for chatluna",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "zod": "3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-zhipu-adapter",
   "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
     "adapter"
   ],
   "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.26",
+    "@chatluna/v1-shared-adapter": "^1.0.27",
     "@langchain/core": "^0.3.80",
     "jsonwebtoken": "^9.0.2",
     "zod": "3.25.76",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.21",
+  "version": "1.3.22-alpha.4",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/chain/prompt.ts
+++ b/packages/core/src/llm-core/chain/prompt.ts
@@ -4,6 +4,7 @@ import {
     AIMessage,
     BaseMessage,
     HumanMessage,
+    MessageContent,
     SystemMessage
 } from '@langchain/core/messages'
 import {
@@ -21,7 +22,10 @@ import {
 import { logger } from 'koishi-plugin-chatluna'
 import { SystemPrompts } from 'koishi-plugin-chatluna/llm-core/chain/base'
 import { Logger } from 'koishi'
-import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
+import {
+    getMessageContent,
+    isMessageContentImageUrl
+} from 'koishi-plugin-chatluna/utils/string'
 import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
 import type {
     ChatLunaPromptRenderService,
@@ -303,6 +307,31 @@ Your goal is to provide better assistance based on these materials while maintai
                     // 神秘 null
                     return msg
                 }
+
+                const content = original.data.content as MessageContent
+
+                if (!Array.isArray(content)) return original
+
+                original.data.content = content.map((item) => {
+                    if (!isMessageContentImageUrl(item)) return item
+
+                    const url =
+                        typeof item.image_url === 'string'
+                            ? item.image_url
+                            : item.image_url.url
+
+                    if (!url.startsWith('http')) {
+                        const truncated = url.substring(0, 100)
+                        if (typeof item.image_url === 'string') {
+                            item.image_url = truncated
+                        } else {
+                            item.image_url.url = truncated
+                        }
+                    }
+
+                    return item
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                }) as any
 
                 return original
             })

--- a/packages/core/src/utils/logger.ts
+++ b/packages/core/src/utils/logger.ts
@@ -1,4 +1,4 @@
-import { Context, Logger } from 'koishi'
+import { Context, Logger, sleep } from 'koishi'
 import os from 'os'
 import fs from 'fs'
 
@@ -77,7 +77,7 @@ export async function trackLogToLocal(
                 } catch {
                     // ignore failed deletions
                 }
-                await new Promise((resolve) => setTimeout(resolve, 0))
+                await sleep(0)
             }
         }
 

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chatluna/v1-shared-adapter",
   "description": "chatluna shared adapter",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
This PR fixes an issue where large base64-encoded image data URIs in message content were being written verbatim to local log files, causing problems in Koishi Desktop environments.

## Bug fixes

- Truncate non-HTTP image URLs (e.g., base64 data URIs) to 100 characters before logging in `prompt.ts` to prevent excessively large data from being written to log files
- Replace raw `new Promise((resolve) => setTimeout(resolve, 0))` with koishi's `sleep(0)` utility in `logger.ts`

## Other Changes

- Bump `@chatluna/v1-shared-adapter` to `1.0.27` and update all adapter package dependencies accordingly
- Bump core version to `1.3.22-alpha.4`