### PR TITLE
[Fix] Add optional chaining for message type check in QQ markdown handler

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna",
   "description": "chatluna for koishi",
-  "version": "1.3.30",
+  "version": "1.3.31",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/core/src/chains/chain.ts
+++ b/packages/core/src/chains/chain.ts
@@ -725,7 +725,7 @@ class DefaultChatChainSender {
 
         if (
             isElementArray(messages?.[0]) &&
-            messages[0][1].type === 'markdown-qq'
+            messages[0][1]?.type === 'markdown-qq'
         ) {
             await this.sendAsQQMarkdown(session, messages[0][0])
             return


### PR DESCRIPTION
$(cat <<'EOF'