### PR TITLE
[Feature] Improve agent output parsing with message content extraction

### DIFF
--- a/packages/core/src/llm-core/agent/openai/output_parser.ts
+++ b/packages/core/src/llm-core/agent/openai/output_parser.ts
@@ -13,6 +13,7 @@ import {
     ChatCompletionMessageFunctionCall,
     ChatCompletionMessageToolCall
 } from '../types'
+import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 
 /**
  * Type that represents an agent action with an optional message log.
@@ -60,35 +61,36 @@ export class OpenAIFunctionsAgentOutputParser extends AgentActionOutputParser {
                 'This agent cannot parse non-string model responses.'
             )
         }
-        if (message.additional_kwargs.function_call) {
-            // eslint-disable-next-line prefer-destructuring, @typescript-eslint/naming-convention
-            const function_call: ChatCompletionMessageFunctionCall =
-                message.additional_kwargs.function_call
-            try {
-                const toolInput = function_call.arguments
-                    ? JSON.parse(function_call.arguments)
-                    : {}
-                return {
-                    tool: function_call.name as string,
-                    toolInput,
-                    log:
-                        message.content?.length > 0
-                            ? (message.content as string)
-                            : `Invoking "${function_call.name}" with ${
-                                  function_call.arguments ?? '{}'
-                              }`,
-                    messageLog: [message]
-                }
-            } catch (error) {
-                throw new OutputParserException(
-                    `Failed to parse function arguments from chat model response. Text: "${function_call.arguments}". ${error}`
-                )
-            }
-        } else {
+
+        // eslint-disable-next-line prefer-destructuring, @typescript-eslint/naming-convention
+        const function_call: ChatCompletionMessageFunctionCall =
+            message.additional_kwargs.function_call
+
+        if (!function_call) {
             return {
                 returnValues: { output: message.content, message },
                 log: message.content as string
             }
+        }
+
+        try {
+            const toolInput = function_call.arguments
+                ? JSON.parse(function_call.arguments)
+                : {}
+            const content = getMessageContent(message.content)
+            return {
+                tool: function_call.name,
+                toolInput,
+                log:
+                    content?.length > 0
+                        ? content
+                        : `Invoking "${function_call.name}" with ${function_call.arguments ?? '{}'}`,
+                messageLog: [message]
+            }
+        } catch (error) {
+            throw new OutputParserException(
+                `Failed to parse function arguments from chat model response. Text: "${function_call.arguments}". ${error}`
+            )
         }
     }
 
@@ -151,83 +153,67 @@ export class OpenAIToolsAgentOutputParser extends AgentMultiActionOutputParser {
             )
         }
 
-        if (
-            message.additional_kwargs.tool_calls &&
-            Array.isArray(message.additional_kwargs.tool_calls) &&
-            message.additional_kwargs.tool_calls.length > 0
-        ) {
-            const toolCalls: ChatCompletionMessageToolCall[] = message
-                .additional_kwargs.tool_calls as ChatCompletionMessageToolCall[]
+        const agentFinish: AgentFinish = {
+            returnValues: { output: message.content },
+            log: message.content as string
+        }
+
+        const { tool_calls: rawToolCalls } = message.additional_kwargs
+        if (Array.isArray(rawToolCalls) && rawToolCalls.length > 0) {
+            const toolCalls = rawToolCalls as ChatCompletionMessageToolCall[]
             try {
                 return toolCalls.map((toolCall, i) => {
-                    const toolInput = toolCall.function.arguments
-                        ? JSON.parse(toolCall.function.arguments)
-                        : {}
-                    const messageLog = i === 0 ? [message] : []
+                    const content = getMessageContent(message.content)
                     return {
-                        tool: toolCall.function.name as string,
-                        toolInput,
+                        tool: toolCall.function.name,
+                        toolInput: toolCall.function.arguments
+                            ? JSON.parse(toolCall.function.arguments)
+                            : {},
                         toolCallId: toolCall.id,
                         log:
-                            message.content?.length > 0
-                                ? (message.content as string)
-                                : `Invoking "${toolCall.function.name}" with ${
-                                      toolCall.function.arguments ?? '{}'
-                                  }`,
-                        messageLog
+                            content?.length > 0
+                                ? content
+                                : `Invoking "${toolCall.function.name}" with ${toolCall.function.arguments ?? '{}'}`,
+                        messageLog: i === 0 ? [message] : [],
+                        content: message.content
                     }
                 })
             } catch (error) {
                 throw new OutputParserException(
-                    `Failed to parse tool arguments from chat model response. Text: "${JSON.stringify(
-                        toolCalls
-                    )}". ${error}`
+                    `Failed to parse tool arguments from chat model response. Text: "${JSON.stringify(toolCalls)}". ${error}`
                 )
-            }
-        } else if (
-            (message instanceof AIMessageChunk ||
-                message instanceof AIMessage) &&
-            message.tool_calls != null
-        ) {
-            const toolCalls = message.tool_calls
-
-            if (toolCalls.length < 1) {
-                return {
-                    returnValues: { output: message.content },
-                    log: message.content as string
-                }
-            }
-
-            try {
-                return toolCalls.map((toolCall, i) => {
-                    const toolInput = toolCall.args
-                    const messageLog = i === 0 ? [message] : []
-                    return {
-                        tool: toolCall.name as string,
-                        toolInput,
-                        toolCallId: toolCall.id /* ?? `tool_call_${i}` */,
-                        log:
-                            message.content?.length > 0
-                                ? (message.content as string)
-                                : `Invoking "${toolCall.name}" with ${
-                                      JSON.stringify(toolCall.args) ?? '{}'
-                                  }`,
-                        messageLog
-                    }
-                })
-            } catch (error) {
-                throw new OutputParserException(
-                    `Failed to parse tool arguments from chat model response. Text: "${JSON.stringify(
-                        toolCalls
-                    )}". ${error}`
-                )
-            }
-        } else {
-            return {
-                returnValues: { output: message.content },
-                log: message.content as string
             }
         }
+
+        if (
+            (message instanceof AIMessageChunk ||
+                message instanceof AIMessage) &&
+            message.tool_calls?.length > 0
+        ) {
+            const { tool_calls: toolCalls } = message
+            try {
+                return toolCalls.map((toolCall, i) => {
+                    const content = getMessageContent(message.content)
+                    return {
+                        tool: toolCall.name,
+                        toolInput: toolCall.args,
+                        toolCallId: toolCall.id,
+                        log:
+                            content?.length > 0
+                                ? content
+                                : `Invoking "${toolCall.name}" with ${JSON.stringify(toolCall.args) ?? '{}'}`,
+                        messageLog: i === 0 ? [message] : [],
+                        content: message.content
+                    }
+                })
+            } catch (error) {
+                throw new OutputParserException(
+                    `Failed to parse tool arguments from chat model response. Text: "${JSON.stringify(toolCalls)}". ${error}`
+                )
+            }
+        }
+
+        return agentFinish
     }
 
     getFormatInstructions(): string {

--- a/packages/core/src/llm-core/agent/openai/output_parser.ts
+++ b/packages/core/src/llm-core/agent/openai/output_parser.ts
@@ -5,10 +5,12 @@ import {
     isBaseMessage
 } from '@langchain/core/messages'
 import { ChatGeneration } from '@langchain/core/outputs'
-import { AgentAction, AgentFinish, AgentStep } from '@langchain/core/agents'
+import { AgentStep } from '@langchain/core/agents'
 import { OutputParserException } from '@langchain/core/output_parsers'
 import {
+    AgentAction,
     AgentActionOutputParser,
+    AgentFinish,
     AgentMultiActionOutputParser,
     ChatCompletionMessageFunctionCall,
     ChatCompletionMessageToolCall
@@ -85,7 +87,8 @@ export class OpenAIFunctionsAgentOutputParser extends AgentActionOutputParser {
                     content?.length > 0
                         ? content
                         : `Invoking "${function_call.name}" with ${function_call.arguments ?? '{}'}`,
-                messageLog: [message]
+                messageLog: [message],
+                content: message.content
             }
         } catch (error) {
             throw new OutputParserException(
@@ -147,23 +150,17 @@ export class OpenAIToolsAgentOutputParser extends AgentMultiActionOutputParser {
      * @returns A ToolsAgentAction[] or AgentFinish object.
      */
     parseAIMessage(message: BaseMessage): ToolsAgentAction[] | AgentFinish {
-        if (message.content && typeof message.content !== 'string') {
-            throw new Error(
-                'This agent cannot parse non-string model responses.'
-            )
-        }
-
         const agentFinish: AgentFinish = {
             returnValues: { output: message.content },
             log: message.content as string
         }
 
+        const content = getMessageContent(message.content)
         const { tool_calls: rawToolCalls } = message.additional_kwargs
         if (Array.isArray(rawToolCalls) && rawToolCalls.length > 0) {
             const toolCalls = rawToolCalls as ChatCompletionMessageToolCall[]
             try {
                 return toolCalls.map((toolCall, i) => {
-                    const content = getMessageContent(message.content)
                     return {
                         tool: toolCall.function.name,
                         toolInput: toolCall.function.arguments
@@ -193,7 +190,6 @@ export class OpenAIToolsAgentOutputParser extends AgentMultiActionOutputParser {
             const { tool_calls: toolCalls } = message
             try {
                 return toolCalls.map((toolCall, i) => {
-                    const content = getMessageContent(message.content)
                     return {
                         tool: toolCall.name,
                         toolInput: toolCall.args,

--- a/packages/core/src/llm-core/agent/types.ts
+++ b/packages/core/src/llm-core/agent/types.ts
@@ -2,6 +2,7 @@ import type { Runnable } from '@langchain/core/runnables'
 import { BaseOutputParser } from '@langchain/core/output_parsers'
 import type {
     BaseMessage,
+    MessageContent,
     MessageContentImageUrl,
     MessageContentText
 } from '@langchain/core/messages'
@@ -249,6 +250,7 @@ export type AgentAction = {
     toolInput: string | Record<string, any>
     toolCallId?: string
     log: string
+    content?: MessageContent
 }
 export type AgentFinish = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## Summary

This PR improves the agent output parsers by refactoring control flow for clarity and adding `getMessageContent` utility to properly extract message content from model responses.

## New Features

- Added `content` field to `AgentAction` type to preserve original message content through the agent pipeline
- Use `getMessageContent` utility to robustly extract string content from `MessageContent` (which can be string or structured content array)

## Bug Fixes

- Fixed content extraction in `OpenAIFunctionsAgentOutputParser` and `OpenAIToolsAgentOutputParser` that previously cast `message.content` directly to string, which could fail for structured content arrays

## Other Changes

- Refactored `OpenAIFunctionsAgentOutputParser.parse` to use early-return pattern for cleaner control flow
- Refactored `OpenAIToolsAgentOutputParser.parse` to reduce nesting and deduplicate agent finish logic
- Simplified tool call mapping with inline destructuring and expressions
- Imported `MessageContent` type in `agent/types.ts`