### PR TITLE
[Fix] normalize multimodal agent observations

### DIFF
--- a/packages/adapter-gemini/src/client.ts
+++ b/packages/adapter-gemini/src/client.ts
@@ -101,13 +101,7 @@ export class GeminiClient extends PlatformModelAndEmbeddingsClient<ClientConfig>
         maxFileSizeBytes: 100 * 1024 * 1024,
         maxFileSizeBytesOverrides: {
             'application/pdf': 50 * 1024 * 1024
-        },
-        legacyStorageMimeTypes: new Set<string>([
-            'application/pdf',
-            'text/plain',
-            'text/markdown'
-        ]),
-        supportsInlineData: true
+        }
     }
 
     getFileHandlingConfig(): FileHandlingConfig {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -175,7 +175,7 @@ async function processFunctionMessage(
                   name: message.name,
                   parts: await processGeminiContentParts(
                       plugin,
-                      message.content as MessageContentComplex[]
+                      message.content
                   )
               }
             : {

--- a/packages/core/src/llm-core/agent/executor.ts
+++ b/packages/core/src/llm-core/agent/executor.ts
@@ -37,6 +37,10 @@ import {
 } from 'koishi-plugin-chatluna/llm-core/chain/base'
 import { Serializable } from '@langchain/core/load/serializable'
 import { logger } from 'koishi-plugin-chatluna'
+import {
+    isMessageContentComplex,
+    isMessageContentText
+} from 'koishi-plugin-chatluna/utils/langchain'
 
 interface AgentExecutorIteratorInput {
     agentExecutor: AgentExecutor
@@ -340,7 +344,7 @@ export class ExceptionTool extends Tool {
     }
 }
 
-function isSupportedObservation(value: unknown): value is AgentObservation {
+function isAgentObservation(value: unknown): value is AgentObservation {
     if (typeof value === 'string') {
         return true
     }
@@ -349,16 +353,20 @@ function isSupportedObservation(value: unknown): value is AgentObservation {
         return false
     }
 
-    return value.every(
-        (item) => item != null && typeof item === 'object' && 'type' in item
-    )
+    return value.every((item) => isMessageContentComplex(item))
 }
 
-function normalizeObservation(
+function coerceToAgentObservation(
     observation: unknown,
     toolName?: string
 ): AgentObservation {
-    if (isSupportedObservation(observation)) {
+    if (isAgentObservation(observation)) {
+        if (
+            Array.isArray(observation) &&
+            observation.every(isMessageContentText)
+        ) {
+            return observation.map((item) => item.text).join('')
+        }
         return observation
     }
 
@@ -576,7 +584,9 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                     let text = e.message
                     if (this.handleParsingErrors === true) {
                         if (e.sendToLLM) {
-                            observation = normalizeObservation(e.observation)
+                            observation = coerceToAgentObservation(
+                                e.observation
+                            )
                             text = e.llmOutput ?? ''
                         } else {
                             observation = 'Invalid or incomplete response'
@@ -622,7 +632,7 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                     let observation: AgentObservation = ''
                     try {
                         observation = tool
-                            ? normalizeObservation(
+                            ? coerceToAgentObservation(
                                   await tool.invoke(
                                       action.toolInput,
                                       patchConfig(config, {
@@ -657,10 +667,11 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                             )
                             return {
                                 action,
-                                observation: normalizeObservation(observation)
+                                observation:
+                                    coerceToAgentObservation(observation)
                             }
                         } else if (this.handleToolRuntimeErrors !== undefined) {
-                            observation = normalizeObservation(
+                            observation = coerceToAgentObservation(
                                 this.handleToolRuntimeErrors(e)
                             )
                         }
@@ -670,7 +681,10 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                         action,
                         observation:
                             observation != null
-                                ? normalizeObservation(observation, tool?.name)
+                                ? coerceToAgentObservation(
+                                      observation,
+                                      tool?.name
+                                  )
                                 : ''
                     }
                 })
@@ -734,7 +748,7 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                 let text = e.message
                 if (this.handleParsingErrors === true) {
                     if (e.sendToLLM) {
-                        observation = normalizeObservation(e.observation)
+                        observation = coerceToAgentObservation(e.observation)
                         text = e.llmOutput ?? ''
                     } else {
                         observation = 'Invalid or incomplete response'
@@ -779,7 +793,7 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
             if (agentAction.tool in nameToolMap) {
                 const tool = nameToolMap[agentAction.tool]
                 try {
-                    observation = normalizeObservation(
+                    observation = coerceToAgentObservation(
                         await tool.invoke(
                             agentAction.toolInput,
                             runManager?.getChild()
@@ -798,7 +812,7 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                         } else if (
                             typeof this.handleParsingErrors === 'function'
                         ) {
-                            observation = normalizeObservation(
+                            observation = coerceToAgentObservation(
                                 this.handleParsingErrors(e)
                             )
                         } else {
@@ -821,7 +835,7 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
             }
             result.push({
                 action: agentAction,
-                observation: normalizeObservation(observation)
+                observation: coerceToAgentObservation(observation)
             })
         }
         return result

--- a/packages/core/src/llm-core/agent/types.ts
+++ b/packages/core/src/llm-core/agent/types.ts
@@ -6,6 +6,11 @@ import type {
     MessageContentText
 } from '@langchain/core/messages'
 import type { ChainValues } from '@langchain/core/utils/types'
+import type {
+    MessageContentAudio,
+    MessageContentFileUrl,
+    MessageContentVideo
+} from 'koishi-plugin-chatluna/utils/langchain'
 
 export interface ChatCompletionMessageToolCall {
     /**
@@ -251,9 +256,14 @@ export type AgentFinish = {
     log: string
 }
 
-export type AgentObservation =
-    | (MessageContentImageUrl | MessageContentText)[]
-    | string
+export type AgentObservationComplexContent =
+    | MessageContentImageUrl
+    | MessageContentText
+    | MessageContentFileUrl
+    | MessageContentAudio
+    | MessageContentVideo
+
+export type AgentObservation = AgentObservationComplexContent[] | string
 
 export type AgentStep = {
     action: AgentAction

--- a/packages/core/src/utils/langchain.ts
+++ b/packages/core/src/utils/langchain.ts
@@ -41,6 +41,22 @@ export function isMessageContentVideo(
     return message.type === 'video_url' && message['video_url'] != null
 }
 
+export function isMessageContentComplex(
+    value: unknown
+): value is MessageContentComplex {
+    if (value == null || typeof value !== 'object') {
+        return false
+    }
+    const item = value as MessageContentComplex
+    return (
+        isMessageContentText(item) ||
+        isMessageContentImageUrl(item) ||
+        isMessageContentFileUrl(item) ||
+        isMessageContentAudio(item) ||
+        isMessageContentVideo(item)
+    )
+}
+
 function isMessageContentUrlPart(
     message: MessageContentComplex
 ): message is MessageContentUrlPart {


### PR DESCRIPTION
This pr improves multimodal tool observation handling and aligns Gemini adapter content processing for tool-calling flows.

## New Features

- Expand agent observation complex content support to include file, audio, and video blocks.

## Bug fixes

- Fix observation coercion by validating message content blocks and converting text-only arrays to plain strings.
- Fix Gemini function message processing by accepting generic message content without unsafe casting.
- Remove legacy Gemini file storage flags that are no longer needed in current handling logic.

## Other Changes

- Add reusable `isMessageContentComplex` type guard in core langchain utilities.
- Rename observation helper methods for clearer intent (`isAgentObservation`, `coerceToAgentObservation`).