### PR TITLE
fix(extension-long-memory): stabilize emgas extraction and graph persistence

### DIFF
--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koishi-plugin-chatluna-long-memory",
   "description": "long memory for chatluna",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",
   "typings": "lib/index.d.ts",

--- a/packages/extension-long-memory/src/layers/emgas/extractor.ts
+++ b/packages/extension-long-memory/src/layers/emgas/extractor.ts
@@ -1,16 +1,8 @@
-import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
 import YAML from 'js-yaml'
 import { ComputedRef } from 'koishi-plugin-chatluna'
+import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
-import {
-    ChatLunaError,
-    ChatLunaErrorCode
-} from 'koishi-plugin-chatluna/utils/error'
-
-export interface ExtractedGraphElements {
-    concepts: string[]
-    topics: string[]
-}
+import { ExtractedGraphElements } from './types'
 
 const GRAPH_ELEMENTS_EXTRACTION_PROMPT = (text: string) => `
 You are an expert in knowledge extraction. Your task is to analyze the following text to identify key concepts and overarching topics.
@@ -45,66 +37,147 @@ topics:
 YAML Output:
 `
 
+const STOP_WORDS = new Set([
+    'a',
+    'an',
+    'and',
+    'are',
+    'as',
+    'at',
+    'be',
+    'by',
+    'for',
+    'from',
+    'how',
+    'in',
+    'is',
+    'it',
+    'of',
+    'on',
+    'or',
+    'that',
+    'the',
+    'their',
+    'they',
+    'this',
+    'to',
+    'with',
+    '用户',
+    '我们',
+    '你们',
+    '他们',
+    '以及',
+    '但是',
+    '如果',
+    '因为',
+    '所以'
+])
+
+function format(items: unknown[]): string[] {
+    return items
+        .map((item) => String(item).trim().replace(/\s+/g, ' '))
+        .filter(Boolean)
+        .map((item) =>
+            /^[\x00-\x7F]+$/.test(item) ? item.toLowerCase() : item
+        )
+}
+
+function extractLocal(text: string): ExtractedGraphElements {
+    const counts = new Map<string, number>()
+    const groups: string[] = []
+
+    for (const item of text.match(
+        /[A-Za-z][A-Za-z0-9+#./-]{1,}|[\u3400-\u9fff]{2,}/g
+    ) ?? []) {
+        if (/^[A-Za-z]/.test(item)) {
+            const word = item.toLowerCase()
+            if (STOP_WORDS.has(word)) {
+                continue
+            }
+            counts.set(word, (counts.get(word) ?? 0) + 1)
+            if (word.length >= 4) {
+                groups.push(word)
+            }
+            continue
+        }
+
+        if (item.length >= 2) {
+            groups.push(item.length > 12 ? item.slice(0, 12) : item)
+        }
+
+        if (item.length <= 8) {
+            counts.set(item, (counts.get(item) ?? 0) + 1)
+            continue
+        }
+
+        for (let i = 0; i < item.length - 1; i++) {
+            const word = item.slice(i, i + 2)
+            counts.set(word, (counts.get(word) ?? 0) + 1)
+        }
+    }
+
+    const concepts = Array.from(counts.entries())
+        .sort((a, b) => b[1] - a[1] || b[0].length - a[0].length)
+        .map(([item]) => item)
+        .slice(0, 12)
+
+    const topics = Array.from(new Set(format(groups)))
+        .filter((item) => !STOP_WORDS.has(item))
+        .slice(0, 3)
+
+    return {
+        concepts,
+        topics: topics.length > 0 ? topics : concepts.slice(0, 3)
+    }
+}
+
 /**
- * Extracts key concepts and topics from a text chunk using an LLM.
- * @param ctx The Koishi context.
- * @param config The plugin configuration.
+ * Extracts key concepts and topics from a text chunk.
+ * It prefers the configured LLM and falls back to local extraction.
+ * @param modelRef The configured extractor model.
  * @param text The text to analyze.
  * @returns A promise that resolves to an object containing concepts and topics.
  */
 export async function extractGraphElements(
-    modelRef: ComputedRef<ChatLunaChatModel>,
+    modelRef: ComputedRef<ChatLunaChatModel | undefined> | undefined,
     text: string
 ): Promise<ExtractedGraphElements> {
-    if (!modelRef.value) {
-        throw new ChatLunaError(
-            ChatLunaErrorCode.MODEL_NOT_FOUND,
-            new Error(
-                'LLM-based extractor is disabled. Cannot extract graph elements.'
-            )
-        )
+    const model = modelRef?.value
+    if (model == null) {
+        return extractLocal(text)
     }
-
-    const model = modelRef.value
 
     try {
         const prompt = GRAPH_ELEMENTS_EXTRACTION_PROMPT(text)
         const res = await model.invoke(prompt)
-        const content = getMessageContent(res.content)
+        const content = getMessageContent(res.content).trim()
 
         const yamlMatch = content.match(
             /```(?:ya?ml)?\s*\r?\n([\s\S]*?)\r?\n```/i
         )
-        if (yamlMatch && yamlMatch[1]) {
-            const parsed = YAML.load(yamlMatch[1]) as {
-                concepts: string[]
-                topics: string[]
-            }
-            return {
-                concepts: []
-                    .concat(parsed.concepts || [])
-                    .map((item) => String(item).trim())
-                    .filter(Boolean),
-                topics: []
-                    .concat(parsed.topics || [])
-                    .map((item) => String(item).trim())
-                    .filter(Boolean)
+        const parsed = YAML.load(yamlMatch?.[1] ?? content) as {
+            concepts?: unknown[]
+            topics?: unknown[]
+        } | null
+
+        if (parsed && typeof parsed === 'object') {
+            const concepts = format(
+                Array.isArray(parsed.concepts) ? parsed.concepts : []
+            )
+            const topics = format(
+                Array.isArray(parsed.topics) ? parsed.topics : []
+            )
+
+            if (concepts.length > 0 || topics.length > 0) {
+                return {
+                    concepts,
+                    topics: topics.length > 0 ? topics : concepts.slice(0, 3)
+                }
             }
         }
 
-        throw new ChatLunaError(
-            ChatLunaErrorCode.MODEL_RESPONSE_IS_EMPTY,
-            new Error(
-                'LLM did not return a valid YAML for graph element extraction.'
-            )
-        )
-    } catch (error) {
-        if (error instanceof ChatLunaError) {
-            throw error
-        }
-        throw new ChatLunaError(
-            ChatLunaErrorCode.API_REQUEST_FAILED,
-            error as Error
-        )
+        return extractLocal(text)
+    } catch {
+        return extractLocal(text)
     }
 }

--- a/packages/extension-long-memory/src/layers/emgas/graph.ts
+++ b/packages/extension-long-memory/src/layers/emgas/graph.ts
@@ -1,8 +1,9 @@
-import { ExtractedGraphElements } from './extractor'
 import {
+    ExtractedGraphElements,
     MemoryEdge,
     MemoryNode,
     SerializedMemoryGraph,
+    SerializedMemoryNode,
     SpreadingActivationOptions
 } from './types'
 
@@ -289,15 +290,18 @@ export class MemoryGraph {
     }
 
     public toJSON(): SerializedMemoryGraph {
-        const nodes: MemoryNode[] = Array.from(this.nodes.values()).map(
-            (node) =>
-                ({
-                    ...node,
-                    sourcePassageIds: node.sourcePassageIds
-                        ? Array.from(node.sourcePassageIds)
-                        : []
-                }) as unknown as MemoryNode
-        )
+        const nodes: SerializedMemoryNode[] = Array.from(
+            this.nodes.values()
+        ).map((node) => ({
+            id: node.id,
+            type: node.type,
+            baseActivation: node.baseActivation,
+            createdAt: node.createdAt.toISOString(),
+            lastAccessed: node.lastAccessed.toISOString(),
+            sourcePassageIds: node.sourcePassageIds
+                ? Array.from(node.sourcePassageIds)
+                : []
+        }))
 
         const edges: MemoryEdge[] = []
         const seenEdges = new Set<string>()
@@ -329,9 +333,11 @@ export class MemoryGraph {
 
         for (const nodeData of serializedGraph.nodes || []) {
             graph.nodes.set(nodeData.id, {
-                ...nodeData,
                 createdAt: new Date(nodeData.createdAt),
                 lastAccessed: new Date(nodeData.lastAccessed),
+                id: nodeData.id,
+                type: nodeData.type,
+                baseActivation: nodeData.baseActivation,
                 sourcePassageIds: new Set(nodeData.sourcePassageIds || [])
             })
         }

--- a/packages/extension-long-memory/src/layers/emgas/index.ts
+++ b/packages/extension-long-memory/src/layers/emgas/index.ts
@@ -1,3 +1,4 @@
 export * from './types'
+export { extractGraphElements } from './extractor'
 export { MemoryGraph } from './graph'
 export { EmgasMemoryLayer } from './layer'

--- a/packages/extension-long-memory/src/layers/emgas/layer.ts
+++ b/packages/extension-long-memory/src/layers/emgas/layer.ts
@@ -1,5 +1,10 @@
-import { Context } from 'koishi'
 import { randomUUID } from 'crypto'
+import { promises as fs } from 'fs'
+import * as path from 'path'
+import { Context } from 'koishi'
+import { ComputedRef } from 'koishi-plugin-chatluna'
+import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
+import { DataBaseDocstore } from 'koishi-plugin-chatluna/llm-core/vectorstores'
 import { Config, logger } from '../../index'
 import {
     EnhancedMemory,
@@ -10,21 +15,20 @@ import {
     BaseMemoryRetrievalLayer,
     resolveLongMemoryId
 } from '../../utils/layer'
-import { MemoryGraph } from './graph'
-import { SpreadingActivationOptions } from './types'
 import {
     documentToEnhancedMemory,
     enhancedMemoryToDocument
 } from '../../utils/memory'
-import { promises as fs } from 'fs'
-import * as path from 'path'
-import { DataBaseDocstore } from 'koishi-plugin-chatluna/llm-core/vectorstores'
 import { extractGraphElements } from './extractor'
-import { ComputedRef } from 'koishi-plugin-chatluna'
-import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/model'
+import { MemoryGraph } from './graph'
+import { SpreadingActivationOptions } from './types'
 
 // Helper function to get the persistence path for a memory graph
-function getGraphFilePath(baseDir: string, memoryId: string): string {
+function getGraphFilePath(
+    baseDir: string,
+    memoryId: string,
+    dir: string = 'emgas'
+): string {
     if (!memoryId || typeof memoryId !== 'string') {
         throw new Error('Invalid memoryId: must be a non-empty string.')
     }
@@ -37,7 +41,10 @@ function getGraphFilePath(baseDir: string, memoryId: string): string {
 
     return path.join(
         baseDir,
-        'data/chatluna/long-memory/emgasa',
+        'data',
+        'chatluna',
+        'long-memory',
+        dir,
         `${sanitizedId}.json`
     )
 }
@@ -52,7 +59,7 @@ export class EmgasMemoryLayer<
 
     private docstore: DataBaseDocstore
 
-    private extractModel: ComputedRef<ChatLunaChatModel>
+    private extractModel: ComputedRef<ChatLunaChatModel | undefined> | undefined
 
     constructor(
         protected ctx: Context,
@@ -68,30 +75,61 @@ export class EmgasMemoryLayer<
             `Initializing EMGAS layer for memory ID: ${this.info.memoryId}`
         )
         const baseDir = this.ctx.baseDir || process.cwd()
-        const filePath = getGraphFilePath(baseDir, this.info.memoryId)
+        let loaded = false
 
-        try {
-            const data = await fs.readFile(filePath, 'utf-8')
-            const serialized = JSON.parse(data)
-            this.memoryGraph = MemoryGraph.fromJSON(serialized)
-            logger.debug(`EMGAS graph loaded from ${filePath}`)
-        } catch (error) {
-            const err = error as NodeJS.ErrnoException
-            if (err && err.code === 'ENOENT') {
-                logger.debug(
-                    `No existing EMGAS graph found for ${this.info.memoryId}. A new one will be created.`
-                )
-            } else {
+        for (const filePath of [
+            getGraphFilePath(baseDir, this.info.memoryId),
+            getGraphFilePath(baseDir, this.info.memoryId, 'emgasa')
+        ]) {
+            try {
+                const data = await fs.readFile(filePath, 'utf-8')
+                const serialized = JSON.parse(data)
+                this.memoryGraph = MemoryGraph.fromJSON(serialized)
+                logger.debug(`EMGAS graph loaded from ${filePath}`)
+                loaded = true
+                break
+            } catch (error) {
+                const err = error as NodeJS.ErrnoException
+                if (err && err.code === 'ENOENT') {
+                    continue
+                }
+
                 logger.error(
-                    `Failed to load EMGAS graph from ${filePath}:`,
+                    `Failed to load EMGAS graph for ${this.info.memoryId}:`,
                     error
                 )
+                break
             }
         }
 
-        this.extractModel = await this.ctx.chatluna.createChatModel(
-            this.config.emgasExtractModel
-        )
+        if (!loaded) {
+            logger.debug(
+                `No existing EMGAS graph found for ${this.info.memoryId}. A new one will be created.`
+            )
+        }
+
+        const modelName =
+            this.config.emgasExtractModel !== '无'
+                ? this.config.emgasExtractModel
+                : this.config.longMemoryExtractModel !== '无'
+                  ? this.config.longMemoryExtractModel
+                  : this.config.hippoExtractModel !== '无'
+                    ? this.config.hippoExtractModel
+                    : undefined
+
+        this.extractModel = undefined
+        if (modelName?.includes('/')) {
+            this.extractModel =
+                await this.ctx.chatluna.createChatModel(modelName)
+        } else if (modelName != null) {
+            logger.warn(
+                `Invalid EMGAS extractor model: ${modelName}. Falling back to local concept extraction.`
+            )
+        } else {
+            logger.debug(
+                'No EMGAS extractor model configured. Falling back to local concept extraction.'
+            )
+        }
 
         // Initialize the doc store for passage storage
         this.docstore = new DataBaseDocstore(

--- a/packages/extension-long-memory/src/layers/emgas/types.ts
+++ b/packages/extension-long-memory/src/layers/emgas/types.ts
@@ -3,6 +3,11 @@
  * Based on the TypeScript blueprint provided in the design document.
  */
 
+export interface ExtractedGraphElements {
+    concepts: string[]
+    topics: string[]
+}
+
 /**
  * Options for the Spreading Activation retrieval algorithm.
  */
@@ -73,6 +78,15 @@ export interface MemoryNode {
     sourcePassageIds?: Set<string>
 }
 
+export interface SerializedMemoryNode extends Omit<
+    MemoryNode,
+    'createdAt' | 'lastAccessed' | 'sourcePassageIds'
+> {
+    createdAt: string
+    lastAccessed: string
+    sourcePassageIds: string[]
+}
+
 /**
  * Represents a weighted edge in the memory graph, connecting two nodes.
  */
@@ -105,7 +119,7 @@ export interface MemoryEdge {
  * Represents the entire memory graph, including nodes, edges, and persistence data.
  */
 export interface SerializedMemoryGraph {
-    nodes: MemoryNode[]
+    nodes: SerializedMemoryNode[]
     edges: MemoryEdge[]
     conceptCounts: [string, number][]
     pairCounts: [string, number][]


### PR DESCRIPTION
## Summary
- add a local concept extraction fallback so EMGAS still indexes memories when no dedicated extractor model is configured or the model response is malformed
- fix EMGAS graph serialization and legacy path loading so persisted graphs can be saved and restored reliably
- reuse compatible extractor model settings and export the extractor helper for the layer module

## Validation
- yarn fast-build extension-long-memory