### PR TITLE
[Fix] mixed-image 输出模式将整个回复渲染为图片

### DIFF
--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -19,14 +19,10 @@ import {
 } from 'koishi-plugin-chatluna/utils/koishi'
 
 export function apply(ctx: Context, config: Config, chain: ChatChain) {
-    const forwardHistoryInternalKey = '__chatluna_forwardHistory'
-
     chain
         .middleware('read_chat_message', async (session, context) => {
             let message =
                 context.command != null ? context.message : session.elements
-
-            message = message as h[] | string
 
             if (typeof message === 'string') {
                 message = [h.text(message)]
@@ -37,7 +33,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             const transformedMessage =
                 await ctx.chatluna.messageTransformer.transform(
                     session,
-                    message,
+                    message as h[],
                     room?.model ?? '',
                     undefined,
                     {
@@ -47,37 +43,21 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 )
 
             if (config.attachForwardMsgIdToContext) {
-                const additionalKwargs =
-                    (transformedMessage.additional_kwargs ?? {}) as Record<
-                        string,
-                        unknown
-                    >
-                const state = additionalKwargs[forwardHistoryInternalKey] as
-                    | { ids?: string[]; hasForwardHistory?: boolean }
+                const kwargs = transformedMessage.additional_kwargs
+                const state = kwargs?.[forwardHistoryInternalKey] as
+                    | ForwardHistoryState
                     | undefined
 
                 if (state?.hasForwardHistory) {
-                    if (!transformedMessage.additional_kwargs) {
-                        transformedMessage.additional_kwargs = {}
-                    }
-
-                    if (Array.isArray(state.ids) && state.ids.length > 0) {
-                        transformedMessage.additional_kwargs.forwardMessageIds =
+                    if (state.ids.length > 0) {
+                        transformedMessage.additional_kwargs!.forwardMessageIds =
                             state.ids
                     }
-
                     addMessageContent(transformedMessage, '[聊天记录]')
                 }
 
                 // Internal-only state, should not leak outside this middleware.
-                if (transformedMessage.additional_kwargs) {
-                    const kwargs =
-                        transformedMessage.additional_kwargs as Record<
-                            string,
-                            unknown
-                        >
-                    delete kwargs[forwardHistoryInternalKey]
-                }
+                delete kwargs?.[forwardHistoryInternalKey]
             }
 
             if (
@@ -120,27 +100,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         'forward',
         async (session, element, message) => {
             if (!config.attachForwardMsgIdToContext) return
-
-            if (!message.additional_kwargs) message.additional_kwargs = {}
-            const additionalKwargs = message.additional_kwargs as Record<
-                string,
-                unknown
-            >
-            const state = additionalKwargs[forwardHistoryInternalKey] as
-                | { ids: string[]; hasForwardHistory: boolean }
-                | undefined
-
-            const current = state ?? { ids: [], hasForwardHistory: false }
-            current.hasForwardHistory = true
-
-            const normalizedId = pickForwardMessageId(element)
-            if (normalizedId) {
-                if (!current.ids.includes(normalizedId)) {
-                    current.ids.push(normalizedId)
-                }
-            }
-
-            additionalKwargs[forwardHistoryInternalKey] = current
+            trackForwardId(element, message)
         }
     )
 
@@ -149,27 +109,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         async (session, element, message) => {
             if (!config.attachForwardMsgIdToContext) return
             if (!isForwardMessageElement(element)) return
-
-            if (!message.additional_kwargs) message.additional_kwargs = {}
-            const additionalKwargs = message.additional_kwargs as Record<
-                string,
-                unknown
-            >
-            const state = additionalKwargs[forwardHistoryInternalKey] as
-                | { ids: string[]; hasForwardHistory: boolean }
-                | undefined
-
-            const current = state ?? { ids: [], hasForwardHistory: false }
-            current.hasForwardHistory = true
-
-            const normalizedId = pickForwardMessageId(element)
-            if (normalizedId) {
-                if (!current.ids.includes(normalizedId)) {
-                    current.ids.push(normalizedId)
-                }
-            }
-
-            additionalKwargs[forwardHistoryInternalKey] = current
+            trackForwardId(element, message)
         }
     )
 
@@ -500,6 +440,28 @@ function addMessageContent(message: Message, content: MessageContent) {
             ? [{ type: 'text', text: content }]
             : content)
     ]
+}
+
+const forwardHistoryInternalKey = '__chatluna_forwardHistory'
+
+function trackForwardId(element: h, message: Message) {
+    const kwargs = (message.additional_kwargs ??= {})
+    const state = (kwargs[forwardHistoryInternalKey] ??= {
+        ids: [],
+        hasForwardHistory: false
+    }) as ForwardHistoryState
+
+    state.hasForwardHistory = true
+
+    const id = pickForwardMessageId(element)
+    if (id && !state.ids.includes(id)) {
+        state.ids.push(id)
+    }
+}
+
+interface ForwardHistoryState {
+    ids: string[]
+    hasForwardHistory: boolean
 }
 
 declare module '../../chains/chain' {

--- a/packages/core/src/utils/koishi.ts
+++ b/packages/core/src/utils/koishi.ts
@@ -164,10 +164,7 @@ export function isForwardMessageElement(element: h): boolean {
     if (element.type === 'forward') return true
     if (element.type !== 'message') return false
 
-    const attrs = element.attrs ?? {}
-    if (['true', '1'].includes(String(attrs['forward']))) return true
-
-    return false
+    return ['true', '1'].includes(String(element.attrs?.['forward']))
 }
 
 export function normalizeForwardMessageId(value: unknown): string | null {

--- a/packages/renderer-image/src/renders/mixed-image.ts
+++ b/packages/renderer-image/src/renders/mixed-image.ts
@@ -152,7 +152,7 @@ export class MixedImageRenderer extends Renderer {
         }
     }
 
-    private _matchText(tokens: Token[]): MatchedText[] {
+    private _matchText(tokens: Token[], isInline = false): MatchedText[] {
         const currentMatchedTexts: MatchedText[] = []
 
         for (const token of tokens) {
@@ -169,28 +169,32 @@ export class MixedImageRenderer extends Renderer {
                 token.type === 'code' ||
                 token.type === 'image' ||
                 token.type === 'html' ||
-                token.type === 'table'
+                token.type === 'table' ||
+                token.type === 'heading' ||
+                token.type === 'list' ||
+                token.type === 'blockquote' ||
+                token.type === 'hr'
             ) {
                 currentMatchedTexts.push({
                     type: 'markdown',
                     text: token.raw
                 })
             } else if (token.type === 'paragraph') {
-                const matchedTexts = this._matchText(token.tokens)
+                const matchedTexts = this._matchText(token.tokens, true)
                 currentMatchedTexts.push(...matchedTexts)
             } else if (token.type === 'space') {
-                const currentMatchedText =
+                const lastMatchedText =
                     currentMatchedTexts[currentMatchedTexts.length - 1]
-                currentMatchedText.text = currentMatchedText.text + token.raw
+                if (lastMatchedText) {
+                    lastMatchedText.text = lastMatchedText.text + token.raw
+                }
             } else {
-                currentMatchedTexts.length = 0
-
+                // For inline tokens (strong, em, codespan, link, etc.) treat as
+                // plain text. For unknown block tokens treat as markdown.
                 currentMatchedTexts.push({
-                    type: 'markdown',
-                    text: tokens.map((token) => token.raw).join('')
+                    type: isInline ? 'text' : 'markdown',
+                    text: token.raw
                 })
-
-                break
             }
         }
         return currentMatchedTexts


### PR DESCRIPTION
This PR fixes the mixed-image output mode always rendering the entire reply as a single image instead of mixing text and images.

## Bug Fixes

- Fix `_matchText` in `MixedImageRenderer` falling into the catch-all `else` branch on any unrecognized token (`heading`, `list`, `blockquote`, `hr`, inline `strong`/`em`/`codespan` etc.), which cleared all classified tokens and rendered the whole message as one image
- Add explicit handling for block tokens (`heading`, `list`, `blockquote`, `hr`) as `markdown` (rendered as image)
- Pass `isInline=true` when recursing into paragraph tokens so unknown inline tokens are treated as plain text
- Fix potential crash in the `space` token handler when `currentMatchedTexts` is empty

## Other Changes

- Refactor forward message tracking in `read_chat_message.ts`: extract shared `trackForwardId()` helper to eliminate ~40 lines of duplicated code across the `forward` and `message` interceptors
- Introduce `ForwardHistoryState` interface for clearer typing
- Simplify `isForwardMessageElement()` in `koishi.ts`

Closes #730