### PR TITLE
feat(multimodal): 拆分开关并统一语音标签与 read_files 能力

### DIFF
--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -479,6 +479,8 @@ async function handleFileElement(
     model: string | undefined,
     elementType: 'file' | 'video' | 'audio'
 ): Promise<boolean> {
+    const displayElementType = elementType === 'audio' ? 'voice' : elementType
+
     if (elementType === 'audio' && isAudioHandled(message, element)) {
         logger.debug(
             'Skip handling audio file because audio is already handled.'
@@ -547,7 +549,7 @@ async function handleFileElement(
         if (mimeType != null && !fileConfig.supportedMimeTypes.has(mimeType)) {
             addMessageContent(
                 message,
-                `[${elementType}: ${fileName ?? 'attachment'} (skipped: unsupported MIME type "${mimeType}")]`
+                `[${displayElementType}: ${fileName ?? 'attachment'} (skipped: unsupported MIME type "${mimeType}")]`
             )
             return false
         }
@@ -567,7 +569,7 @@ async function handleFileElement(
         if (encodedSize > maxSize) {
             addMessageContent(
                 message,
-                `[${elementType}: ${fileName ?? 'attachment'} (skipped: file size ${encodedSize} bytes exceeds limit ${maxSize} bytes)]`
+                `[${displayElementType}: ${fileName ?? 'attachment'} (skipped: file size ${encodedSize} bytes exceeds limit ${maxSize} bytes)]`
             )
             return false
         }
@@ -579,7 +581,7 @@ async function handleFileElement(
         if (newTotal > fileConfig.maxTotalSizeBytes) {
             addMessageContent(
                 message,
-                `[${elementType}: ${fileName ?? 'attachment'} (skipped: total inline size would exceed limit)]`
+                `[${displayElementType}: ${fileName ?? 'attachment'} (skipped: total inline size would exceed limit)]`
             )
             return false
         }
@@ -593,10 +595,10 @@ async function handleFileElement(
 
     const label =
         elementType === 'audio'
-            ? 'Voice'
+            ? 'voice'
             : elementType === 'video'
-              ? 'Video'
-              : 'File'
+              ? 'video'
+              : 'file'
 
     let fileUrl: string
     if (ctx.chatluna_storage) {

--- a/packages/service-multimodal/src/index.ts
+++ b/packages/service-multimodal/src/index.ts
@@ -24,7 +24,11 @@ export function apply(ctx: Context, config: Config) {
 
 export interface Config extends ChatLunaPlugin.Config {
     imageModel: string
-    enableMultimodalTool: boolean
+    enableContextImageDescription: boolean
+    enableContextGifHandling: boolean
+    enableImageReadTool: boolean
+    enableGifReadTool: boolean
+    enableFileReadTool: boolean
     enableAudioFfmpegConversion: boolean
     fileInsertPrompt: string
     imagePrompt: string
@@ -35,7 +39,13 @@ export interface Config extends ChatLunaPlugin.Config {
 
 export const Config: Schema<Config> = Schema.intersect([
     Schema.object({
-        enableMultimodalTool: Schema.boolean().default(false)
+        enableContextImageDescription: Schema.boolean().default(false),
+        enableContextGifHandling: Schema.boolean().default(false)
+    }),
+    Schema.object({
+        enableImageReadTool: Schema.boolean().default(false),
+        enableGifReadTool: Schema.boolean().default(false),
+        enableFileReadTool: Schema.boolean().default(false)
     }),
     Schema.object({
         enableAudioFfmpegConversion: Schema.boolean().default(false)
@@ -77,3 +87,16 @@ export const inject = {
 }
 
 export const name = 'chatluna-multimodal-service'
+
+export const usage = `
+## chatluna-multimodal-service
+
+### 上下文图像描述服务
+为上下文中的图像提前生成文本描述，使不支持图像输入的模型可以直接在对话历史记录中看到图像对应的文本描述。
+
+### 图像及文件读取/描述工具
+允许模型调用 \`read_files\` 工具读取 URL 中的图像（如工具返回的图像 URL）、文件内容，并根据读取的内容回答用户的问题。
+
+### 注意
+建议搭配 \`chatluna-storage-service\` 使用。请求中的图像、文件大小限制遵循模型平台配置（如 Gemini：PDF 单文件 50MB、其他单文件 100MB、单轮总计 100MB，以文件被编码为 Base64 后的大小为准）。
+`

--- a/packages/service-multimodal/src/locales/en-US.schema.yml
+++ b/packages/service-multimodal/src/locales/en-US.schema.yml
@@ -1,6 +1,12 @@
 $inner:
-    - $desc: Basic Settings
-      enableMultimodalTool: 'Enable multimodal input tool. When enabled, registers file reading and image description tools for models. Supports reading files from URLs and injecting them as context for subsequent conversation rounds. If the underlying model natively supports the file type (e.g. image, audio, video, PDF, text), the content is directly added as multimodal context. Otherwise, images are described using the configured image model. Supported types depend on the model capabilities (FileHandlingConfig). For image types, GIF images are automatically split into frames. Size limits follow the model platform configuration (e.g. PDF 50MB per file, other files 100MB per file, 100MB total per request for Gemini). Recommended to use with `chatluna-storage-service`, and disable other image description tools such as "Register as image reading tool" in `chatluna-image-service` and "Image description tool" in `chatluna-forward-msg`.'
+    - $desc: Context Image Description Service
+      enableContextImageDescription: 'Enable image description in chat context.'
+      enableContextGifHandling: 'Enable GIF handling (input and description) in chat context.'
+
+    - $desc: Image/File URL Read & Describe Tool
+      enableImageReadTool: 'Enable non-GIF image read/describe capability in read_files.'
+      enableGifReadTool: 'Enable GIF read/describe capability in read_files.'
+      enableFileReadTool: 'Enable general file read capability in read_files (text, PDF, JSON, audio, video, etc., subject to model capabilities).'
 
     - $desc: Audio Conversion Settings
       enableAudioFfmpegConversion: 'Enable ffmpeg conversion for unsupported audio formats. Works like GIF handling: only audio formats not natively supported by the current model are transcoded to MP3 before input.'

--- a/packages/service-multimodal/src/locales/zh-CN.schema.yml
+++ b/packages/service-multimodal/src/locales/zh-CN.schema.yml
@@ -1,19 +1,25 @@
 $inner:
-    - $desc: 基础设置
-      enableMultimodalTool: '启用多模态输入工具。开启后，将注册文件读取和图片描述工具。支持从 URL 读取文件并注入为后续对话轮次的上下文。如果当前使用的模型原生支持该文件类型（如图片、音频、视频、PDF、文本等），内容将直接作为多模态上下文添加；否则，图片将使用配置的图片模型进行描述。支持的类型取决于模型平台的能力配置（FileHandlingConfig）。对于图片类型，GIF 图片会自动拆分为帧。大小限制遵循模型平台配置（如 Gemini：PDF 单文件 50MB、其他单文件 100MB、单轮总计 100MB，以文件被编码为 Base64 后的大小为准）。建议搭配 `chatluna-storage-service` 使用，并关闭其他图像描述工具，如 `chatluna-image-service` 的"允许注册为读图工具"和 `chatluna-forward-msg` 的"图像描述工具"。'
+    - $desc: 上下文图像描述服务设置
+      enableContextImageDescription: '是否为上下文中的图像使用图像描述服务生成并注入文本描述。仅当前模型不支持图像输入时生效。'
+      enableContextGifHandling: '是否为上下文中的 GIF 使用图像描述服务生成并注入文本描述。关闭后 GIF 将被从上下文中移除。'
+
+    - $desc: 文件读取/描述工具设置
+      enableImageReadTool: '启用 read_files 工具的图像读取/描述功能（非 GIF），若当前模型不支持图像输入，则会使用图像描述模型生成描述。若当前模型支持图像输入，建议只保留这一个图像读取工具开启，因为它能使模型自己看见图像内容，比图像描述更加精确。'
+      enableGifReadTool: '启用 read_files 工具的 GIF 描述功能。'
+      enableFileReadTool: '启用 read_files 工具的通用文件读取功能（支持纯文本、PDF、JSON、音频、视频等，具体取决于模型能力）。若模型不支持该文件类型输入，则会返回报错。'
 
     - $desc: 音频转换设置
-      enableAudioFfmpegConversion: '启用不支持音频格式的 ffmpeg 转换。行为参考 GIF 处理：仅当当前模型不原生支持该音频格式时，才会先转码为 MP3 再注入。'
+      enableAudioFfmpegConversion: '启用不支持音频格式的 ffmpeg 转换（仅当当前模型不原生支持该音频格式时，才会先转码为 MP3 再注入，主要针对语音消息）。'
 
     - $desc: 文件读取设置
-      fileInsertPrompt: 文件内容注入到上下文时的提示词。在注入的文件内容（图片、音频、视频、PDF、文本等）前面追加此提示词，用于引导模型结合文件内容回答问题。
+      fileInsertPrompt: 文件内容注入到上下文时的提示词。在注入的文件内容前面追加此提示词，用于引导模型结合文件内容回答问题。
 
-    - $desc: 图片多模态配置
-      imageModel: '选择支持图片输入的图片模型（如：gpt-4o, gemini-2.0-flash)'
-      imagePrompt: 图片输入的系统提示词。
-      imageInsertPrompt: 图片描述插入到具体消息里的提示词。
+    - $desc: 图像描述服务设置
+      imageModel: '选择支持图像输入的模型以生成图像描述（如 `gemini-3-flash-preview`、`qwen3.5-flash`、`doubao-seed-2.0-lite`）'
+      imagePrompt: 图像输入的系统提示词。
+      imageInsertPrompt: 图像描述插入到具体消息里的提示词。
       gifStrategy:
-          $desc: GIF 图片帧提取策略
+          $desc: GIF 图像帧提取策略
           $inner:
               - 只获取第一帧
               - 获取前 N 帧

--- a/packages/service-multimodal/src/plugins/audio.ts
+++ b/packages/service-multimodal/src/plugins/audio.ts
@@ -87,7 +87,7 @@ export function apply(ctx: Context, config: Config) {
                 element.attrs['chatluna_file_url'] = sourceUrl
             }
 
-            ensureContentArray(message, `[Voice:${displayFileName}]`)
+            ensureContentArray(message, `[voice:${displayFileName}]`)
             ;(message.content as MessageContentComplex[]).push({
                 type: 'audio_url',
                 audio_url: {

--- a/packages/service-multimodal/src/plugins/image.ts
+++ b/packages/service-multimodal/src/plugins/image.ts
@@ -1,12 +1,7 @@
 /* eslint-disable max-len */
-import { Tool } from '@langchain/core/tools'
 import { Context } from 'koishi'
-import { ComputedRef, Message } from 'koishi-plugin-chatluna'
-import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
-import {
-    ChatLunaToolRunnable,
-    ModelCapabilities
-} from 'koishi-plugin-chatluna/llm-core/platform/types'
+import { Message } from 'koishi-plugin-chatluna'
+import { ModelCapabilities } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Config, logger } from '..'
 import {
@@ -20,26 +15,11 @@ import {
 export async function apply(
     ctx: Context,
     config: Config,
-    plugin: ChatLunaPlugin
+    _plugin: ChatLunaPlugin
 ) {
     const imageUnderstandModel = await ctx.chatluna.createChatModel(
         config.imageModel
     )
-
-    if (config.enableMultimodalTool) {
-        plugin.registerTool('read_image', {
-            selector() {
-                return true
-            },
-            createTool() {
-                return new ReadImageTool(
-                    ctx,
-                    config,
-                    () => imageUnderstandModel
-                )
-            }
-        })
-    }
 
     const disposable = ctx.chatluna.messageTransformer.intercept(
         'img',
@@ -48,16 +28,16 @@ export async function apply(
                 model != null
                     ? ctx.chatluna.platform.findModel(model)
                     : undefined
-
-            let imageData: Awaited<ReturnType<typeof readImage>>
-            const url = (element.attrs.url ?? element.attrs.src) as string
-
-            if (
+            const modelSupportsImageInput =
                 parsedModelInfo?.value != null &&
                 parsedModelInfo.value.capabilities.includes(
                     ModelCapabilities.ImageInput
                 )
-            ) {
+
+            let imageData: Awaited<ReturnType<typeof readImage>>
+            const url = (element.attrs.url ?? element.attrs.src) as string
+
+            if (modelSupportsImageInput) {
                 imageData = await readImage(ctx, url)
 
                 if (imageData.ext == null) {
@@ -65,6 +45,10 @@ export async function apply(
                 }
 
                 if (imageData.ext === 'image/gif') {
+                    if (!config.enableContextGifHandling) {
+                        return false
+                    }
+
                     logger.debug(`image url: ${url.substring(0, 50)}...`)
                     const frames = await parseGifToFrames(imageData.buffer, {
                         strategy: config.gifStrategy,
@@ -86,6 +70,10 @@ export async function apply(
                     addImageToContent(message, imageData.base64Source)
                     return true
                 }
+            }
+
+            if (!config.enableContextImageDescription) {
+                return false
             }
 
             if (imageUnderstandModel.value == null) {
@@ -120,6 +108,10 @@ export async function apply(
                 }
 
                 if (imageData.ext === 'image/gif') {
+                    if (!config.enableContextGifHandling) {
+                        return false
+                    }
+
                     const frames = await parseGifToFrames(imageData.buffer, {
                         strategy: config.gifStrategy,
                         frameCount: config.gifFrameCount
@@ -161,95 +153,4 @@ export async function apply(
     )
 
     ctx.effect(() => disposable)
-}
-
-export class ReadImageTool extends Tool {
-    name = 'read_image'
-
-    description =
-        'Describe an image from a URL or data URI. Input should be the image URL.'
-
-    constructor(
-        private readonly ctx: Context,
-        private readonly config: Config,
-        private readonly imageModelRef: () => ComputedRef<
-            ChatLunaChatModel | undefined
-        >
-    ) {
-        super({})
-    }
-
-    /** @ignore */
-    async _call(input: string, _, _runConfig: ChatLunaToolRunnable) {
-        const url = input?.trim()
-        if (!url) {
-            return 'No image url provided.'
-        }
-
-        const model = this.imageModelRef().value
-        if (model == null) {
-            logger.warn(
-                'Image model is not loaded, please check your chat adapter.'
-            )
-            return 'Image model is not loaded. Please check your chat adapter.'
-        }
-
-        if (
-            !model.modelInfo.capabilities.includes(ModelCapabilities.ImageInput)
-        ) {
-            logger.warn('Image model does not support image input.')
-            return 'Image model does not support image input.'
-        }
-
-        try {
-            const imageData = await readImage(this.ctx, url)
-
-            if (
-                imageData.ext == null ||
-                imageData.buffer == null ||
-                imageData.base64Source == null
-            ) {
-                return `Failed to read image from ${url}.`
-            }
-
-            const fakeMessage: Message = {
-                content: []
-            }
-
-            if (imageData.ext === 'image/gif') {
-                const frames = await parseGifToFrames(imageData.buffer, {
-                    strategy: this.config.gifStrategy,
-                    frameCount: this.config.gifFrameCount
-                })
-
-                addTextToContent(
-                    fakeMessage,
-                    'This is a GIF image. See the frames below:'
-                )
-                for (const frame of frames) {
-                    addImageToContent(fakeMessage, frame)
-                }
-            } else {
-                addImageToContent(fakeMessage, imageData.base64Source)
-            }
-
-            const result = await processImageWithModel(
-                model,
-                this.config,
-                fakeMessage
-            )
-
-            if (!result) {
-                return `Failed to process image from ${url}.`
-            }
-
-            return result
-        } catch (error) {
-            logger.warn(
-                `Read image ${url} error, check your chat adapter`,
-                error
-            )
-            return `Read image ${url} error, please check your chat adapter.`
-        }
-    }
 }

--- a/packages/service-multimodal/src/plugins/read_files.ts
+++ b/packages/service-multimodal/src/plugins/read_files.ts
@@ -121,22 +121,6 @@ function inferMimeTypeFromUrl(url: string): string | null {
     return null
 }
 
-function classifyError(error: unknown): string {
-    const message =
-        error instanceof Error ? error.message.toLowerCase() : String(error)
-
-    if (message.includes('only http/https urls are supported'))
-        return 'invalid_url_scheme'
-    if (message.includes('unsupported mime type'))
-        return 'unsupported_mime_type'
-    if (message.includes('file too large')) return 'file_too_large'
-    if (message.includes('total inline upload size too large'))
-        return 'total_size_exceeded'
-    if (message.includes('feature disabled')) return 'feature_disabled'
-    if (message.includes('http ')) return 'fetch_failed'
-    return 'internal_error'
-}
-
 /**
  * Check whether the model natively supports a given MIME type based on its
  * capabilities and `FileHandlingConfig`.
@@ -294,16 +278,12 @@ export class ReadFilesTool extends StructuredTool {
         files: z
             .union([
                 z.object({
-                    url: z.string().url().refine(isHttpOrHttpsUrl, {
-                        message: 'Only http/https URLs are supported.'
-                    })
+                    url: z.string().url()
                 }),
                 z
                     .array(
                         z.object({
-                            url: z.string().url().refine(isHttpOrHttpsUrl, {
-                                message: 'Only http/https URLs are supported.'
-                            })
+                            url: z.string().url()
                         })
                     )
                     .min(1)
@@ -364,11 +344,23 @@ export class ReadFilesTool extends StructuredTool {
 
         for (const file of files) {
             const sourceUrl = file.url
+
+            const pushError = (errorMessage: string, mimeType?: string) => {
+                response.files.push({
+                    sourceUrl,
+                    mimeType,
+                    status: 'error',
+                    error: errorMessage
+                })
+                response.failureCount++
+            }
+
             try {
                 if (!isHttpOrHttpsUrl(sourceUrl)) {
-                    throw new Error(
+                    pushError(
                         'Only http/https URLs are supported for read_files.'
                     )
+                    continue
                 }
 
                 // Determine MIME type first by fetching with headers
@@ -410,15 +402,18 @@ export class ReadFilesTool extends StructuredTool {
                     responseMimeType ?? inferMimeTypeFromUrl(sourceUrl)
 
                 if (!mimeType) {
-                    throw new Error(
+                    pushError(
                         `Could not determine MIME type for ${sourceUrl}. Please ensure the URL returns a valid content type.`
                     )
+                    continue
                 }
 
                 if (!isMimeTypeEnabled(this.config, mimeType)) {
-                    throw new Error(
-                        `Feature disabled for MIME type "${mimeType}". Please enable the corresponding read_files switch.`
+                    pushError(
+                        `Feature disabled for MIME type "${mimeType}". Please enable the corresponding read_files switch.`,
+                        mimeType
                     )
+                    continue
                 }
 
                 // Check if the model supports this MIME type natively
@@ -437,15 +432,19 @@ export class ReadFilesTool extends StructuredTool {
                     const encodedSize = getBase64EncodedSize(buffer.byteLength)
 
                     if (encodedSize > maxFileSize) {
-                        throw new Error(
-                            `File too large (${encodedSize} bytes after base64), max ${maxFileSize} bytes for ${mimeType}`
+                        pushError(
+                            `File too large (${encodedSize} bytes after base64), max ${maxFileSize} bytes for ${mimeType}`,
+                            mimeType
                         )
+                        continue
                     }
 
                     if (totalBase64Bytes + encodedSize > maxTotalSize) {
-                        throw new Error(
-                            `Total inline upload size too large (${totalBase64Bytes + encodedSize} bytes), max ${maxTotalSize} bytes per request`
+                        pushError(
+                            `Total inline upload size too large (${totalBase64Bytes + encodedSize} bytes), max ${maxTotalSize} bytes per request`,
+                            mimeType
                         )
+                        continue
                     }
 
                     totalBase64Bytes += encodedSize
@@ -472,9 +471,11 @@ export class ReadFilesTool extends StructuredTool {
                     const encodedSize = getBase64EncodedSize(buffer.byteLength)
 
                     if (encodedSize > maxFileSize) {
-                        throw new Error(
-                            `File too large (${encodedSize} bytes after base64, raw ${buffer.byteLength} bytes), max ${maxFileSize} bytes for ${mimeType}`
+                        pushError(
+                            `File too large (${encodedSize} bytes after base64, raw ${buffer.byteLength} bytes), max ${maxFileSize} bytes for ${mimeType}`,
+                            mimeType
                         )
+                        continue
                     }
 
                     // For GIF: split into frames
@@ -511,9 +512,11 @@ export class ReadFilesTool extends StructuredTool {
                         }
                     } else {
                         if (totalBase64Bytes + encodedSize > maxTotalSize) {
-                            throw new Error(
-                                `Total inline upload size too large (${totalBase64Bytes + encodedSize} bytes), max ${maxTotalSize} bytes per request`
+                            pushError(
+                                `Total inline upload size too large (${totalBase64Bytes + encodedSize} bytes), max ${maxTotalSize} bytes per request`,
+                                mimeType
                             )
+                            continue
                         }
 
                         totalBase64Bytes += encodedSize
@@ -540,9 +543,11 @@ export class ReadFilesTool extends StructuredTool {
                     const encodedSize = getBase64EncodedSize(buffer.byteLength)
 
                     if (encodedSize > maxFileSize) {
-                        throw new Error(
-                            `File too large (${encodedSize} bytes after base64, raw ${buffer.byteLength} bytes), max ${maxFileSize} bytes for ${mimeType}`
+                        pushError(
+                            `File too large (${encodedSize} bytes after base64, raw ${buffer.byteLength} bytes), max ${maxFileSize} bytes for ${mimeType}`,
+                            mimeType
                         )
+                        continue
                     }
 
                     const describeResult = await this._describeImageWithModel(
@@ -561,24 +566,25 @@ export class ReadFilesTool extends StructuredTool {
                         response.successCount++
                         describedCount++
                     } else {
-                        throw new Error(
-                            `Failed to describe image from ${sourceUrl}`
+                        pushError(
+                            `Failed to describe image from ${sourceUrl}`,
+                            mimeType
                         )
+                        continue
                     }
                 } else {
                     // Non-image, model doesn't support it natively
-                    throw new Error(
-                        `Unsupported MIME type "${mimeType}" for the current model. The model does not natively support this file type.`
+                    pushError(
+                        `Unsupported MIME type "${mimeType}" for the current model. The model does not natively support this file type.`,
+                        mimeType
                     )
+                    continue
                 }
             } catch (error) {
                 logger.warn(`read_files error for ${sourceUrl}:`, error)
-                response.files.push({
-                    sourceUrl,
-                    status: 'error',
-                    error: classifyError(error)
-                })
-                response.failureCount++
+                const errorMessage =
+                    error instanceof Error ? error.message : String(error)
+                pushError(errorMessage)
             }
         }
 

--- a/packages/service-multimodal/src/plugins/read_files.ts
+++ b/packages/service-multimodal/src/plugins/read_files.ts
@@ -110,17 +110,7 @@ function inferMimeTypeFromPath(path: string): string | null {
     return FILE_EXTENSION_TO_MIME_TYPE.get(extension) ?? null
 }
 
-function inferMimeTypeFromNameOrUrl(
-    name: string | undefined,
-    url: string
-): string | null {
-    if (name != null && name.trim().length > 0) {
-        const mimeTypeFromName = inferMimeTypeFromPath(name)
-        if (mimeTypeFromName != null) {
-            return mimeTypeFromName
-        }
-    }
-
+function inferMimeTypeFromUrl(url: string): string | null {
     try {
         const pathname = new URL(url).pathname
         return inferMimeTypeFromPath(pathname)
@@ -142,6 +132,7 @@ function classifyError(error: unknown): string {
     if (message.includes('file too large')) return 'file_too_large'
     if (message.includes('total inline upload size too large'))
         return 'total_size_exceeded'
+    if (message.includes('feature disabled')) return 'feature_disabled'
     if (message.includes('http ')) return 'fetch_failed'
     return 'internal_error'
 }
@@ -181,6 +172,45 @@ function modelSupportsNativeMimeType(
     }
 
     return true
+}
+
+function isMimeTypeEnabled(config: Config, mimeType: string): boolean {
+    if (mimeType === 'image/gif') {
+        return config.enableGifReadTool
+    }
+
+    if (IMAGE_MIME_TYPES.has(mimeType)) {
+        return config.enableImageReadTool
+    }
+
+    return config.enableFileReadTool
+}
+
+function buildReadFilesDescription(config: Config): string {
+    const sections: string[] = []
+
+    if (config.enableImageReadTool) {
+        sections.push(
+            '- Image read/describe (non-GIF): image/bmp, image/jpeg, image/png, image/webp. If the model lacks native image input, fallback image description will be used.'
+        )
+    }
+
+    if (config.enableGifReadTool) {
+        sections.push(
+            '- GIF read/describe: image/gif. Native-capable models receive extracted frames; otherwise fallback image description is used.'
+        )
+    }
+
+    if (config.enableFileReadTool) {
+        sections.push(
+            '- File read: text/html, text/css, text/plain, text/markdown, text/xml, text/csv, text/rtf, text/javascript, application/json, application/pdf, audio/*, video/* (effective MIME set still depends on model capabilities and FileHandlingConfig).'
+        )
+    }
+
+    return `Read files from URL(s) and return their content.
+Enabled read_files capabilities:
+${sections.join('\n')}
+Use this tool when you need to read files from URL(s) as context.`
 }
 
 /**
@@ -258,21 +288,12 @@ function buildMultimodalMessage(
 
 export class ReadFilesTool extends StructuredTool {
     name = 'read_files'
-
-    description = `Read files from URL(s) and return their content. Each file supports an name for MIME type inference when URL extension is unavailable. If the current model natively supports the file type, the content is injected as multimodal context for the next conversation turn. Otherwise, images are described using a vision model.
-Supported file types depend on the model. Common types include:
-- Text: text/html, text/css, text/plain, text/markdown, text/xml, text/csv, text/rtf, text/javascript
-- Application: application/json, application/pdf
-- Image: image/bmp, image/jpeg, image/png, image/webp, image/gif
-- Audio: audio/mpeg, audio/mp3, audio/aiff, audio/aac, audio/flac, audio/wav, audio/webm, audio/ogg, audio/mp4
-- Video: video/mp4, video/mpeg, video/mov, video/avi, video/x-flv, video/mpg, video/webm, video/wmv, video/3gpp
-Use this tool when you need to read files from URL(s) as context.`
+    description: string
 
     schema = z.object({
         files: z
             .union([
                 z.object({
-                    name: z.string(),
                     url: z.string().url().refine(isHttpOrHttpsUrl, {
                         message: 'Only http/https URLs are supported.'
                     })
@@ -280,7 +301,6 @@ Use this tool when you need to read files from URL(s) as context.`
                 z
                     .array(
                         z.object({
-                            name: z.string().optional(),
                             url: z.string().url().refine(isHttpOrHttpsUrl, {
                                 message: 'Only http/https URLs are supported.'
                             })
@@ -290,7 +310,7 @@ Use this tool when you need to read files from URL(s) as context.`
                     .max(10)
             ])
             .describe(
-                'One file or a list of files to read (max 10). File format: { name: string, url: string }. MIME type is inferred from response headers, then name/url extension.'
+                'One file or a list of files to read (max 10). File format: { url: string }. MIME type is inferred from response headers, then URL extension.'
             )
     })
 
@@ -302,6 +322,7 @@ Use this tool when you need to read files from URL(s) as context.`
         >
     ) {
         super({})
+        this.description = buildReadFilesDescription(config)
     }
 
     async _call(
@@ -343,7 +364,6 @@ Use this tool when you need to read files from URL(s) as context.`
 
         for (const file of files) {
             const sourceUrl = file.url
-            const sourceName = file.name?.trim() || undefined
             try {
                 if (!isHttpOrHttpsUrl(sourceUrl)) {
                     throw new Error(
@@ -387,12 +407,17 @@ Use this tool when you need to read files from URL(s) as context.`
                 }
 
                 const mimeType =
-                    responseMimeType ??
-                    inferMimeTypeFromNameOrUrl(sourceName, sourceUrl)
+                    responseMimeType ?? inferMimeTypeFromUrl(sourceUrl)
 
                 if (!mimeType) {
                     throw new Error(
                         `Could not determine MIME type for ${sourceUrl}. Please ensure the URL returns a valid content type.`
+                    )
+                }
+
+                if (!isMimeTypeEnabled(this.config, mimeType)) {
+                    throw new Error(
+                        `Feature disabled for MIME type "${mimeType}". Please enable the corresponding read_files switch.`
                     )
                 }
 
@@ -659,7 +684,13 @@ export async function apply(
     config: Config,
     plugin: ChatLunaPlugin
 ) {
-    if (!config.enableMultimodalTool) return
+    if (
+        !config.enableImageReadTool &&
+        !config.enableGifReadTool &&
+        !config.enableFileReadTool
+    ) {
+        return
+    }
 
     const imageUnderstandModel = await ctx.chatluna.createChatModel(
         config.imageModel


### PR DESCRIPTION
## 变更摘要
- 拆分 `enableMultimodalTool` 为上下文描述与 `read_files` 工具能力开关。
- 移除 `read_image` 工具，统一由 `read_files` 承担文件/图像读取与描述。
- `read_files` 改为按开关动态描述能力，并在能力关闭时返回 `feature_disabled`。
- 统一语音标签为小写 `voice`（包括 core 与 multimodal audio fallback 文本）。
- `read_files` 入参移除 `name` 字段，仅保留 `url`，MIME 推断改为“响应头 + URL 后缀”。
- 调整中英文 schema 文案与 usage 说明，默认值改为相关开关默认关闭。

## 兼容性说明
- 配置项 `enableMultimodalTool` 被替换为：
  - `enableContextImageDescription`
  - `enableContextGifHandling`
  - `enableImageReadTool`
  - `enableGifReadTool`
  - `enableFileReadTool`
- `read_files` 参数从 `{ name, url }` / `[{ name, url }]` 调整为 `{ url }` / `[{ url }]`。

## 验证
- `yarn yakumo build core service-multimodal`
