### PR TITLE
fix: add text placeholder for GIF images to prevent empty query error

### DIFF
--- a/packages/service-image/src/index.ts
+++ b/packages/service-image/src/index.ts
@@ -71,6 +71,7 @@ export function apply(ctx: Context, config: Config) {
                         logger.debug(
                             `Extracted ${frames.length} frames from GIF`
                         )
+                        addTextToContent(message, '[image:GIF]')
 
                         for (const frame of frames) {
                             addImageToContent(message, frame)


### PR DESCRIPTION
When users send GIF images without text (e.g., just mentioning the bot), the message content only contains image frames with no text. This causes Dify API to return 'query is required' error.

Added '[image:GIF]' placeholder text to ensure query is never empty.