### PR TITLE
Refactor: Migrate to LangChain UsageMetadata and improve agent executor event flow

### DIFF
--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -28,13 +28,13 @@ import {
     ChatMessagePart,
     ChatPart,
     ChatResponse,
-    GeminiUsageMetadata,
     ChatUsageMetadataPart,
     CreateEmbeddingResponse,
     GeminiModelInfo
 } from './types'
 import {
     createChatGenerationParams,
+    getUsage,
     isChatResponse,
     partAsType,
     partAsTypeCheck,
@@ -48,45 +48,6 @@ import { ToolCallChunk } from '@langchain/core/messages/tool'
 import { RunnableConfig } from '@langchain/core/runnables'
 import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
 import { createUsageMetadata } from '@chatluna/v1-shared-adapter'
-
-function getModalityTokens(
-    details: GeminiUsageMetadata['promptTokensDetails'],
-    modality: string
-) {
-    return details?.find((item) => item.modality === modality)?.tokenCount
-}
-
-function getCompletionTokens(data: ChatResponse) {
-    if (data.usageMetadata?.candidatesTokenCount != null) {
-        return data.usageMetadata.candidatesTokenCount
-    }
-
-    let total = 0
-    for (const candidate of data.candidates ?? []) {
-        total += candidate.tokenCount ?? 0
-    }
-    return total
-}
-
-function getUsage(data: ChatResponse) {
-    const usage = data.usageMetadata
-    if (usage == null) {
-        return
-    }
-
-    return {
-        promptTokens: usage.promptTokenCount,
-        completionTokens: getCompletionTokens(data),
-        totalTokens: usage.totalTokenCount,
-        inputAudioTokens: getModalityTokens(usage.promptTokensDetails, 'AUDIO'),
-        outputAudioTokens: getModalityTokens(
-            usage.candidatesTokensDetails,
-            'AUDIO'
-        ),
-        cacheReadTokens: usage.cachedContentTokenCount,
-        reasoningTokens: usage.thoughtsTokenCount
-    }
-}
 
 export class GeminiRequester
     extends ModelRequester<ClientConfig, Config>

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -28,6 +28,7 @@ import {
     ChatMessagePart,
     ChatPart,
     ChatResponse,
+    GeminiUsageMetadata,
     ChatUsageMetadataPart,
     CreateEmbeddingResponse,
     GeminiModelInfo
@@ -46,6 +47,46 @@ import type {} from 'koishi-plugin-chatluna-storage-service'
 import { ToolCallChunk } from '@langchain/core/messages/tool'
 import { RunnableConfig } from '@langchain/core/runnables'
 import { trackLogToLocal } from 'koishi-plugin-chatluna/utils/logger'
+import { createUsageMetadata } from '@chatluna/v1-shared-adapter'
+
+function getModalityTokens(
+    details: GeminiUsageMetadata['promptTokensDetails'],
+    modality: string
+) {
+    return details?.find((item) => item.modality === modality)?.tokenCount
+}
+
+function getCompletionTokens(data: ChatResponse) {
+    if (data.usageMetadata?.candidatesTokenCount != null) {
+        return data.usageMetadata.candidatesTokenCount
+    }
+
+    let total = 0
+    for (const candidate of data.candidates ?? []) {
+        total += candidate.tokenCount ?? 0
+    }
+    return total
+}
+
+function getUsage(data: ChatResponse) {
+    const usage = data.usageMetadata
+    if (usage == null) {
+        return
+    }
+
+    return {
+        promptTokens: usage.promptTokenCount,
+        completionTokens: getCompletionTokens(data),
+        totalTokens: usage.totalTokenCount,
+        inputAudioTokens: getModalityTokens(usage.promptTokensDetails, 'AUDIO'),
+        outputAudioTokens: getModalityTokens(
+            usage.candidatesTokensDetails,
+            'AUDIO'
+        ),
+        cacheReadTokens: usage.cachedContentTokenCount,
+        reasoningTokens: usage.thoughtsTokenCount
+    }
+}
 
 export class GeminiRequester
     extends ModelRequester<ClientConfig, Config>
@@ -412,22 +453,10 @@ export class GeminiRequester
                         ? (JSON.parse(chunk) as unknown as ChatResponse)
                         : chunk
 
-                if (transformValue.usageMetadata) {
-                    const promptTokens =
-                        transformValue.usageMetadata.promptTokenCount
-
-                    const totalTokens =
-                        transformValue.usageMetadata.totalTokenCount
-                    const completionTokens =
-                        transformValue.usageMetadata.candidatesTokenCount ??
-                        totalTokens - promptTokens
-
+                const usage = getUsage(transformValue)
+                if (usage != null) {
                     controller.enqueue({
-                        usage: {
-                            promptTokens,
-                            completionTokens,
-                            totalTokens
-                        }
+                        usage
                     })
                 }
 
@@ -496,12 +525,23 @@ export class GeminiRequester
                     (chunk) => chunk['usage'] != null
                 ))
             ) {
+                const usageMetadata = createUsageMetadata({
+                    inputTokens: parsedChunk.usage.promptTokens,
+                    outputTokens: parsedChunk.usage.completionTokens,
+                    totalTokens: parsedChunk.usage.totalTokens,
+                    inputAudioTokens: parsedChunk.usage.inputAudioTokens,
+                    outputAudioTokens: parsedChunk.usage.outputAudioTokens,
+                    cacheReadTokens: parsedChunk.usage.cacheReadTokens,
+                    reasoningTokens: parsedChunk.usage.reasoningTokens
+                })
+
                 const generationChunk = new ChatGenerationChunk({
+                    generationInfo: {
+                        usage_metadata: usageMetadata
+                    },
                     message: new AIMessageChunk({
                         content: '',
-                        response_metadata: {
-                            tokenUsage: parsedChunk.usage
-                        }
+                        usage_metadata: usageMetadata
                     }),
                     text: ''
                 })

--- a/packages/adapter-gemini/src/types.ts
+++ b/packages/adapter-gemini/src/types.ts
@@ -26,7 +26,29 @@ export type ChatUsageMetadataPart = {
         promptTokens: number
         completionTokens: number
         totalTokens: number
+        inputAudioTokens?: number
+        outputAudioTokens?: number
+        cacheReadTokens?: number
+        reasoningTokens?: number
     }
+}
+
+export type GeminiModalityTokenCount = {
+    modality: string
+    tokenCount: number
+}
+
+export type GeminiUsageMetadata = {
+    promptTokenCount: number
+    cachedContentTokenCount?: number
+    candidatesTokenCount?: number
+    toolUsePromptTokenCount?: number
+    thoughtsTokenCount?: number
+    totalTokenCount: number
+    promptTokensDetails?: GeminiModalityTokenCount[]
+    cacheTokensDetails?: GeminiModalityTokenCount[]
+    candidatesTokensDetails?: GeminiModalityTokenCount[]
+    toolUsePromptTokensDetails?: GeminiModalityTokenCount[]
 }
 
 export type ChatInlineDataPart = {
@@ -66,6 +88,7 @@ export type ChatFunctionResponsePart = {
 export interface ChatResponse {
     candidates: {
         content: ChatCompletionResponseMessage
+        tokenCount?: number
         groundingMetadata: {
             searchEntryPoint: {
                 renderedContent: string
@@ -99,14 +122,7 @@ export interface ChatResponse {
             probability: string
         }[]
     }
-    usageMetadata: {
-        promptTokenCount: number
-        cachedContentTokenCount: number
-        candidatesTokenCount: number
-        toolUsePromptTokenCount: number
-        thoughtsTokenCount: number
-        totalTokenCount: number
-    }
+    usageMetadata?: GeminiUsageMetadata
 }
 
 export interface ChatCompletionFunction {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -16,7 +16,8 @@ import {
     ChatFunctionResponsePart,
     ChatMessagePart,
     ChatPart,
-    ChatResponse
+    ChatResponse,
+    GeminiUsageMetadata
 } from './types'
 import { Config, logger } from '.'
 import { ModelRequestParams } from 'koishi-plugin-chatluna/llm-core/platform/api'
@@ -924,6 +925,45 @@ export function expandModelVariants(
 }
 
 // #endregion
+
+export function getModalityTokens(
+    details: GeminiUsageMetadata['promptTokensDetails'],
+    modality: string
+) {
+    return details?.find((item) => item.modality === modality)?.tokenCount
+}
+
+function getCompletionTokens(data: ChatResponse) {
+    if (data.usageMetadata?.candidatesTokenCount != null) {
+        return data.usageMetadata.candidatesTokenCount
+    }
+
+    let total = 0
+    for (const candidate of data.candidates ?? []) {
+        total += candidate.tokenCount ?? 0
+    }
+    return total
+}
+
+export function getUsage(data: ChatResponse) {
+    const usage = data.usageMetadata
+    if (usage == null) {
+        return
+    }
+
+    return {
+        promptTokens: usage.promptTokenCount,
+        completionTokens: getCompletionTokens(data),
+        totalTokens: usage.totalTokenCount,
+        inputAudioTokens: getModalityTokens(usage.promptTokensDetails, 'AUDIO'),
+        outputAudioTokens: getModalityTokens(
+            usage.candidatesTokensDetails,
+            'AUDIO'
+        ),
+        cacheReadTokens: usage.cachedContentTokenCount,
+        reasoningTokens: usage.thoughtsTokenCount
+    }
+}
 
 function notNullFn<K, V>(_: K, v: V): v is NonNullable<V> {
     return v != null

--- a/packages/adapter-zhipu/src/requester.ts
+++ b/packages/adapter-zhipu/src/requester.ts
@@ -16,6 +16,7 @@ import {
 } from 'koishi-plugin-chatluna/utils/error'
 import { sseIterable } from 'koishi-plugin-chatluna/utils/sse'
 import * as fetchType from 'undici/types/fetch'
+import { createUsageMetadata } from '@chatluna/v1-shared-adapter'
 import {
     ChatCompletionResponse,
     ChatCompletionResponseMessageRoleEnum,
@@ -135,17 +136,19 @@ export class ZhipuRequester
                 }
 
                 if (data.usage) {
+                    const usageMetadata = createUsageMetadata({
+                        inputTokens: data.usage.prompt_tokens,
+                        outputTokens: data.usage.completion_tokens,
+                        totalTokens: data.usage.total_tokens
+                    })
+
                     yield new ChatGenerationChunk({
+                        generationInfo: {
+                            usage_metadata: usageMetadata
+                        },
                         message: new AIMessageChunk({
                             content: '',
-                            response_metadata: {
-                                tokenUsage: {
-                                    promptTokens: data.usage.prompt_tokens,
-                                    completionTokens:
-                                        data.usage.completion_tokens,
-                                    totalTokens: data.usage.total_tokens
-                                }
-                            }
+                            usage_metadata: usageMetadata
                         }),
                         text: ''
                     })

--- a/packages/core/src/llm-core/agent/executor.ts
+++ b/packages/core/src/llm-core/agent/executor.ts
@@ -319,6 +319,10 @@ export async function* runAgent(
             }
         }
 
+        yield {
+            type: 'round-decision'
+        }
+
         let output: AgentAction[] | AgentFinish
 
         try {
@@ -340,6 +344,11 @@ export async function* runAgent(
         checkAborted(signal)
 
         if (isAgentFinish(output)) {
+            yield {
+                type: 'round-decision',
+                canContinue: false
+            }
+
             const pending = options.messageQueue?.drain() ?? []
             if (pending.length > 0) {
                 yield {
@@ -359,6 +368,14 @@ export async function* runAgent(
         }
 
         if (output.length > 0) {
+            const last = output[output.length - 1]
+            const tool = toolMap[last.tool?.toLowerCase()]
+
+            yield {
+                type: 'round-decision',
+                canContinue: !tool?.returnDirect
+            }
+
             yield {
                 type: 'tool-call',
                 actions: output
@@ -407,6 +424,11 @@ export async function* runAgent(
         }
 
         iterations += 1
+    }
+
+    yield {
+        type: 'round-decision',
+        canContinue: false
     }
 
     yield {
@@ -482,19 +504,11 @@ export class AgentExecutor extends BaseChain<ChainValues, AgentExecutorOutput> {
                 for (const action of event.actions) {
                     await runManager?.handleAgentAction(action)
                 }
-                await configurable.onAgentEvent?.({
-                    type: 'round-decision',
-                    canContinue: true
-                })
             }
 
             await configurable.onAgentEvent?.(event)
 
             if (event.type === 'done') {
-                await configurable.onAgentEvent?.({
-                    type: 'round-decision',
-                    canContinue: false
-                })
                 await runManager?.handleAgentEnd({
                     returnValues: {
                         output: event.output

--- a/packages/core/src/llm-core/agent/types.ts
+++ b/packages/core/src/llm-core/agent/types.ts
@@ -221,7 +221,7 @@ export type AgentEvent =
       }
     | {
           type: 'round-decision'
-          canContinue: boolean
+          canContinue?: boolean
       }
     | {
           type: 'done'

--- a/packages/core/src/llm-core/chain/base.ts
+++ b/packages/core/src/llm-core/chain/base.ts
@@ -378,7 +378,8 @@ export async function callChatLunaChain(
                     events?.['llm-new-token']?.(token)
                 },
                 handleLLMEnd(output, runId, parentRunId, tags) {
-                    usedToken += output.llmOutput?.tokenUsage?.totalTokens ?? 0
+                    usedToken +=
+                        output.llmOutput?.usage_metadata?.total_tokens ?? 0
                 },
                 handleCustomEvent(eventName, data, runId, tags, metadata) {
                     if (eventName === 'LLMNewChunk') {

--- a/packages/core/src/llm-core/chain/plugin_chat_chain.ts
+++ b/packages/core/src/llm-core/chain/plugin_chat_chain.ts
@@ -222,7 +222,8 @@ export class ChatLunaPluginChain
                         {
                             handleLLMEnd(out) {
                                 usedToken +=
-                                    out.llmOutput?.tokenUsage?.totalTokens ?? 0
+                                    out.llmOutput?.usage_metadata
+                                        ?.total_tokens ?? 0
                             },
                             handleAgentAction(action: AgentAction) {
                                 return events?.['llm-call-tool']?.(

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -4,7 +4,12 @@ import {
     BaseChatModel,
     BaseChatModelCallOptions
 } from '@langchain/core/language_models/chat_models'
-import { AIMessageChunk, BaseMessage } from '@langchain/core/messages'
+import {
+    AIMessage,
+    AIMessageChunk,
+    BaseMessage,
+    type UsageMetadata
+} from '@langchain/core/messages'
 import {
     ChatGeneration,
     ChatGenerationChunk,
@@ -286,9 +291,9 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
 
     private _createTokenUsageTracker(): TokenUsageTracker {
         return {
-            promptTokens: 0,
-            completionTokens: 0,
-            totalTokens: 0
+            input_tokens: 0,
+            output_tokens: 0,
+            total_tokens: 0
         }
     }
 
@@ -329,15 +334,17 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         chunk: ChatGenerationChunk,
         latestTokenUsage: TokenUsageTracker
     ) {
-        const tokenUsage = chunk.message.response_metadata?.['tokenUsage']
+        const usage = (chunk.message as AIMessageChunk).usage_metadata
 
-        if (!tokenUsage) {
+        if (!usage?.total_tokens) {
             return
         }
 
-        latestTokenUsage.promptTokens = tokenUsage['promptTokens']
-        latestTokenUsage.completionTokens = tokenUsage['completionTokens']
-        latestTokenUsage.totalTokens = tokenUsage['totalTokens']
+        latestTokenUsage.input_tokens = usage.input_tokens
+        latestTokenUsage.output_tokens = usage.output_tokens
+        latestTokenUsage.total_tokens = usage.total_tokens
+        latestTokenUsage.input_token_details = usage.input_token_details
+        latestTokenUsage.output_token_details = usage.output_token_details
     }
 
     private _ensureChunksReceived(hasChunk: boolean) {
@@ -358,16 +365,11 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             void runManager?.handleCustomEvent('LLMNewChunk', undefined)
         }
 
-        if (latestTokenUsage.totalTokens <= 0) {
+        if (latestTokenUsage.total_tokens <= 0) {
             return
         }
 
-        logger.debug(
-            'Token usage from API: Prompt Token = %d, Completion Token = %d, Total Token = %d',
-            latestTokenUsage.promptTokens,
-            latestTokenUsage.completionTokens,
-            latestTokenUsage.totalTokens
-        )
+        logger.debug(formatUsageMetadata(latestTokenUsage))
     }
 
     private async _closeStream(
@@ -427,28 +429,30 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED)
         }
 
-        response.message.response_metadata =
-            response.message.response_metadata ?? {}
+        let usageMetadata = (response.message as AIMessage | AIMessageChunk)
+            .usage_metadata
 
-        if (!response.message.response_metadata.tokenUsage) {
+        if (!usageMetadata?.total_tokens) {
             const completionTokens = await this.countMessageTokens(
                 response.message
             )
-            response.message.response_metadata.tokenUsage = {
-                completionTokens,
-                promptTokens,
-                totalTokens: completionTokens + promptTokens
+            usageMetadata = {
+                input_tokens: promptTokens,
+                output_tokens: completionTokens,
+                total_tokens: completionTokens + promptTokens
             }
         } else if (options.stream !== true) {
-            const tokenUsage = response.message.response_metadata['tokenUsage']
-            if (tokenUsage) {
-                logger.debug(
-                    'Token usage from API: Prompt Token = %d, Completion Token = %d, Total Token = %d',
-                    tokenUsage.promptTokens,
-                    tokenUsage.completionTokens,
-                    tokenUsage.totalTokens
-                )
-            }
+            logger.debug(formatUsageMetadata(usageMetadata))
+        }
+
+        if (response.message.getType() === 'ai') {
+            ;(response.message as AIMessage | AIMessageChunk).usage_metadata =
+                usageMetadata
+        }
+
+        response.generationInfo = {
+            ...response.generationInfo,
+            usage_metadata: usageMetadata
         }
 
         return {
@@ -948,4 +952,41 @@ export class ChatLunaEmbeddings extends ChatLunaBaseEmbeddings {
             throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED, e)
         }
     }
+}
+
+function formatUsageMetadata(usage: UsageMetadata) {
+    const result = [
+        `Token usage from API: input=${usage.input_tokens}`,
+        `output=${usage.output_tokens}`,
+        `total=${usage.total_tokens}`
+    ]
+    const input = [
+        ...(usage.input_token_details?.audio != null
+            ? [`audio=${usage.input_token_details.audio}`]
+            : []),
+        ...(usage.input_token_details?.cache_read != null
+            ? [`cache_read=${usage.input_token_details.cache_read}`]
+            : []),
+        ...(usage.input_token_details?.cache_creation != null
+            ? [`cache_creation=${usage.input_token_details.cache_creation}`]
+            : [])
+    ]
+    const output = [
+        ...(usage.output_token_details?.audio != null
+            ? [`audio=${usage.output_token_details.audio}`]
+            : []),
+        ...(usage.output_token_details?.reasoning != null
+            ? [`reasoning=${usage.output_token_details.reasoning}`]
+            : [])
+    ]
+
+    if (input.length > 0) {
+        result.push(`| input(${input.join(', ')})`)
+    }
+
+    if (output.length > 0) {
+        result.push(`| output(${output.join(', ')})`)
+    }
+
+    return result.join(' ')
 }

--- a/packages/core/src/llm-core/platform/types.ts
+++ b/packages/core/src/llm-core/platform/types.ts
@@ -2,7 +2,7 @@ import { BufferMemory } from 'koishi-plugin-chatluna/llm-core/memory/langchain'
 import { ChatLunaBaseEmbeddings, ChatLunaChatModel } from './model'
 import { ChatLunaLLMChainWrapper } from '../chain/base'
 import { StructuredTool, ToolRunnableConfig } from '@langchain/core/tools'
-import { BaseMessage } from '@langchain/core/messages'
+import { BaseMessage, type UsageMetadata } from '@langchain/core/messages'
 import { Dict, Session } from 'koishi'
 import { PresetTemplate } from 'koishi-plugin-chatluna/llm-core/prompt'
 import { ChatLunaSaveableVectorStore } from 'koishi-plugin-chatluna/llm-core/vectorstores'
@@ -131,11 +131,7 @@ export function isPlatformModelInfo(model: any): model is PlatformModelInfo {
     )
 }
 
-export type TokenUsageTracker = {
-    promptTokens: number
-    completionTokens: number
-    totalTokens: number
-}
+export type TokenUsageTracker = UsageMetadata
 
 /**
  * Describes how a platform handles file uploads (inline data, size limits, etc.).

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -1019,6 +1019,10 @@ class ChatInterfaceWrapper {
                 onAgentEvent: async (agentEvent) => {
                     if (agentEvent.type === 'round-decision') {
                         activeRequest.lastDecision = agentEvent.canContinue
+                        if (agentEvent.canContinue == null) {
+                            return
+                        }
+
                         for (const resolve of activeRequest.roundDecisionResolvers) {
                             resolve(agentEvent.canContinue)
                         }

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -1,4 +1,8 @@
-import { AIMessage, HumanMessage } from '@langchain/core/messages'
+import {
+    AIMessage,
+    HumanMessage,
+    type UsageMetadata
+} from '@langchain/core/messages'
 import fs from 'fs'
 import {
     Awaitable,
@@ -1031,6 +1035,8 @@ class ChatInterfaceWrapper {
             const reasoningTime = aiMessage.additional_kwargs
                 ?.reasoning_time as number
 
+            const usageMetadata = aiMessage.usage_metadata
+
             const additionalReplyMessages: Message[] = []
 
             if (
@@ -1040,6 +1046,16 @@ class ChatInterfaceWrapper {
             ) {
                 additionalReplyMessages.push({
                     content: `Thought for ${reasoningTime / 1000} seconds: \n\n${reasoningContent}`
+                })
+            }
+
+            if (
+                usageMetadata != null &&
+                usageMetadata.total_tokens > 0 &&
+                this._service.currentConfig.showThoughtMessage
+            ) {
+                additionalReplyMessages.push({
+                    content: formatUsageMetadataMessage(usageMetadata)
                 })
             }
 
@@ -1291,6 +1307,37 @@ class ChatInterfaceWrapper {
 
         return result
     }
+}
+
+function formatUsageMetadataMessage(usage: UsageMetadata) {
+    const input = [
+        ...(usage.input_token_details?.audio != null
+            ? [`audio=${usage.input_token_details.audio}`]
+            : []),
+        ...(usage.input_token_details?.cache_read != null
+            ? [`cache_read=${usage.input_token_details.cache_read}`]
+            : []),
+        ...(usage.input_token_details?.cache_creation != null
+            ? [`cache_creation=${usage.input_token_details.cache_creation}`]
+            : [])
+    ]
+    const output = [
+        ...(usage.output_token_details?.audio != null
+            ? [`audio=${usage.output_token_details.audio}`]
+            : []),
+        ...(usage.output_token_details?.reasoning != null
+            ? [`reasoning=${usage.output_token_details.reasoning}`]
+            : [])
+    ]
+
+    return [
+        'Token usage:',
+        `- input: ${usage.input_tokens}`,
+        `- output: ${usage.output_tokens}`,
+        `- total: ${usage.total_tokens}`,
+        ...(input.length > 0 ? [`- input details: ${input.join(', ')}`] : []),
+        ...(output.length > 0 ? [`- output details: ${output.join(', ')}`] : [])
+    ].join('\n')
 }
 
 // eslint-disable-next-line @typescript-eslint/no-namespace

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -151,6 +151,8 @@ const imageModelMatchers = [
     'qwen*-omni',
     'qwen-omni',
     'qwen*-vl',
+    'qwen-3.5',
+    'qwen3.5',
     'qvq',
     'o1',
     'o3',

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -19,7 +19,8 @@ import {
     convertDeltaToMessageChunk,
     convertMessageToMessageChunk,
     formatToolsToOpenAITools,
-    langchainMessageToOpenAIMessage
+    langchainMessageToOpenAIMessage,
+    openAIUsageToUsageMetadata
 } from './utils'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Context } from 'koishi'
@@ -111,31 +112,6 @@ export async function buildChatCompletionParams(
     return deepAssign({}, base, params.overrideRequestParams ?? {})
 }
 
-export function processReasoningContent(
-    delta: { reasoning_content?: string; content?: string },
-    reasoningState: { content: string; time: number; isSet: boolean }
-) {
-    if (delta.reasoning_content) {
-        reasoningState.content += delta.reasoning_content
-        if (reasoningState.time === 0) {
-            reasoningState.time = Date.now()
-        }
-    }
-
-    if (
-        (delta.reasoning_content == null || delta.reasoning_content === '') &&
-        delta.content &&
-        delta.content.length > 0 &&
-        reasoningState.time > 0 &&
-        !reasoningState.isSet
-    ) {
-        const reasoningTime = Date.now() - reasoningState.time
-        reasoningState.time = reasoningTime
-        reasoningState.isSet = true
-        return reasoningTime
-    }
-}
-
 // eslint-disable-next-line generator-star-spacing
 export async function* processStreamResponse<
     T extends ClientConfig,
@@ -146,7 +122,12 @@ export async function* processStreamResponse<
 ) {
     let defaultRole: ChatCompletionResponseMessageRoleEnum = 'assistant'
     let errorCount = 0
-    const reasoningState = { content: '', time: 0, isSet: false }
+    const reasoningState = {
+        content: '',
+        startedAt: 0,
+        duration: 0,
+        done: false
+    }
 
     for await (const event of iterator) {
         const chunk = event.data
@@ -167,16 +148,14 @@ export async function* processStreamResponse<
             const choice = data.choices?.[0]
 
             if (data.usage) {
+                const usageMetadata = openAIUsageToUsageMetadata(data.usage)
                 yield new ChatGenerationChunk({
+                    generationInfo: {
+                        usage_metadata: usageMetadata
+                    },
                     message: new AIMessageChunk({
                         content: '',
-                        response_metadata: {
-                            tokenUsage: {
-                                promptTokens: data.usage.prompt_tokens,
-                                completionTokens: data.usage.completion_tokens,
-                                totalTokens: data.usage.total_tokens
-                            }
-                        }
+                        usage_metadata: usageMetadata
                     }),
                     text: ''
                 })
@@ -187,9 +166,24 @@ export async function* processStreamResponse<
             const { delta } = choice
             const messageChunk = convertDeltaToMessageChunk(delta, defaultRole)
 
-            const reasoningTime = processReasoningContent(delta, reasoningState)
-            if (reasoningTime !== undefined) {
-                messageChunk.additional_kwargs.reasoning_time = reasoningTime
+            if (delta.reasoning_content) {
+                reasoningState.content += delta.reasoning_content
+                if (reasoningState.startedAt === 0) {
+                    reasoningState.startedAt = Date.now()
+                }
+            }
+
+            if (
+                !reasoningState.done &&
+                reasoningState.startedAt > 0 &&
+                ((delta.content?.length ?? 0) > 0 ||
+                    (delta.tool_calls?.length ?? 0) > 0 ||
+                    delta.function_call != null)
+            ) {
+                reasoningState.duration = Date.now() - reasoningState.startedAt
+                reasoningState.done = true
+                messageChunk.additional_kwargs.reasoning_time =
+                    reasoningState.duration
             }
 
             defaultRole = (
@@ -225,8 +219,23 @@ export async function* processStreamResponse<
     }
 
     if (reasoningState.content.length > 0) {
+        if (!reasoningState.done && reasoningState.startedAt > 0) {
+            reasoningState.duration = Date.now() - reasoningState.startedAt
+            reasoningState.done = true
+
+            yield new ChatGenerationChunk({
+                message: new AIMessageChunk({
+                    content: '',
+                    additional_kwargs: {
+                        reasoning_time: reasoningState.duration
+                    }
+                }),
+                text: ''
+            })
+        }
+
         requestContext.modelRequester.logger.debug(
-            `reasoning content: ${reasoningState.content}. Use time: ${reasoningState.time / 1000}s`
+            `reasoning content: ${reasoningState.content}. Use time: ${reasoningState.duration / 1000}s`
         )
     }
 }
@@ -276,13 +285,23 @@ export async function processResponse<
         }
 
         const messageChunk = convertMessageToMessageChunk(choice.message)
+        const usageMetadata = data.usage
+            ? openAIUsageToUsageMetadata(data.usage)
+            : undefined
+
+        if (messageChunk instanceof AIMessageChunk) {
+            messageChunk.usage_metadata = usageMetadata
+        }
 
         return new ChatGenerationChunk({
             message: messageChunk,
             text: getMessageContent(messageChunk.content),
-            generationInfo: {
-                tokenUsage: data.usage
-            }
+            generationInfo:
+                usageMetadata == null
+                    ? undefined
+                    : {
+                          usage_metadata: usageMetadata
+                      }
         })
     } catch (e) {
         if (e instanceof ChatLunaError) {

--- a/packages/shared-adapter/src/types.ts
+++ b/packages/shared-adapter/src/types.ts
@@ -7,6 +7,7 @@ export interface ChatCompletionResponse {
             role?: string
             reasoning_content?: string
             function_call?: ChatCompletionRequestMessageToolCall
+            tool_calls?: ChatCompletionRequestMessageToolCall[]
         }
         message: ChatCompletionResponseMessage
     }[]
@@ -14,11 +15,27 @@ export interface ChatCompletionResponse {
     object: string
     created: number
     model: string
-    usage: {
-        prompt_tokens: number
-        completion_tokens: number
-        total_tokens: number
-    }
+    usage?: ChatCompletionUsage
+}
+
+export interface ChatCompletionPromptTokensDetails {
+    audio_tokens?: number
+    cached_tokens?: number
+}
+
+export interface ChatCompletionCompletionTokensDetails {
+    reasoning_tokens?: number
+    audio_tokens?: number
+    accepted_prediction_tokens?: number
+    rejected_prediction_tokens?: number
+}
+
+export interface ChatCompletionUsage {
+    prompt_tokens: number
+    completion_tokens: number
+    total_tokens: number
+    prompt_tokens_details?: ChatCompletionPromptTokensDetails
+    completion_tokens_details?: ChatCompletionCompletionTokensDetails
 }
 
 export interface ChatCompletionTextPart {

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -9,12 +9,14 @@ import {
     MessageContentImageUrl,
     MessageType,
     SystemMessageChunk,
+    type UsageMetadata,
     ToolMessage,
     ToolMessageChunk
 } from '@langchain/core/messages'
 import { StructuredTool } from '@langchain/core/tools'
 import { JsonSchema7Type, zodToJsonSchema } from 'zod-to-json-schema'
 import {
+    ChatCompletionUsage,
     ChatCompletionResponseMessage,
     ChatCompletionResponseMessageRoleEnum,
     ChatCompletionTool
@@ -28,6 +30,63 @@ import {
 import { ToolCallChunk } from '@langchain/core/messages/tool'
 import { isZodSchemaV3 } from '@langchain/core/utils/types'
 import { normalizeOpenAIModelName, supportImageInput } from './client'
+
+export function createUsageMetadata(data: {
+    inputTokens: number
+    outputTokens: number
+    totalTokens: number
+    inputAudioTokens?: number
+    outputAudioTokens?: number
+    cacheReadTokens?: number
+    cacheCreationTokens?: number
+    reasoningTokens?: number
+}): UsageMetadata {
+    const inputTokenDetails = {
+        ...(data.inputAudioTokens != null
+            ? { audio: data.inputAudioTokens }
+            : {}),
+        ...(data.cacheReadTokens != null
+            ? { cache_read: data.cacheReadTokens }
+            : {}),
+        ...(data.cacheCreationTokens != null
+            ? { cache_creation: data.cacheCreationTokens }
+            : {})
+    }
+    const outputTokenDetails = {
+        ...(data.outputAudioTokens != null
+            ? { audio: data.outputAudioTokens }
+            : {}),
+        ...(data.reasoningTokens != null
+            ? { reasoning: data.reasoningTokens }
+            : {})
+    }
+
+    return {
+        input_tokens: data.inputTokens,
+        output_tokens: data.outputTokens,
+        total_tokens: data.totalTokens,
+        ...(Object.keys(inputTokenDetails).length > 0
+            ? { input_token_details: inputTokenDetails }
+            : {}),
+        ...(Object.keys(outputTokenDetails).length > 0
+            ? { output_token_details: outputTokenDetails }
+            : {})
+    }
+}
+
+export function openAIUsageToUsageMetadata(
+    usage: ChatCompletionUsage
+): UsageMetadata {
+    return createUsageMetadata({
+        inputTokens: usage.prompt_tokens,
+        outputTokens: usage.completion_tokens,
+        totalTokens: usage.total_tokens,
+        inputAudioTokens: usage.prompt_tokens_details?.audio_tokens,
+        outputAudioTokens: usage.completion_tokens_details?.audio_tokens,
+        cacheReadTokens: usage.prompt_tokens_details?.cached_tokens,
+        reasoningTokens: usage.completion_tokens_details?.reasoning_tokens
+    })
+}
 
 export async function langchainMessageToOpenAIMessage(
     messages: BaseMessage[],


### PR DESCRIPTION
## Summary

This PR includes comprehensive improvements to token usage tracking and agent executor event management:

1. **UsageMetadata Migration**: Migrate from custom `response_metadata.tokenUsage` format to LangChain's standardized `UsageMetadata` type across all adapters
2. **Agent Executor Events**: Improve agent execution control flow by moving `round-decision` event emission to the executor for more accurate signaling
3. **Code Organization**: Extract token utility functions to improve module maintainability

## New Features

- Support for extended token details including audio tokens, cache tokens, and reasoning tokens
- Better agent execution visibility with precise round-decision event timing
- Conditional round-decision events that signal iteration state transitions
- Extracted token utility functions for improved code reusability

## Bug fixes

- Fixed token usage tracking to use the standard LangChain UsageMetadata format
- Improved agent executor control flow to prevent race conditions in async coordination
- Corrected optional canContinue property in round-decision events

## Other Changes

- Extract token utility functions (getUsage, getCompletionTokens, getModalityTokens) to utils module
- Create `createUsageMetadata` and `openAIUsageToUsageMetadata` helper functions for consistent format conversion
- Add `formatUsageMetadata` utility for improved token usage logging
- Update TokenUsageTracker type to alias UsageMetadata for type consistency
- Updated all adapters (Gemini, Zhipu, shared-adapter) to emit usage_metadata in generation chunks
- Refactored agent executor to emit round-decision events at critical execution points
- Enhanced chat service to handle optional canContinue values in round-decision events