### PR TITLE
[Refactor] Simplify infinite context compression system

### DIFF
--- a/packages/core/src/commands/chat.ts
+++ b/packages/core/src/commands/chat.ts
@@ -84,6 +84,23 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             )
         })
 
+    ctx.command('chatluna.chat.compress')
+        .option('room', '-r <room:string>')
+        .action(async ({ options, session }) => {
+            await chain.receiveCommand(
+                session,
+                'compress_room',
+                {
+                    force: true,
+                    i18n_base: 'commands.chatluna.chat.compress.messages',
+                    room_resolve: {
+                        name: options.room
+                    }
+                },
+                ctx
+            )
+        })
+
     ctx.command('chatluna.chat.voice <message:text>')
         .option('room', '-r <room:string>')
         .option('speaker', '-s <speakerId:number>', { authority: 1 })

--- a/packages/core/src/commands/room.ts
+++ b/packages/core/src/commands/room.ts
@@ -109,6 +109,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     ctx.command('chatluna.room.compress [room:text]').action(
         async ({ session }, room) => {
             await chain.receiveCommand(session, 'compress_room', {
+                force: true,
+                i18n_base: 'commands.chatluna.room.compress.messages',
                 room_resolve: {
                     name: room
                 }

--- a/packages/core/src/llm-core/chain/infinite_context_chain.ts
+++ b/packages/core/src/llm-core/chain/infinite_context_chain.ts
@@ -1,6 +1,6 @@
 import { ChainValues } from '@langchain/core/utils/types'
 import { PromptTemplate } from '@langchain/core/prompts'
-import { BaseMessage } from '@langchain/core/messages'
+import { AIMessage, type UsageMetadata } from '@langchain/core/messages'
 import { BufferMemory } from 'koishi-plugin-chatluna/llm-core/memory/langchain'
 import {
     ChatLunaLLMCallArg,
@@ -22,6 +22,11 @@ export interface ChatLunaInfiniteContextChunkArg {
     chunk: string
     conversationId: string
     signal?: AbortSignal
+}
+
+export interface ChatLunaInfiniteContextChunkResult {
+    text: string
+    usageMetadata?: UsageMetadata
 }
 
 export class ChatLunaInfiniteContextChain
@@ -46,25 +51,22 @@ export class ChatLunaInfiniteContextChain
         { historyMemory }: ChatLunaInfiniteContextChainInput
     ) {
         const prompt =
-            PromptTemplate.fromTemplate(`You are "Infinite Context", the memory architect for a conversational AI assistant.
-Your task is to compress the provided fragment of dialogue into a compact knowledge note that keeps only information necessary to continue future conversations.
+            PromptTemplate.fromTemplate(`You are a helpful AI assistant tasked with summarizing conversations.
 
-Requirements:
-- Organise the fragment into clear topics.
-- Keep actionable commitments, unresolved questions, decisions, instructions, user preferences, emotional tone shifts, and critical facts.
-- Remove chit-chat, repeated phrasing, or expired information.
-- Use concise bullet points grouped by topic.
-- Respond in the primary language of the fragment.
+When asked to summarize, provide a detailed but concise summary of the conversation.
+Focus on information that would be helpful for continuing the conversation, including:
+- What was done
+- What is currently being worked on
+- Which files are being modified
+- What needs to be done next
+- Key user requests, constraints, or preferences that should persist
+- Important technical decisions and why they were made
 
-Format:
-<infinite_context>
-- Topic: <short title>
-  - Detail: <essential fact, instruction, or open task>
-</infinite_context>
+Your summary should be comprehensive enough to provide context but concise enough to be quickly understood.
 
-If nothing important remains, output "<infinite_context />".
+Do not respond to any questions in the conversation, only output the summary.
 
-Fragment:
+Conversation:
 {conversation_chunk}`)
 
         const chain = new ChatLunaLLMChain({ llm, prompt })
@@ -79,15 +81,11 @@ Fragment:
         chunk,
         conversationId,
         signal
-    }: ChatLunaInfiniteContextChunkArg): Promise<string | null> {
+    }: ChatLunaInfiniteContextChunkArg): Promise<ChatLunaInfiniteContextChunkResult | null> {
         const trimmedChunk = chunk?.trim()
 
         if (!trimmedChunk) {
             return null
-        }
-
-        if (this._isAlreadyCompressed(trimmedChunk)) {
-            return trimmedChunk
         }
 
         const result = await this.chain.invoke({
@@ -97,7 +95,7 @@ Fragment:
             signal
         })
 
-        const rawMessage = (result['message'] ?? null) as BaseMessage | null
+        const rawMessage = (result['message'] ?? null) as AIMessage | null
 
         const text =
             (result['text'] ?? '').toString().trim() ||
@@ -107,23 +105,10 @@ Fragment:
             return null
         }
 
-        return text
-    }
-
-    private _isAlreadyCompressed(chunk: string): boolean {
-        if (!chunk) {
-            return false
+        return {
+            text,
+            usageMetadata: rawMessage?.usage_metadata
         }
-
-        if (/<\/?infinite_context/iu.test(chunk)) {
-            return true
-        }
-
-        if (/source:\s*['"]infinite-context['"]/iu.test(chunk)) {
-            return true
-        }
-
-        return false
     }
 
     async call(

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -29,6 +29,7 @@ import { PresetTemplate } from 'koishi-plugin-chatluna/llm-core/prompt'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import type { HandlerResult } from '../../utils/types'
 import { computed, ComputedRef } from '@vue/reactivity'
+import type { CompressContextResult } from './infinite_context'
 import { InfiniteContextManager } from './infinite_context'
 
 export class ChatInterface {
@@ -394,19 +395,17 @@ export class ChatInterface {
         await this._chain?.value?.model.clearContext(this._input.conversationId)
     }
 
-    async compressContext(): Promise<boolean> {
+    async compressContext(force = false): Promise<CompressContextResult> {
         const wrapper = await this.getChatLunaLLMChainWrapper()
-        if (!wrapper) {
-            return false
-        }
-
         const manager = this._ensureInfiniteContextManager()
         if (!manager) {
-            return false
+            throw new ChatLunaError(
+                ChatLunaErrorCode.CHAT_HISTORY_INIT_ERROR,
+                new Error('Chat history is not initialized')
+            )
         }
 
-        await manager.compressIfNeeded(wrapper)
-        return true
+        return manager.compressIfNeeded(wrapper, force)
     }
 
     private async _initEmbeddings(service: PlatformService) {

--- a/packages/core/src/llm-core/chat/infinite_context.ts
+++ b/packages/core/src/llm-core/chat/infinite_context.ts
@@ -1,17 +1,31 @@
 /* eslint-disable max-len */
 import { BaseMessage, HumanMessage } from '@langchain/core/messages'
-import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
-import { ChatLunaLLMChainWrapper } from 'koishi-plugin-chatluna/llm-core/chain/base'
-import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
-import { logger } from 'koishi-plugin-chatluna'
 import { ComputedRef } from '@vue/reactivity'
+import { logger } from 'koishi-plugin-chatluna'
+import { ChatLunaLLMChainWrapper } from 'koishi-plugin-chatluna/llm-core/chain/base'
 import { KoishiChatMessageHistory } from 'koishi-plugin-chatluna/llm-core/memory/message'
-import { ChatLunaInfiniteContextChain } from '../chain/infinite_context_chain'
+import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
 import { PresetTemplate } from 'koishi-plugin-chatluna/llm-core/prompt'
+import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
+import { ChatLunaInfiniteContextChain } from '../chain/infinite_context_chain'
 
-type MessageTokenStat = {
-    message: BaseMessage
-    tokens: number
+export interface CompressContextResult {
+    inputTokens: number
+    outputTokens: number
+    reducedTokens: number
+    reducedPercent: number
+    compressed: boolean
+}
+
+function formatTranscript(messages: BaseMessage[]) {
+    return messages
+        .map((message) => {
+            const role = message.getType().toUpperCase()
+            const name = message.name ? ` (${message.name})` : ''
+            const content = getMessageContent(message.content).trim()
+            return `[${role}${name}]\n${content || '(empty)'}`
+        })
+        .join('\n\n---\n\n')
 }
 
 export interface InfiniteContextManagerOptions {
@@ -26,328 +40,159 @@ export class InfiniteContextManager {
 
     constructor(private readonly options: InfiniteContextManagerOptions) {}
 
-    async compressIfNeeded(wrapper: ChatLunaLLMChainWrapper): Promise<void> {
+    async compressIfNeeded(
+        wrapper: ChatLunaLLMChainWrapper,
+        force = false
+    ): Promise<CompressContextResult> {
         const model = wrapper.model
 
         if (!model) {
-            return
+            return {
+                inputTokens: 0,
+                outputTokens: 0,
+                reducedTokens: 0,
+                reducedPercent: 0,
+                compressed: false
+            }
         }
 
         const messages = await this.options.chatHistory.getMessages()
 
         if (messages.length === 0) {
-            return
+            return {
+                inputTokens: 0,
+                outputTokens: 0,
+                reducedTokens: 0,
+                reducedPercent: 0,
+                compressed: false
+            }
         }
 
-        const invocation = model.invocationParams()
-        const maxTokenLimit =
-            invocation.maxTokenLimit && invocation.maxTokenLimit > 0
-                ? invocation.maxTokenLimit
-                : model.getModelMaxContextSize()
+        const inputTokens = await this._countMessagesTokens(model, messages)
+        let presetTokens = 0
+        let threshold: number | undefined
 
-        if (!maxTokenLimit || maxTokenLimit <= 0) {
-            return
-        }
+        if (!force) {
+            const invocation = model.invocationParams()
+            const maxTokenLimit =
+                invocation.maxTokenLimit && invocation.maxTokenLimit > 0
+                    ? invocation.maxTokenLimit
+                    : model.getModelMaxContextSize()
 
-        const presetMessages = Array.isArray(
-            this.options.preset?.value?.messages
-        )
-            ? (this.options.preset?.value.messages as BaseMessage[])
-            : []
+            if (!maxTokenLimit || maxTokenLimit <= 0) {
+                return {
+                    inputTokens,
+                    outputTokens: inputTokens,
+                    reducedTokens: 0,
+                    reducedPercent: 0,
+                    compressed: false
+                }
+            }
 
-        const presetTokens = await this._calculateMessageTokenStats(
-            model,
-            presetMessages
-        ).then((stats) =>
-            stats.reduce((sum, current) => sum + current.tokens, 0)
-        )
+            const presetMessages = Array.isArray(
+                this.options.preset?.value?.messages
+            )
+                ? (this.options.preset?.value.messages as BaseMessage[])
+                : []
 
-        const threshold = Math.floor(
-            maxTokenLimit * (this.options.threshold ?? 0.85)
-        )
+            presetTokens = await this._countMessagesTokens(
+                model,
+                presetMessages
+            )
+            threshold = Math.floor(
+                maxTokenLimit * (this.options.threshold ?? 0.85)
+            )
 
-        const stats = await this._calculateMessageTokenStats(model, messages)
-        const totalTokens =
-            stats.reduce((sum, current) => sum + current.tokens, 0) +
-            presetTokens
-
-        if (totalTokens <= threshold) {
-            return
-        }
-
-        logger.info(
-            `[InfiniteContext] Start compression with total tokens: ${totalTokens}, threshold: ${threshold}`
-        )
-
-        const filteredMessages = messages.filter(
-            (message) => !this._isToolRelatedMessage(message)
-        )
-
-        if (filteredMessages.length === 0) {
-            return
-        }
-
-        const filteredStats = await this._calculateMessageTokenStats(
-            model,
-            filteredMessages
-        )
-
-        const filteredTotalTokens =
-            filteredStats.reduce((sum, current) => sum + current.tokens, 0) +
-            presetTokens
-
-        if (filteredTotalTokens <= threshold) {
-            await this._rewriteChatHistory(filteredMessages)
+            if (inputTokens + presetTokens <= threshold) {
+                return {
+                    inputTokens,
+                    outputTokens: inputTokens,
+                    reducedTokens: 0,
+                    reducedPercent: 0,
+                    compressed: false
+                }
+            }
 
             logger.info(
-                '[InfiniteContext] Filtered tool-related messages reduced tokens from %d to %d',
-                totalTokens,
-                filteredTotalTokens
+                '[InfiniteContext] Start compression with history tokens: %d, total tokens: %d, threshold: %d',
+                inputTokens,
+                inputTokens + presetTokens,
+                threshold
             )
-
-            return
+        } else {
+            logger.info(
+                '[InfiniteContext] Start manual compression with history tokens: %d',
+                inputTokens
+            )
         }
 
-        const compressionResult = await this._compressMessages(
-            wrapper,
-            filteredStats,
-            maxTokenLimit
-        )
+        const transcript = formatTranscript(messages)
 
-        if (!compressionResult) {
-            if (filteredMessages.length !== messages.length) {
-                await this._rewriteChatHistory(filteredMessages)
-                logger.info(
-                    '[InfiniteContext] Filtered tool-related messages (compression skipped) reduced tokens from %d to %d',
-                    totalTokens,
-                    filteredTotalTokens
-                )
+        if (!transcript.trim()) {
+            return {
+                inputTokens,
+                outputTokens: inputTokens,
+                reducedTokens: 0,
+                reducedPercent: 0,
+                compressed: false
             }
-            return
         }
 
-        const { messages: rewrittenMessages, tokenCount } = compressionResult
+        const summary = await this._ensureInfiniteContextChain(
+            wrapper
+        ).compressChunk({
+            chunk: transcript,
+            conversationId: this.options.conversationId
+        })
 
-        const additionalArgs = {
-            ...(await this.options.chatHistory.getAdditionalArgs())
+        if (!summary?.text.trim()) {
+            return {
+                inputTokens,
+                outputTokens: inputTokens,
+                reducedTokens: 0,
+                reducedPercent: 0,
+                compressed: false
+            }
         }
 
-        await this.options.chatHistory.clear()
+        const message = new HumanMessage({
+            content: summary.text.trim(),
+            name: 'infinite_context',
+            additional_kwargs: {
+                source: 'infinite-context'
+            }
+        })
 
-        for (const message of rewrittenMessages) {
-            await this.options.chatHistory.addMessage(message)
-        }
+        await this._rewriteChatHistory([message])
 
-        if (Object.keys(additionalArgs).length > 0) {
-            await this.options.chatHistory.overrideAdditionalArgs(
-                additionalArgs
-            )
-        }
-
-        await this.options.chatHistory.loadConversation()
-
-        // Add presetTokens to post-compression count for consistent comparison
-        const newTotalTokens = tokenCount + presetTokens
-        const reducedTokens = totalTokens - newTotalTokens
+        const outputTokens = summary.usageMetadata?.output_tokens ?? 0
+        const reducedTokens = inputTokens - outputTokens
         const reducedPercent =
-            totalTokens > 0 ? (reducedTokens / totalTokens) * 100 : 0
+            inputTokens > 0 ? (reducedTokens / inputTokens) * 100 : 0
 
         logger.info(
-            '[InfiniteContext] Compressed tokens from %d to %d (-%d, -%s%%)',
-            totalTokens,
-            newTotalTokens,
+            '[InfiniteContext] Compressed history from %d to %d (-%d, %s%%)',
+            inputTokens,
+            outputTokens,
             reducedTokens,
             reducedPercent.toFixed(2)
         )
 
-        if (newTotalTokens > threshold) {
+        if (threshold != null && outputTokens + presetTokens > threshold) {
             logger.warn(
                 '[InfiniteContext] Tokens remain above threshold after compression: %d > %d',
-                newTotalTokens,
+                outputTokens + presetTokens,
                 threshold
             )
         }
-    }
-
-    private async _compressMessages(
-        wrapper: ChatLunaLLMChainWrapper,
-        stats: MessageTokenStat[],
-        maxTokenLimit: number
-    ): Promise<{ messages: BaseMessage[]; tokenCount: number } | null> {
-        const model = wrapper.model
-
-        const systemStats = stats.filter(
-            (item) => item.message.getType() === 'system'
-        )
-        const contentStats = stats.filter(
-            (item) => item.message.getType() !== 'system'
-        )
-
-        if (contentStats.length === 0) {
-            return null
-        }
-
-        let preserveCount = Math.min(8, contentStats.length)
-        let compressible: MessageTokenStat[] = []
-
-        while (preserveCount >= 0) {
-            const thresholdIndex = Math.max(
-                0,
-                contentStats.length - preserveCount
-            )
-
-            compressible = contentStats.filter(
-                (stat, index) => index < thresholdIndex
-            )
-
-            if (compressible.length > 0) {
-                break
-            }
-
-            preserveCount -= 1
-        }
-
-        if (compressible.length === 0) {
-            return null
-        }
-
-        const compressibleSet = new Set(compressible)
-        const preserved = contentStats.filter(
-            (stat) => !compressibleSet.has(stat)
-        )
-
-        const chunkStats = this._splitChunksForCompression(
-            compressible,
-            maxTokenLimit
-        )
-
-        if (chunkStats.length === 0) {
-            return null
-        }
-
-        const compressor = this._ensureInfiniteContextChain(wrapper)
-        const chunkSummaries: {
-            content: string
-            chunkIndex: number
-            chunkSize: number
-        }[] = []
-
-        const previousSummaries = compressible
-            .filter((stat) => this._isCompressedMessage(stat.message))
-            .map(
-                (stat) => getMessageContent(stat.message.content)?.trim() ?? ''
-            )
-            .filter((text) => text.length > 0)
-
-        for (let index = 0; index < chunkStats.length; index++) {
-            const chunk = chunkStats[index]
-            const chunkMessages = chunk
-                .map((item) => item.message)
-                // Once a summary is produced, treat it as standalone context and do not mix it into chunk compression again.
-                .filter((message) => !this._isCompressedMessage(message))
-
-            if (chunkMessages.length === 0) {
-                continue
-            }
-
-            const chunkText = this._formatChunkForCompression(chunkMessages)
-
-            const compressedText = await compressor.compressChunk({
-                chunk: chunkText,
-                conversationId: this.options.conversationId
-            })
-
-            if (!compressedText) {
-                continue
-            }
-
-            chunkSummaries.push({
-                content: compressedText,
-                chunkIndex: index,
-                chunkSize: chunkMessages.length
-            })
-        }
-
-        if (chunkSummaries.length === 0 && previousSummaries.length === 0) {
-            return null
-        }
-
-        const finalSummary = await this._buildFinalSummary(
-            compressor,
-            previousSummaries,
-            chunkSummaries
-        )
-
-        if (!finalSummary) {
-            return null
-        }
-
-        const compressedMessages: BaseMessage[] = [
-            new HumanMessage({
-                content: finalSummary.content,
-                name: 'infinite_context',
-                additional_kwargs: finalSummary.meta
-            })
-        ]
-
-        const mergedMessages = [
-            ...systemStats.map((item) => item.message),
-            ...compressedMessages,
-            ...preserved.map((item) => item.message)
-        ]
-
-        const tokenCount = await this._countMessagesTokens(
-            model,
-            mergedMessages
-        )
 
         return {
-            messages: mergedMessages,
-            tokenCount
+            inputTokens,
+            outputTokens,
+            reducedTokens,
+            reducedPercent,
+            compressed: true
         }
-    }
-
-    private _isCompressedMessage(message: BaseMessage): boolean {
-        const source = message?.additional_kwargs?.['source']
-        if (source === 'infinite-context') {
-            return true
-        }
-
-        if (message?.name === 'infinite_context') {
-            return true
-        }
-
-        const content = getMessageContent(message?.content ?? '')
-        return (
-            typeof content === 'string' &&
-            /<\/?infinite_context/iu.test(content)
-        )
-    }
-
-    private _isToolRelatedMessage(message: BaseMessage): boolean {
-        if (message.getType() === 'tool') {
-            return true
-        }
-
-        const anyMessage = message as unknown as {
-            tool_calls?: unknown
-            additional_kwargs?: Record<string, unknown>
-        }
-
-        if (
-            Array.isArray(anyMessage.tool_calls) &&
-            anyMessage.tool_calls.length > 0
-        ) {
-            return true
-        }
-
-        const additionalToolCalls = anyMessage.additional_kwargs?.[
-            'tool_calls'
-        ] as unknown
-
-        return (
-            Array.isArray(additionalToolCalls) && additionalToolCalls.length > 0
-        )
     }
 
     private async _rewriteChatHistory(messages: BaseMessage[]): Promise<void> {
@@ -370,50 +215,6 @@ export class InfiniteContextManager {
         await this.options.chatHistory.loadConversation()
     }
 
-    private _splitChunksForCompression(
-        stats: MessageTokenStat[],
-        maxTokenLimit: number
-    ): MessageTokenStat[][] {
-        const chunkTokenTarget = Math.max(Math.floor(maxTokenLimit * 0.15), 300)
-        const chunks: MessageTokenStat[][] = []
-        let currentChunk: MessageTokenStat[] = []
-        let currentTokens = 0
-
-        for (const stat of stats) {
-            if (
-                currentChunk.length > 0 &&
-                currentTokens + stat.tokens > chunkTokenTarget
-            ) {
-                chunks.push(currentChunk)
-                currentChunk = []
-                currentTokens = 0
-            }
-
-            currentChunk.push(stat)
-            currentTokens += stat.tokens
-        }
-
-        if (currentChunk.length > 0) {
-            chunks.push(currentChunk)
-        }
-
-        return chunks
-    }
-
-    private async _calculateMessageTokenStats(
-        model: ChatLunaChatModel,
-        messages: BaseMessage[]
-    ): Promise<MessageTokenStat[]> {
-        const stats: MessageTokenStat[] = []
-
-        for (const message of messages) {
-            const tokens = await model.countMessageTokens(message)
-            stats.push({ message, tokens })
-        }
-
-        return stats
-    }
-
     private async _countMessagesTokens(
         model: ChatLunaChatModel,
         messages: BaseMessage[]
@@ -427,17 +228,6 @@ export class InfiniteContextManager {
         return total
     }
 
-    private _formatChunkForCompression(messages: BaseMessage[]): string {
-        return messages
-            .map((message) => {
-                const role = message.getType().toUpperCase()
-                const nameSuffix = message.name ? ` (${message.name})` : ''
-                const content = getMessageContent(message.content).trim()
-                return `[${role}${nameSuffix}]\n${content || '(empty)'}`
-            })
-            .join('\n---\n')
-    }
-
     private _ensureInfiniteContextChain(
         wrapper: ChatLunaLLMChainWrapper
     ): ChatLunaInfiniteContextChain {
@@ -448,83 +238,5 @@ export class InfiniteContextManager {
         }
 
         return this._chain
-    }
-
-    private async _buildFinalSummary(
-        compressor: ChatLunaInfiniteContextChain,
-        previousSummaries: string[],
-        chunkSummaries: {
-            content: string
-            chunkIndex: number
-            chunkSize: number
-        }[]
-    ): Promise<{
-        content: string
-        meta: Record<string, unknown>
-    } | null> {
-        const cleanedPrevious = previousSummaries.filter(
-            (text) => text.trim().length > 0
-        )
-        const cleanedChunks = chunkSummaries.filter(
-            (summary) => summary.content.trim().length > 0
-        )
-
-        if (cleanedPrevious.length === 0 && cleanedChunks.length === 0) {
-            return null
-        }
-
-        if (cleanedPrevious.length === 0 && cleanedChunks.length === 1) {
-            return {
-                content: cleanedChunks[0].content.trim(),
-                meta: {
-                    source: 'infinite-context',
-                    mergedSegments: 1,
-                    previousSummaries: 0,
-                    chunkDetail: [
-                        {
-                            chunkIndex: cleanedChunks[0].chunkIndex,
-                            chunkSize: cleanedChunks[0].chunkSize
-                        }
-                    ]
-                }
-            }
-        }
-
-        // Build a virtual transcript that first feeds the existing summary and then the new chunk summaries.
-        const virtualTranscript: string[] = []
-
-        if (cleanedPrevious.length > 0) {
-            virtualTranscript.push(
-                `Existing summary snapshot:\n${cleanedPrevious.join('\n\n')}`
-            )
-        }
-
-        cleanedChunks.forEach((chunk, index) => {
-            virtualTranscript.push(
-                `Recent segment ${index + 1} (${chunk.chunkSize} turns):\n${chunk.content}`
-            )
-        })
-
-        const mergedInput = virtualTranscript.join('\n\n---\n\n')
-
-        const refined = await compressor.compressChunk({
-            chunk: mergedInput,
-            conversationId: this.options.conversationId
-        })
-
-        const content = refined?.trim() || mergedInput
-
-        return {
-            content,
-            meta: {
-                source: 'infinite-context',
-                mergedSegments: cleanedChunks.length,
-                previousSummaries: cleanedPrevious.length,
-                chunkDetail: cleanedChunks.map((chunk) => ({
-                    chunkIndex: chunk.chunkIndex,
-                    chunkSize: chunk.chunkSize
-                }))
-            }
-        }
     }
 }

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -108,7 +108,8 @@ commands:
                 arguments:
                     room: 'Target room'
                 messages:
-                    success: 'Chat history for room {0} has been compressed.'
+                    success: '{0} -> {1}, {2}%'
+                    skipped: 'Compression skipped. {0} -> {1}, {2}%'
                     no_room: 'Room not found.'
                     failed: 'Failed to compress chat history for room {0}: {1}'
             set:
@@ -236,7 +237,7 @@ commands:
                     conversation_not_exist: 'Room does not exist.'
                     no_chat_history: 'Chat history not found.'
                     invalid_chat_history: 'Invalid chat history. Clear history and retry.'
-                    rollback_success_1: "Successfully rolled back to {0} rounds ago."
+                    rollback_success_1: 'Successfully rolled back to {0} rounds ago.'
             stop:
                 description: Immediately terminate ongoing conversation.
                 options:
@@ -246,6 +247,15 @@ commands:
                     no_active_chat: 'No active conversation in current room.'
                     stop_failed: 'Failed to stop conversation.'
                     success: 'Conversation stopped successfully.'
+            compress:
+                description: Manually compress chat history using Infinite Context.
+                options:
+                    room: Target room for compression.
+                messages:
+                    success: '{0} -> {1}, {2}%'
+                    skipped: 'Compression skipped. {0} -> {1}, {2}%'
+                    no_room: 'Room not found.'
+                    failed: 'Failed to compress chat history for room {0}: {1}'
             voice:
                 description: Converse with AI model and receive voice output.
                 options:

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -108,7 +108,8 @@ commands:
                 arguments:
                     room: '目标房间。'
                 messages:
-                    success: '已压缩房间 {0} 的聊天记录。'
+                    success: '{0} -> {1}, {2}%'
+                    skipped: '未执行压缩。{0} -> {1}, {2}%'
                     no_room: '未找到指定的房间。'
                     failed: '压缩房间 {0} 的聊天记录失败：{1}'
             set:
@@ -246,6 +247,15 @@ commands:
                     no_active_chat: '当前未在房间中对话。'
                     stop_failed: '停止对话失败。'
                     success: '已成功停止当前对话。'
+            compress:
+                description: 手动压缩聊天记录（使用无限上下文）。
+                options:
+                    room: 指定要压缩的目标房间。
+                messages:
+                    success: '{0} -> {1}, {2}%'
+                    skipped: '未执行压缩。{0} -> {1}, {2}%'
+                    no_room: '未找到指定的房间。'
+                    failed: '压缩房间 {0} 的聊天记录失败：{1}'
             voice:
                 description: 与模型进行对话并将回复转换为语音输出。
                 options:
@@ -549,7 +559,6 @@ commands:
                     pages: '当前为第 [page] / [total] 页'
                     search_failed: '搜索记忆失败。'
                     invalid_view: '无效的记忆层级。目前可用：{0}'
-
 
             delete:
                 description: '删除记忆。'

--- a/packages/core/src/middlewares/room/compress_room.ts
+++ b/packages/core/src/middlewares/room/compress_room.ts
@@ -32,18 +32,39 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             }
 
             if (targetRoom == null) {
-                context.message = session.text('.no_room')
+                const key =
+                    context.options.i18n_base ??
+                    'commands.chatluna.room.compress.messages'
+
+                context.message = session.text(`${key}.no_room`)
                 return ChainMiddlewareRunStatus.STOP
             }
 
             try {
-                await ctx.chatluna.compressContext(targetRoom)
-                context.message = session.text('.success', [
-                    targetRoom.roomName
-                ])
+                const key =
+                    context.options.i18n_base ??
+                    'commands.chatluna.room.compress.messages'
+                const result = await ctx.chatluna.compressContext(
+                    targetRoom,
+                    context.options.force === true
+                )
+                const args = [
+                    result.inputTokens,
+                    result.outputTokens,
+                    result.reducedPercent.toFixed(2)
+                ]
+
+                context.message = session.text(
+                    result.compressed ? `${key}.success` : `${key}.skipped`,
+                    args
+                )
             } catch (error) {
                 ctx.logger.error(error)
-                context.message = session.text('.failed', [
+                const key =
+                    context.options.i18n_base ??
+                    'commands.chatluna.room.compress.messages'
+
+                context.message = session.text(`${key}.failed`, [
                     targetRoom.roomName,
                     error.message
                 ])

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -264,11 +264,11 @@ export class ChatLunaService extends Service<Config> {
         return chatBridger.clearChatHistory(room)
     }
 
-    async compressContext(room: ConversationRoom) {
+    async compressContext(room: ConversationRoom, force = false) {
         const chatBridger =
             this._chatInterfaceWrapper ?? this._createChatInterfaceWrapper()
 
-        return chatBridger.compressContext(room)
+        return chatBridger.compressContext(room, force)
     }
 
     getCachedInterfaceWrapper() {
@@ -1163,7 +1163,7 @@ class ChatInterfaceWrapper {
         }
     }
 
-    async compressContext(room: ConversationRoom) {
+    async compressContext(room: ConversationRoom, force = false) {
         const { conversationId, model: fullModelName } = room
         const requestId = randomUUID()
         const modelRequestId = randomUUID()
@@ -1200,7 +1200,7 @@ class ChatInterfaceWrapper {
             ])
 
             const chatInterface = await this.query(room, true)
-            return await chatInterface.compressContext()
+            return await chatInterface.compressContext(force)
         } finally {
             await Promise.all([
                 this._conversationQueue.remove(conversationId, requestId),


### PR DESCRIPTION
This PR refactors the infinite context compression system to be simpler and more straightforward.

## New Features

- Added manual compression command via `chatluna.chat.compress` with optional room selection and force flag
- Added `CompressContextResult` interface to track compression metrics (input tokens, output tokens, reduction percentage)
- Improved compression feedback with detailed metrics displayed in user-facing messages

## Bug fixes

- Fixed compression logic to handle edge cases and empty conversations properly
- Improved error handling in compression workflow with better i18n support

## Other Changes

- Simplified compression prompt and logic to focus on conversation summarization
- Replaced chunked compression approach with single-pass summary of entire conversation
- Removed complex message filtering and token-based chunking logic
- Extracted `formatTranscript` helper function for cleaner code
- Updated i18n messages for both English and Chinese to display token reduction statistics
- Updated room.ts and chat.ts commands to support i18n_base option for flexible message localization
- Improved compression flow to provide better feedback to users about compression results