### PR TITLE
[Fix] normalize multimodal file handling config

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23",
+    "koishi-plugin-chatluna": "^1.3.24",
     "koishi-plugin-chatluna-storage-service": "^1.0.1"
   },
   "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.24",
+  "version": "1.3.25",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.23",
+  "version": "1.3.24",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/platform/client.ts
+++ b/packages/core/src/llm-core/platform/client.ts
@@ -8,6 +8,7 @@ import {
     ChatLunaChatModel
 } from 'koishi-plugin-chatluna/llm-core/platform/model'
 import {
+    FileHandlingConfig,
     ModelInfo,
     PlatformClientNames
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
@@ -18,39 +19,7 @@ import {
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
 
-/**
- * Describes how a platform handles file uploads (inline data, size limits, etc.).
- * Platforms that support multimodal file input should override
- * {@link BasePlatformClient.getFileHandlingConfig} and return this.
- */
-export interface FileHandlingConfig {
-    /** Set of MIME types the platform can accept as inline data. */
-    supportedMimeTypes: Set<string>
-
-    /** Maximum total inline data size (in bytes) per message. */
-    maxTotalSizeBytes: number
-
-    /** Default maximum size (in bytes) for a single inline file. */
-    maxFileSizeBytes: number
-
-    /**
-     * Per-MIME-type size overrides.
-     * For example, `{ 'application/pdf': 50 * 1024 * 1024 }`.
-     */
-    maxFileSizeBytesOverrides?: Record<string, number>
-
-    /**
-     * MIME types that should be stored in storage service rather than
-     * inlined (e.g. text/plain, application/pdf for legacy pipelines).
-     */
-    legacyStorageMimeTypes?: Set<string>
-
-    /**
-     * Whether the platform supports inline_data content parts
-     * (e.g. Gemini-style { inline_data: { mime_type, data } }).
-     */
-    supportsInlineData?: boolean
-}
+export type { FileHandlingConfig }
 
 export abstract class BasePlatformClient<
     T extends ClientConfig = ClientConfig,

--- a/packages/core/src/llm-core/platform/types.ts
+++ b/packages/core/src/llm-core/platform/types.ts
@@ -136,3 +136,25 @@ export type TokenUsageTracker = {
     completionTokens: number
     totalTokens: number
 }
+
+/**
+ * Describes how a platform handles file uploads (inline data, size limits, etc.).
+ * Platforms that support multimodal file input should override
+ * {@link BasePlatformClient.getFileHandlingConfig} and return this.
+ */
+export interface FileHandlingConfig {
+    /** Set of MIME types the platform can accept as inline data. */
+    supportedMimeTypes: Set<string>
+
+    /** Maximum total inline data size (in bytes) per message. */
+    maxTotalSizeBytes: number
+
+    /** Default maximum size (in bytes) for a single inline file. */
+    maxFileSizeBytes: number
+
+    /**
+     * Per-MIME-type size overrides.
+     * For example, `{ 'application/pdf': 50 * 1024 * 1024 }`.
+     */
+    maxFileSizeBytesOverrides?: Record<string, number>
+}

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -553,12 +553,12 @@ async function handleFileElement(
         }
 
         // Check file size limits
-        const maxSizeMbOverride = element.attrs[
-            'chatluna_multimodal_file_input_max_size_mb'
-        ] as number | undefined
+        const _maxSizeMb = parseFloat(
+            element.attrs['chatluna_multimodal_file_input_max_size_mb']
+        )
         const maxSize =
-            maxSizeMbOverride != null
-                ? maxSizeMbOverride * 1024 * 1024
+            Number.isFinite(_maxSizeMb) && _maxSizeMb > 0
+                ? _maxSizeMb * 1024 * 1024
                 : ((mimeType != null
                       ? fileConfig.maxFileSizeBytesOverrides?.[mimeType]
                       : undefined) ?? fileConfig.maxFileSizeBytes)

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -11,6 +11,7 @@ import {
     hashString
 } from 'koishi-plugin-chatluna/utils/string'
 import { ModelCapabilities } from 'koishi-plugin-chatluna/llm-core/platform/types'
+import type { FileHandlingConfig } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import type {} from 'koishi-plugin-chatluna-storage-service'
 import { Message } from 'koishi-plugin-chatluna'
 import { MessageContent, MessageContentComplex } from '@langchain/core/messages'
@@ -20,7 +21,6 @@ import {
 } from 'koishi-plugin-chatluna/utils/koishi'
 import { parseRawModelName } from 'koishi-plugin-chatluna/llm-core/utils/count_tokens'
 import { getBase64EncodedSize } from 'koishi-plugin-chatluna/utils/base64'
-import { FileHandlingConfig } from 'koishi-plugin-chatluna/llm-core/platform/client'
 
 const CHATLUNA_DOWNLOAD_USER_AGENT =
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
@@ -553,10 +553,15 @@ async function handleFileElement(
         }
 
         // Check file size limits
+        const maxSizeMbOverride = element.attrs[
+            'chatluna_multimodal_file_input_max_size_mb'
+        ] as number | undefined
         const maxSize =
-            (mimeType != null
-                ? fileConfig.maxFileSizeBytesOverrides?.[mimeType]
-                : undefined) ?? fileConfig.maxFileSizeBytes
+            maxSizeMbOverride != null
+                ? maxSizeMbOverride * 1024 * 1024
+                : ((mimeType != null
+                      ? fileConfig.maxFileSizeBytesOverrides?.[mimeType]
+                      : undefined) ?? fileConfig.maxFileSizeBytes)
         const encodedSize = getBase64EncodedSize(buffer.byteLength)
 
         if (encodedSize > maxSize) {
@@ -577,34 +582,6 @@ async function handleFileElement(
                 `[${elementType}: ${fileName ?? 'attachment'} (skipped: total inline size would exceed limit)]`
             )
             return false
-        }
-
-        // Attach inline data if the platform supports it
-        if (fileConfig.supportsInlineData && mimeType != null) {
-            const isLegacyStorage =
-                fileConfig.legacyStorageMimeTypes?.has(mimeType) ?? false
-
-            if (!isLegacyStorage) {
-                const base64 = buffer.toString('base64')
-                const dataUrl = `data:${mimeType};base64,${base64}`
-
-                ensureContentArray(
-                    message,
-                    `[${elementType}:${fileName ?? 'attachment'}:${sourceUrl}]`
-                )
-
-                // Also push the typed *_url part so standard langchain adapters can read it
-                pushTypedContent(message, elementType, dataUrl, mimeType)
-
-                if (message.additional_kwargs == null) {
-                    message.additional_kwargs = {}
-                }
-                ;(message.additional_kwargs as Record<string, unknown>)[
-                    '__file_total_size'
-                ] = newTotal
-
-                return true
-            }
         }
     }
 

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/extension-mcp/package.json
+++ b/packages/extension-mcp/package.json
@@ -60,7 +60,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23",
+    "koishi-plugin-chatluna": "^1.3.24",
     "koishi-plugin-chatluna-storage-service": "^1.0.1"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23",
+    "koishi-plugin-chatluna": "^1.3.24",
     "koishi-plugin-chatluna-storage-service": "^1.0.1"
   },
   "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -61,7 +61,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "resolutions": {
     "@langchain/core": "^0.3.80",

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "koishi": {
     "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
     "@zilliz/milvus2-sdk-node": "^2.6.2",
     "faiss-node": "^0.5.1",
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   },
   "peerDependenciesMeta": {
     "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
   },
   "peerDependencies": {
     "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.23"
+    "koishi-plugin-chatluna": "^1.3.24"
   }
 }


### PR DESCRIPTION
This pr refactors multimodal file handling configuration so the shared type is defined in platform types and consumed consistently by middleware and platform client.

## New Features

- Add per-message file size override support via `chatluna_multimodal_file_input_max_size_mb`.

## Bug fixes

See the list of fixed issues below

- Fix potential type drift by moving `FileHandlingConfig` to `platform/types` and updating imports.
- Remove stale inline-data branch in chat message reading path to keep behavior aligned with current storage fallback flow.

## Other Changes

- Re-export `FileHandlingConfig` from client module for compatibility.