### PR TITLE
feat(core): refine config schema and fix emgas lint

### DIFF
--- a/packages/core/src/chains/chain.ts
+++ b/packages/core/src/chains/chain.ts
@@ -27,8 +27,8 @@ export class ChatChain {
 
         const defaultChatChainSender = new DefaultChatChainSender(config)
 
-        this._senders.push((session, messages) =>
-            defaultChatChainSender.send(session, messages)
+        this._senders.push((session, messages, context) =>
+            defaultChatChainSender.send(session, messages, context)
         )
     }
 
@@ -58,8 +58,10 @@ export class ChatChain {
             message: session.content,
             ctx: ctx ?? this.ctx,
             session,
-            options: {},
-            send: (message) => this.sendMessage(session, message),
+            options: {
+                requestStartedAt: Date.now()
+            },
+            send: (message) => this.sendMessage(session, message, context),
             recallThinkingMessage: this._createRecallThinkingMessage(
                 {} as ChainMiddlewareContext
             )
@@ -87,11 +89,14 @@ export class ChatChain {
             ctx,
             session,
             command,
-            send: (message) => this.sendMessage(session, message),
+            send: (message) => this.sendMessage(session, message, context),
             recallThinkingMessage: this._createRecallThinkingMessage(
                 {} as ChainMiddlewareContext
             ),
-            options
+            options: {
+                ...options,
+                requestStartedAt: Date.now()
+            }
         }
 
         context.recallThinkingMessage =
@@ -182,7 +187,7 @@ export class ChatChain {
         }
 
         if (context.message != null && context.message !== originMessage) {
-            await this.sendMessage(session, context.message)
+            await this.sendMessage(session, context.message, context)
         }
 
         return true
@@ -312,13 +317,14 @@ export class ChatChain {
 
     private async sendMessage(
         session: Session,
-        message: h[] | h[][] | h | string
+        message: h[] | h[][] | h | string,
+        context?: ChainMiddlewareContext
     ) {
         const messages: (h[] | h | string)[] =
             message instanceof Array ? message : [message]
 
         for (const sender of this._senders) {
-            await sender(session, messages)
+            await sender(session, messages, context)
         }
     }
 
@@ -329,7 +335,7 @@ export class ChatChain {
         isOutputLog: boolean
     ) {
         if (context.message != null && context.message !== originMessage) {
-            await this.sendMessage(session, context.message)
+            await this.sendMessage(session, context.message, context)
         }
 
         if (isOutputLog) {
@@ -347,7 +353,7 @@ export class ChatChain {
                 error.errorCode === ChatLunaErrorCode.ABORTED
                     ? session.text('chatluna.aborted')
                     : error.message
-            await this.sendMessage(session, message)
+            await this.sendMessage(session, message, undefined)
             return
         }
 
@@ -361,7 +367,8 @@ export class ChatChain {
             session.text('chatluna.middleware_error', [
                 middlewareName,
                 error.message
-            ])
+            ]),
+            undefined
         )
     }
 }
@@ -719,7 +726,8 @@ class DefaultChatChainSender {
 
     async send(
         session: Session,
-        messages: (h[] | h | string)[]
+        messages: (h[] | h | string)[],
+        context?: ChainMiddlewareContext
     ): Promise<void> {
         if (!messages?.length) return
 
@@ -740,7 +748,7 @@ class DefaultChatChainSender {
             return
         }
 
-        await this.sendAsNormal(session, messages)
+        await this.sendAsNormal(session, messages, context)
     }
 
     private async sendAsQQMarkdown(
@@ -800,12 +808,14 @@ class DefaultChatChainSender {
 
     private async sendAsNormal(
         session: Session,
-        messages: (h[] | h | string)[]
+        messages: (h[] | h | string)[],
+        context?: ChainMiddlewareContext
     ): Promise<void> {
         for (const message of messages) {
             const messageFragment = await this.buildMessageFragment(
                 session,
-                message
+                message,
+                context
             )
 
             if (!messageFragment?.length) continue
@@ -817,12 +827,20 @@ class DefaultChatChainSender {
 
     private async buildMessageFragment(
         session: Session,
-        message: h[] | h | string
+        message: h[] | h | string,
+        context?: ChainMiddlewareContext
     ): Promise<h[]> {
+        const requestStartedAt = context?.options?.requestStartedAt
+        const elapsedTime =
+            typeof requestStartedAt === 'number'
+                ? Date.now() - requestStartedAt
+                : 0
+        const quoteThreshold = (this.config.replyQuoteThreshold ?? 0) * 1000
         const shouldAddQuote =
             this.config.isReplyWithAt &&
             session.isDirect === false &&
-            session.messageId
+            session.messageId &&
+            elapsedTime >= quoteThreshold
 
         const messageContent = this.convertMessageToArray(message)
 
@@ -896,7 +914,8 @@ export type ChainMiddlewareFunction = (
 
 export type ChatChainSender = (
     session: Session,
-    message: (h[] | h | string)[]
+    message: (h[] | h | string)[],
+    context?: ChainMiddlewareContext
 ) => Promise<void>
 
 export enum ChainMiddlewareRunStatus {

--- a/packages/core/src/chains/chain.ts
+++ b/packages/core/src/chains/chain.ts
@@ -59,7 +59,7 @@ export class ChatChain {
             ctx: ctx ?? this.ctx,
             session,
             options: {
-                requestStartedAt: Date.now()
+                startedAt: Date.now()
             },
             send: (message) => this.sendMessage(session, message, context),
             recallThinkingMessage: this._createRecallThinkingMessage(
@@ -95,7 +95,7 @@ export class ChatChain {
             ),
             options: {
                 ...options,
-                requestStartedAt: Date.now()
+                startedAt: Date.now()
             }
         }
 
@@ -830,17 +830,14 @@ class DefaultChatChainSender {
         message: h[] | h | string,
         context?: ChainMiddlewareContext
     ): Promise<h[]> {
-        const requestStartedAt = context?.options?.requestStartedAt
-        const elapsedTime =
-            typeof requestStartedAt === 'number'
-                ? Date.now() - requestStartedAt
-                : 0
-        const quoteThreshold = (this.config.replyQuoteThreshold ?? 0) * 1000
+        const start = context?.options?.startedAt
+        const elapsed = start ? Date.now() - start : 0
+        const threshold = (this.config.replyQuoteThreshold ?? 0) * 1000
         const shouldAddQuote =
             this.config.isReplyWithAt &&
             session.isDirect === false &&
             session.messageId &&
-            elapsedTime >= quoteThreshold
+            elapsed >= threshold
 
         const messageContent = this.convertMessageToArray(message)
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,6 +15,7 @@ export interface Config {
     isLog: boolean
 
     isReplyWithAt: boolean
+    replyQuoteThreshold?: number
     allowQuoteReply: boolean
     proxyAddress: string
     isProxy: boolean
@@ -66,9 +67,6 @@ export const Config: Schema<Config> = Schema.intersect([
         allowPrivate: Schema.boolean().default(true),
         allowAtReply: Schema.boolean().default(true),
         allowQuoteReply: Schema.boolean().default(false),
-        isReplyWithAt: Schema.boolean().default(false),
-        isForwardMsg: Schema.boolean().default(false),
-        forwardMsgMinLength: Schema.number().min(0).max(400).step(1).default(0),
         privateChatWithoutCommand: Schema.boolean().default(true),
         allowChatWithRoomName: Schema.boolean().default(false),
         includeQuoteReply: Schema.boolean().default(true),
@@ -80,6 +78,40 @@ export const Config: Schema<Config> = Schema.intersect([
             .computed(),
         attachForwardMsgIdToContext: Schema.boolean().default(false)
     }),
+
+    Schema.intersect([
+        Schema.object({
+            isForwardMsg: Schema.boolean().default(false)
+        }),
+        Schema.union([
+            Schema.object({
+                isForwardMsg: Schema.const(true).required(),
+                forwardMsgMinLength: Schema.number()
+                    .min(0)
+                    .max(400)
+                    .step(1)
+                    .default(0)
+            }),
+            Schema.object({})
+        ])
+    ]),
+
+    Schema.intersect([
+        Schema.object({
+            isReplyWithAt: Schema.boolean().default(false)
+        }),
+        Schema.union([
+            Schema.object({
+                isReplyWithAt: Schema.const(true).required(),
+                replyQuoteThreshold: Schema.number()
+                    .min(0)
+                    .max(600)
+                    .step(1)
+                    .default(0)
+            }),
+            Schema.object({})
+        ])
+    ]),
 
     Schema.object({
         sendThinkingMessage: Schema.boolean().default(true),

--- a/packages/core/src/locales/en-US.schema.yml
+++ b/packages/core/src/locales/en-US.schema.yml
@@ -9,14 +9,17 @@ $inner:
       allowPrivate: Enable private chat conversations.
       allowAtReply: Enable @mention triggering.
       allowQuoteReply: Enable quote triggering.
-      isReplyWithAt: Quote original message in bot replies.
-      isForwardMsg: Send bot replies as forwarded messages.
       privateChatWithoutCommand: Enable direct conversation in private chats without commands.
       allowChatWithRoomName: 'Enable room name prefix triggering. Note: May impact performance significantly. Recommended for use with filters in specific groups only.'
       randomReplyFrequency: Set random reply frequency (0-100, where 0 means never and 100 means always).
-      forwardMsgMinLength: Set minimum length of forwarded messages (characters).
-      includeQuoteReply: Include quoted message content in replies.
+      includeQuoteReply: Include quoted message content in requests sent to the model.
       attachForwardMsgIdToContext: Attach forward message record IDs to context. When enabled, a "[聊天记录]" marker message will be appended if forward records are detected.
+
+    - isForwardMsg: Send bot replies as forwarded messages.
+      forwardMsgMinLength: Set minimum length of forwarded messages (characters).
+
+    - isReplyWithAt: Quote the original message when the bot replies.
+      replyQuoteThreshold: Minimum response time required to quote the original message. Set to 0 to always apply. When greater than 0, the original message will only be quoted if the response time exceeds this threshold.
 
     - $desc: Response Options
       sendThinkingMessage: Send waiting message during processing.

--- a/packages/core/src/locales/zh-CN.schema.yml
+++ b/packages/core/src/locales/zh-CN.schema.yml
@@ -8,14 +8,17 @@ $inner:
       allowPrivate: 是否允许在私聊中触发对话。
       allowAtReply: 是否允许通过 @ bot 来触发对话。
       allowQuoteReply: 是否允许通过引用 bot 的消息来触发对话。
-      isReplyWithAt: 当 bot 回复时，是否引用原消息。
-      isForwardMsg: 是否以合并消息的形式发送 bot 的回复。
-      forwardMsgMinLength: 合并消息的最小应用长度。为 0 则总是应用。设置大于 0 时，只有发送的文本大于此长度才会转为合并消息。
       privateChatWithoutCommand: 在私聊中是否允许无需命令直接与 bot 对话。
       allowChatWithRoomName: 是否允许使用房间名前缀触发对话。注意：启用此选项可能会显著影响 ChatLuna 的性能，建议配合过滤器仅在特定群组中启用。
       randomReplyFrequency: 设置随机回复的频率。
-      includeQuoteReply: 是否在回复内容中包含引用消息的内容。
+      includeQuoteReply: 是否在向模型的请求内容中添加被引用的消息内容
       attachForwardMsgIdToContext: 是否将合并转发聊天记录消息的 ID 附加到上下文中。启用后，检测到聊天记录会额外追加一条 [聊天记录] 消息。
+
+    - isForwardMsg: 是否以合并消息的形式发送 bot 的回复。
+      forwardMsgMinLength: 合并消息的最小应用长度。为 0 则总是应用。设置大于 0 时，只有发送的文本大于此长度才会转为合并消息。
+
+    - isReplyWithAt: 当 bot 回复时，是否引用原消息
+      replyQuoteThreshold: 引用原消息的最小响应时长。为 0 则总是应用。设置大于 0 时，只有响应耗时大于此时长才会引用原消息。
 
     - $desc: 对话响应选项
       sendThinkingMessage: 是否在请求处理过程中发送等待消息。

--- a/packages/extension-long-memory/src/layers/emgas/extractor.ts
+++ b/packages/extension-long-memory/src/layers/emgas/extractor.ts
@@ -73,13 +73,15 @@ const STOP_WORDS = new Set([
     '所以'
 ])
 
+function isAscii(text: string): boolean {
+    return Array.from(text).every((char) => char.charCodeAt(0) <= 0x7f)
+}
+
 function format(items: unknown[]): string[] {
     return items
         .map((item) => String(item).trim().replace(/\s+/g, ' '))
         .filter(Boolean)
-        .map((item) =>
-            /^[\x00-\x7F]+$/.test(item) ? item.toLowerCase() : item
-        )
+        .map((item) => (isAscii(item) ? item.toLowerCase() : item))
 }
 
 function extractLocal(text: string): ExtractedGraphElements {

--- a/packages/extension-long-memory/src/layers/emgas/extractor.ts
+++ b/packages/extension-long-memory/src/layers/emgas/extractor.ts
@@ -73,15 +73,15 @@ const STOP_WORDS = new Set([
     '所以'
 ])
 
-function isAscii(text: string): boolean {
-    return Array.from(text).every((char) => char.charCodeAt(0) <= 0x7f)
-}
-
 function format(items: unknown[]): string[] {
     return items
         .map((item) => String(item).trim().replace(/\s+/g, ' '))
         .filter(Boolean)
-        .map((item) => (isAscii(item) ? item.toLowerCase() : item))
+        .map((item) =>
+            Array.from(item).every((char) => char.charCodeAt(0) <= 0x7f)
+                ? item.toLowerCase()
+                : item
+        )
 }
 
 function extractLocal(text: string): ExtractedGraphElements {


### PR DESCRIPTION
将 isReplyWithAt 从单纯布尔开关改为“开关 + 阈值分支”配置
新增 replyQuoteThreshold，用于按响应耗时决定是否引用原消息
将 isForwardMsg 同样改为“开关 + 阈值分支”配置
forwardMsgMinLength 仅在启用合并消息时显示
调整 schema 结构，使两个分支配置分别紧跟各自开关显示
同步更新中英文 locales 文案
优化 includeQuoteReply 与 replyQuoteThreshold 的中文描述，使其语义更准确、表达更统一
修复了lint问题
