### PR TITLE
[Fix] Restore adapter v1 endpoint and streaming compatibility

### DIFF
--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -78,13 +78,15 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
         )
 
         if (!this._config.pullModels) {
+            this._requester.setModels(
+                additionalModels.map((model) => model.name)
+            )
             return additionalModels
         }
 
         const fallbackModels = [
             'claude-3-5-sonnet-20241022',
             'claude-3-7-sonnet-20250219',
-            'claude-3-7-sonnet-thinking-20250219',
             'claude-opus-4-20250514',
             'claude-sonnet-4-20250514',
             'claude-sonnet-4-5-20250929',
@@ -153,10 +155,38 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
             }))
         }
 
+        this._requester.setModels(
+            additionalModels
+                .map((model) => model.name)
+                .concat(fetchedModels.map((model) => model.name))
+        )
+
+        const fetchedNames = new Set(fetchedModels.map((model) => model.name))
+        const names = new Set(additionalModels.map((model) => model.name))
+
         return additionalModels.concat(
-            fetchedModels.filter(
-                (model) => !additionalModels.some((m) => m.name === model.name)
-            )
+            fetchedModels
+                .flatMap((model) => {
+                    if (
+                        model.name.includes('thinking') ||
+                        !THINKING_MODELS.some((name) =>
+                            model.name.startsWith(name)
+                        ) ||
+                        fetchedNames.has(`${model.name}-thinking`)
+                    ) {
+                        return [model]
+                    }
+
+                    return [model, { ...model, name: `${model.name}-thinking` }]
+                })
+                .filter((model) => {
+                    if (names.has(model.name)) {
+                        return false
+                    }
+
+                    names.add(model.name)
+                    return true
+                })
         )
     }
 
@@ -180,3 +210,10 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
         })
     }
 }
+
+const THINKING_MODELS = [
+    'claude-3-7-sonnet-',
+    'claude-opus-4',
+    'claude-sonnet-4',
+    'claude-haiku-4-5'
+]

--- a/packages/adapter-claude/src/requester.ts
+++ b/packages/adapter-claude/src/requester.ts
@@ -33,6 +33,8 @@ import {
 } from './utils'
 
 export class ClaudeRequester extends ModelRequester<ClientConfig> {
+    private _models = new Set<string>()
+
     constructor(
         ctx: Context,
         _configPool: ClientConfigPool<ClientConfig>,
@@ -42,11 +44,21 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
         super(ctx, _configPool, _pluginConfig, _plugin)
     }
 
+    setModels(models: string[]) {
+        this._models = new Set(models)
+    }
+
     async *completionStreamInternal(
         params: ModelRequestParams
     ): AsyncGenerator<ChatGenerationChunk> {
-        const model = (params.model ?? '').replace('-thinking-', '-')
-        const maxTokens = params.maxTokens ?? 4096
+        const rawModel = params.model ?? ''
+        const model =
+            rawModel.endsWith('-thinking') &&
+            !this._models.has(rawModel) &&
+            this._models.has(rawModel.slice(0, -'-thinking'.length))
+                ? rawModel.slice(0, -'-thinking'.length)
+                : rawModel
+        const maxTokens = params.maxTokens ?? 10_000
         const request = deepAssign(
             {},
             {
@@ -64,7 +76,7 @@ export class ClaudeRequester extends ModelRequester<ClientConfig> {
                     this._plugin,
                     model
                 ),
-                thinking: params.model?.includes('thinking')
+                thinking: rawModel.includes('thinking')
                     ? {
                           type: 'enabled',
                           budget_tokens: Math.max(

--- a/packages/adapter-doubao/src/requester.ts
+++ b/packages/adapter-doubao/src/requester.ts
@@ -115,32 +115,13 @@ export class DoubaoRequester
         return await createEmbeddings(requestContext, params)
     }
 
-    private _concatUrl(url: string): string {
-        const apiEndPoint = this._config.value.apiEndpoint
-
-        // match the apiEndPoint ends with '/v3' or '/v3/' using regex
-        if (!apiEndPoint.match(/\/v3\/?$/)) {
-            if (apiEndPoint.endsWith('/')) {
-                return apiEndPoint + 'v3/' + url
-            }
-
-            return apiEndPoint + '/v3/' + url
-        }
-
-        if (apiEndPoint.endsWith('/')) {
-            return apiEndPoint + url
-        }
-
-        return apiEndPoint + '/' + url
-    }
-
     post(
         url: string,
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         data: any,
         params: fetchType.RequestInit = {}
     ) {
-        const requestUrl = this._concatUrl(url)
+        const requestUrl = this.concatUrl(url)
 
         for (const key in data) {
             if (data[key] === undefined) {
@@ -159,7 +140,7 @@ export class DoubaoRequester
     }
 
     get(url: string) {
-        const requestUrl = this._concatUrl(url)
+        const requestUrl = this.concatUrl(url)
 
         return this._plugin.fetch(requestUrl, {
             method: 'GET',

--- a/packages/adapter-rwkv/src/index.ts
+++ b/packages/adapter-rwkv/src/index.ts
@@ -48,11 +48,11 @@ export const Config: Schema<Config> = Schema.intersect([
         apiKeys: Schema.array(
             Schema.tuple([
                 Schema.string().role('secret').default(''),
-                Schema.string().default('http://127.0.0.1:8000'),
+                Schema.string().default('http://127.0.0.1:8000/v1'),
                 Schema.boolean().default(true)
             ])
         )
-            .default([['', 'http://127.0.0.1:8000', true]])
+            .default([['', 'http://127.0.0.1:8000/v1', true]])
             .role('table')
     }),
     Schema.object({

--- a/packages/adapter-rwkv/src/requester.ts
+++ b/packages/adapter-rwkv/src/requester.ts
@@ -84,25 +84,6 @@ export class RWKVRequester
         }
     }
 
-    concatUrl(url: string): string {
-        const apiEndPoint = this._config.value.apiEndpoint
-
-        // match the apiEndPoint ends with '/v1' or '/v1/' using regex
-        if (!apiEndPoint.match(/\/v1\/?$/)) {
-            if (apiEndPoint.endsWith('/')) {
-                return apiEndPoint + 'v1/' + url
-            }
-
-            return apiEndPoint + '/v1/' + url
-        }
-
-        if (apiEndPoint.endsWith('/')) {
-            return apiEndPoint + url
-        }
-
-        return apiEndPoint + '/' + url
-    }
-
     get logger() {
         return this.ctx.logger('chatluna-rwkv-adapter')
     }

--- a/packages/core/src/chains/chain.ts
+++ b/packages/core/src/chains/chain.ts
@@ -8,6 +8,7 @@ import {
 import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
 import { Config } from '../config'
 import { lifecycleNames } from '../middlewares/system/lifecycle'
+import { formatDuration } from '../utils/time'
 import type { QQBot } from '@koishijs/plugin-adapter-qq'
 
 let logger: Logger
@@ -285,9 +286,9 @@ export class ChatChain {
 
             if (shouldLogTime) {
                 logger.debug(
-                    `middleware %c executed in %d ms`,
+                    `middleware %c executed in %s`,
                     middleware.name,
-                    executionTime
+                    formatDuration(executionTime)
                 )
             }
 

--- a/packages/core/src/llm-core/platform/api.ts
+++ b/packages/core/src/llm-core/platform/api.ts
@@ -232,15 +232,6 @@ export abstract class ModelRequester<
             return apiEndPoint + url
         }
 
-        // match the apiEndPoint ends with '/v1' or '/v1/' using regex
-        if (!apiEndPoint.match(/\/v1\/?$/)) {
-            if (apiEndPoint.endsWith('/')) {
-                return apiEndPoint + 'v1/' + url
-            }
-
-            return apiEndPoint + '/v1/' + url
-        }
-
         return apiEndPoint + '/' + url
     }
 }

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -1,0 +1,26 @@
+/**
+ * Format milliseconds to a human-readable time string.
+ * @param ms - Time in milliseconds
+ * @returns Formatted time string (e.g., "1.23s", "2m 34s", "1h 23m 45s")
+ */
+export function formatDuration(ms: number): string {
+    if (ms < 1000) {
+        return `${ms}ms`
+    }
+
+    const totalSeconds = Math.floor(ms / 1000)
+    const hours = Math.floor(totalSeconds / 3600)
+    const minutes = Math.floor((totalSeconds % 3600) / 60)
+    const seconds = totalSeconds % 60
+
+    if (hours > 0) {
+        return `${hours}h ${minutes}m ${seconds}s`
+    }
+
+    if (minutes > 0) {
+        return `${minutes}m ${seconds}s`
+    }
+
+    const decimal = (ms / 1000).toFixed(2)
+    return `${decimal}s`
+}

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -162,7 +162,38 @@ export async function* processStreamResponse<
 
             if (!choice) continue
 
-            const { delta } = choice
+            const delta = choice.delta
+
+            if (delta == null) {
+                const messageChunk = convertMessageToMessageChunk(
+                    reasoningState.content.length > 0 &&
+                        (choice.message.reasoning_content?.length ?? 0) < 1
+                        ? {
+                              ...choice.message,
+                              reasoning_content: reasoningState.content
+                          }
+                        : choice.message
+                )
+
+                reasoningState.content = ''
+
+                if (reasoningState.endedAt == null) {
+                    reasoningState.endedAt = Date.now()
+                }
+
+                defaultRole = (
+                    (choice.message.role?.length ?? 0) > 0
+                        ? choice.message.role
+                        : defaultRole
+                ) as ChatCompletionResponseMessageRoleEnum
+
+                yield new ChatGenerationChunk({
+                    message: messageChunk,
+                    text: getMessageContent(messageChunk.content)
+                })
+                continue
+            }
+
             const hasResult =
                 (delta.content?.length ?? 0) > 0 ||
                 (delta.tool_calls?.length ?? 0) > 0 ||
@@ -210,7 +241,7 @@ export async function* processStreamResponse<
 
             yield new ChatGenerationChunk({
                 message: messageChunk,
-                text: messageChunk.content as string
+                text: getMessageContent(messageChunk.content)
             })
         } catch (e) {
             if (


### PR DESCRIPTION
This pr restores v1-compatible endpoint handling across shared and adapter-specific requesters, fixes Claude thinking model resolution, and preserves streamed message chunks that arrive as final message payloads.

## New Features

- Add human-readable middleware duration formatting for debug logs.
- Add derived Claude thinking model aliases when the API exposes only base model names.

## Bug fixes

- Stop OpenAI-compatible adapters from appending duplicated `/v1` or `/v3` path segments.
- Map generated Claude `-thinking` model names back to supported API models before requests are sent.
- Handle stream responses that emit `message` payloads without `delta` chunks so content is not dropped.
- Update RWKV defaults to use the expected `/v1` endpoint.

## Other Changes

- Reuse shared URL concatenation logic in Doubao and RWKV requesters.
- Cache available Claude model names inside the requester for request-time normalization.