### PR TITLE
fix(core): await QQ markdown private message send

### DIFF
--- a/packages/core/src/chains/chain.ts
+++ b/packages/core/src/chains/chain.ts
@@ -749,7 +749,7 @@ class DefaultChatChainSender {
     ): Promise<void> {
         const { user } = session.event
         // only support private
-        ;(session.bot as QQBot<Context>).internal.sendPrivateMessage(user.id, {
+        await (session.bot as QQBot<Context>).internal.sendPrivateMessage(user.id, {
             msg_type: 2,
             msg_seq: 1,
             msg_id: session.messageId,


### PR DESCRIPTION
## 概述

- 为 QQ 私聊 markdown 发送补上 `await`，确保 `sendAsQQMarkdown()` 在底层发送请求完成后再返回。
- 让该分支的发送时序与同文件中的 `sendQueued()`、其他消息发送链路保持一致。
- 避免 `internal.sendPrivateMessage()` 的 Promise 未被等待，导致发送错误无法沿当前调用链正确传播。

## 验证

- 代码检查：`@satorijs/adapter-qq` 中 `internal.sendPrivateMessage()` 返回 `Promise`
- 对比现有实现：同文件其他发送路径与 `chatluna-character` 中对应 QQ 私聊 markdown 发送均使用 `await`
