### PR TITLE
fix(core): 补充 QQ 官方附件消息转换

### DIFF
--- a/packages/adapter-spark/src/types.ts
+++ b/packages/adapter-spark/src/types.ts
@@ -155,7 +155,7 @@ export type ChatCompletionToolChoice =
           tools: {
               type: 'function'
               name: string
-          }>
+          }[]
       }
 
 export interface ChatCompletionResponseFormat {

--- a/packages/core/src/middlewares/chat/read_chat_message.ts
+++ b/packages/core/src/middlewares/chat/read_chat_message.ts
@@ -21,6 +21,7 @@ import {
 } from 'koishi-plugin-chatluna/utils/koishi'
 import { parseRawModelName } from 'koishi-plugin-chatluna/llm-core/utils/count_tokens'
 import { getBase64EncodedSize } from 'koishi-plugin-chatluna/utils/base64'
+import type { QQ } from '@koishijs/plugin-adapter-qq'
 
 const CHATLUNA_DOWNLOAD_USER_AGENT =
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36'
@@ -100,6 +101,10 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         })
 
         .after('resolve_room')
+
+    ctx.chatluna.messageTransformer.before(async (session, elements) => {
+        appendQQAttachments(session, elements)
+    })
 
     ctx.chatluna.messageTransformer.intercept(
         'text',
@@ -820,6 +825,66 @@ function trackForwardId(element: h, message: Message) {
 interface ForwardHistoryState {
     ids: string[]
     hasForwardHistory: boolean
+}
+
+function appendQQAttachments(session: Session, elements: h[]) {
+    if (session.platform !== 'qq') {
+        return
+    }
+
+    const qq = session.qq as QQ.Payload
+
+    // wtf this
+    const attachments = qq?.['d']?.attachments
+    if (!attachments?.length) {
+        return
+    }
+
+    for (const attachment of attachments) {
+        const type = attachment.content_type
+        const src = attachment.url
+        const exists = elements.some(
+            (element) => element.attrs.src === src || element.attrs.url === src
+        )
+
+        if (exists) {
+            continue
+        }
+
+        if (type === 'file') {
+            elements.push(
+                h.file(src, {
+                    filename: attachment.filename
+                })
+            )
+        } else if (type.startsWith('audio/')) {
+            elements.push(
+                h.audio(src, {
+                    filename: attachment.filename,
+                    type,
+                    chatluna_file_url: src
+                })
+            )
+        } else if (type === 'voice') {
+            elements.push(
+                h.audio(src, {
+                    filename: attachment.filename,
+                    type,
+                    chatluna_file_url: src
+                })
+            )
+        } else if (type.startsWith('video/')) {
+            elements.push(
+                h.video(src, {
+                    filename: attachment.filename,
+                    width: attachment.width,
+                    height: attachment.height,
+                    type,
+                    chatluna_file_url: src
+                })
+            )
+        }
+    }
 }
 
 // #endregion

--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -36,6 +36,59 @@ export class MessageTransformer {
             includeQuoteReply: true
         }
     ): Promise<Message> {
+        if (session.platform === 'qq') {
+            const qq = (session as any).qq
+            const attachments = qq?.d?.attachments
+            if (attachments?.length) {
+                for (const attachment of attachments) {
+                    const type = attachment.content_type
+                    const src = attachment.url
+                    const exists = elements.some(
+                        (element) =>
+                            element.attrs.src === src || element.attrs.url === src
+                    )
+
+                    if (exists) {
+                        continue
+                    }
+
+                    if (type === 'file') {
+                        elements.push(
+                            h.file(src, {
+                                filename: attachment.filename
+                            })
+                        )
+                    } else if (type.startsWith('audio/')) {
+                        elements.push(
+                            h.audio(src, {
+                                filename: attachment.filename,
+                                type,
+                                chatluna_file_url: src
+                            })
+                        )
+                    } else if (type === 'voice') {
+                        elements.push(
+                            h.audio(src, {
+                                filename: attachment.filename,
+                                type,
+                                chatluna_file_url: src
+                            })
+                        )
+                    } else if (type.startsWith('video/')) {
+                        elements.push(
+                            h.video(src, {
+                                filename: attachment.filename,
+                                width: attachment.width,
+                                height: attachment.height,
+                                type,
+                                chatluna_file_url: src
+                            })
+                        )
+                    }
+                }
+            }
+        }
+
         const sourceElementString = elements.map((h) => h.toString(true)).join()
         const quoteElementString = (
             (session.quote && session.quote.elements) ??

--- a/packages/core/src/services/message_transform.ts
+++ b/packages/core/src/services/message_transform.ts
@@ -16,7 +16,20 @@ interface TransformFunctionWithPriority {
     priority: number
 }
 
+interface BeforeTransformFunctionWithPriority {
+    func: BeforeMessageTransformFunction
+    priority: number
+}
+
+export interface MessageTransformOptions {
+    quote: boolean
+    includeQuoteReply: boolean
+}
+
 export class MessageTransformer {
+    private _beforeTransformFunctions: BeforeTransformFunctionWithPriority[] =
+        []
+
     private _transformFunctions: Map<string, TransformFunctionWithPriority[]> =
         new Map()
 
@@ -31,63 +44,18 @@ export class MessageTransformer {
             name: session.username,
             additional_kwargs: {}
         },
-        options = {
+        options: MessageTransformOptions = {
             quote: false,
             includeQuoteReply: true
         }
     ): Promise<Message> {
-        if (session.platform === 'qq') {
-            const qq = (session as any).qq
-            const attachments = qq?.d?.attachments
-            if (attachments?.length) {
-                for (const attachment of attachments) {
-                    const type = attachment.content_type
-                    const src = attachment.url
-                    const exists = elements.some(
-                        (element) =>
-                            element.attrs.src === src || element.attrs.url === src
-                    )
-
-                    if (exists) {
-                        continue
-                    }
-
-                    if (type === 'file') {
-                        elements.push(
-                            h.file(src, {
-                                filename: attachment.filename
-                            })
-                        )
-                    } else if (type.startsWith('audio/')) {
-                        elements.push(
-                            h.audio(src, {
-                                filename: attachment.filename,
-                                type,
-                                chatluna_file_url: src
-                            })
-                        )
-                    } else if (type === 'voice') {
-                        elements.push(
-                            h.audio(src, {
-                                filename: attachment.filename,
-                                type,
-                                chatluna_file_url: src
-                            })
-                        )
-                    } else if (type.startsWith('video/')) {
-                        elements.push(
-                            h.video(src, {
-                                filename: attachment.filename,
-                                width: attachment.width,
-                                height: attachment.height,
-                                type,
-                                chatluna_file_url: src
-                            })
-                        )
-                    }
-                }
-            }
-        }
+        await this._runBeforeTransform(
+            session,
+            elements,
+            message,
+            model,
+            options
+        )
 
         const sourceElementString = elements.map((h) => h.toString(true)).join()
         const quoteElementString = (
@@ -191,6 +159,35 @@ export class MessageTransformer {
         }
 
         return message
+    }
+
+    before(
+        transformFunction: BeforeMessageTransformFunction,
+        priority: number = 0
+    ) {
+        const wrapper: BeforeTransformFunctionWithPriority = {
+            func: transformFunction,
+            priority
+        }
+
+        const insertIndex = this._beforeTransformFunctions.findIndex(
+            (item) => item.priority > priority
+        )
+
+        if (insertIndex === -1) {
+            this._beforeTransformFunctions.push(wrapper)
+        } else {
+            this._beforeTransformFunctions.splice(insertIndex, 0, wrapper)
+        }
+
+        return () => {
+            const index = this._beforeTransformFunctions.findIndex(
+                (item) => item.func === transformFunction
+            )
+            if (index === -1) return
+
+            this._beforeTransformFunctions.splice(index, 1)
+        }
     }
 
     intercept(
@@ -328,7 +325,28 @@ export class MessageTransformer {
             })
         }
     }
+
+    private async _runBeforeTransform(
+        session: Session,
+        elements: h[],
+        message: Message,
+        model: string,
+        options: MessageTransformOptions
+    ) {
+        for (const { func: transformFunction } of this
+            ._beforeTransformFunctions) {
+            await transformFunction(session, elements, message, model, options)
+        }
+    }
 }
+
+export type BeforeMessageTransformFunction = (
+    session: Session,
+    elements: h[],
+    message: Message,
+    model?: string,
+    options?: MessageTransformOptions
+) => Promise<void>
 
 export type MessageTransformFunction = (
     session: Session,


### PR DESCRIPTION
## 概要
- 兼容 QQ 官方 Bot 私聊附件消息，将 `attachments` 中的 `video/*`、`audio/*`、`file` 转换为 ChatLuna 可处理的 Koishi 元素。
- 为音频和视频补充 `chatluna_file_url`，让下游多模态插件可以直接复用现有文件处理链路。

## 验证
- 在本地 Koishi 实例中发送 QQ 官方私聊直接视频，确认消息转换后可被 `chatluna-character` 正常识别。
