### PR TITLE
chore(packages): bump manifests for 1.3.34 release

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,87 +1,87 @@
 {
-  "name": "koishi-plugin-chatluna-azure-openai-adapter",
-  "description": "azure openai adapter for chatluna",
-  "version": "1.3.7",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-azure-openai-adapter",
+    "description": "azure openai adapter for chatluna",
+    "version": "1.3.7",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-azure-openai"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-azure-openai#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-azure-openai"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-azure-openai#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的 Azure OpenAI 平台适配器",
-      "en": "Azure OpenAI adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的 Azure OpenAI 平台适配器",
+            "en": "Azure OpenAI adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,89 +1,89 @@
 {
-  "name": "koishi-plugin-chatluna-claude-adapter",
-  "description": "claude adapter for chatluna",
-  "version": "1.3.9",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-claude-adapter",
+    "description": "claude adapter for chatluna",
+    "version": "1.3.10",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-claude"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-claude#readme",
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "newbing",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9",
-    "undici": "^6.21.3"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-claude"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-claude#readme",
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "newbing",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9",
+        "undici": "^6.21.3"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的 Claude API 适配器",
-      "en": "Claude API adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的 Claude API 适配器",
+            "en": "Claude API adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,88 +1,88 @@
 {
-  "name": "koishi-plugin-chatluna-deepseek-adapter",
-  "description": "deepseek adapter for chatluna",
-  "version": "1.3.11",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-deepseek-adapter",
+    "description": "deepseek adapter for chatluna",
+    "version": "1.3.11",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-deepseek"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-deepseek#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-deepseek"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-deepseek#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "deepseek",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "category": "ai",
-    "description": {
-      "zh": "ChatLuna 的 deepseek 适配器",
-      "en": "deepseek adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "deepseek",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "category": "ai",
+        "description": {
+            "zh": "ChatLuna 的 deepseek 适配器",
+            "en": "deepseek adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,87 +1,87 @@
 {
-  "name": "koishi-plugin-chatluna-dify-adapter",
-  "description": "dify adapter for chatluna",
-  "version": "1.3.8",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-dify-adapter",
+    "description": "dify adapter for chatluna",
+    "version": "1.3.8",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-dify"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-dify#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-dify"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-dify#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9",
-    "undici": "^6.21.3"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的 Dify API 适配器",
-      "en": "Dify API adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9",
+        "undici": "^6.21.3"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的 Dify API 适配器",
+            "en": "Dify API adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,87 +1,87 @@
 {
-  "name": "koishi-plugin-chatluna-doubao-adapter",
-  "description": "doubao adapter for chatluna",
-  "version": "1.3.9",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-doubao-adapter",
+    "description": "doubao adapter for chatluna",
+    "version": "1.3.10",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-doubao"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-doubao#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-doubao"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-doubao#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的豆包适配器",
-      "en": "doubao adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的豆包适配器",
+            "en": "doubao adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,97 +1,97 @@
 {
-  "name": "koishi-plugin-chatluna-google-gemini-adapter",
-  "description": "google-gemini adapter for chatluna",
-  "version": "1.3.30",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-google-gemini-adapter",
+    "description": "google-gemini adapter for chatluna",
+    "version": "1.3.30",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-gemini"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-gemini#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-gemini"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-gemini#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "google",
-    "gemini",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@anatine/zod-openapi": "^2.2.8",
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "openapi3-ts": "^4.5.0",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33",
-    "koishi-plugin-chatluna-storage-service": "^1.0.6"
-  },
-  "peerDependenciesMeta": {
-    "koishi-plugin-chatluna-storage-service": {
-      "optional": true
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的 Google Gemini 适配器",
-      "en": "Google Gemini adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "google",
+        "gemini",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@anatine/zod-openapi": "^2.2.8",
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "openapi3-ts": "^4.5.0",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34",
+        "koishi-plugin-chatluna-storage-service": "^1.0.6"
+    },
+    "peerDependenciesMeta": {
+        "koishi-plugin-chatluna-storage-service": {
+            "optional": true
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的 Google Gemini 适配器",
+            "en": "Google Gemini adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,87 +1,87 @@
 {
-  "name": "koishi-plugin-chatluna-hunyuan-adapter",
-  "description": "hunyuan adapter for chatluna",
-  "version": "1.3.8",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-hunyuan-adapter",
+    "description": "hunyuan adapter for chatluna",
+    "version": "1.3.9",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-hunyuan"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-hunyuan#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-hunyuan"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-hunyuan#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的腾讯混元大语言模型 API 适配器",
-      "en": "Tencent Hunyuan LLM API adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的腾讯混元大语言模型 API 适配器",
+            "en": "Tencent Hunyuan LLM API adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,84 +1,84 @@
 {
-  "name": "koishi-plugin-chatluna-ollama-adapter",
-  "description": "ollama adapter for chatluna",
-  "version": "1.3.7",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-ollama-adapter",
+    "description": "ollama adapter for chatluna",
+    "version": "1.3.7",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-ollama"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-ollama#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "ollama",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-ollama"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-ollama#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "ollama",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的 Ollama 适配器（需后端配置）",
-      "en": "Ollama adapter for ChatLuna (backend service required)"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的 Ollama 适配器（需后端配置）",
+            "en": "Ollama adapter for ChatLuna (backend service required)"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,87 +1,87 @@
 {
-  "name": "koishi-plugin-chatluna-openai-like-adapter",
-  "description": "openai style api adapter for chatluna",
-  "version": "1.3.12",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-openai-like-adapter",
+    "description": "openai style api adapter for chatluna",
+    "version": "1.3.13",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-openai-like"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-openai-like#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-openai-like"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-openai-like#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的 OpenAI 兼容 API 适配器",
-      "en": "OpenAI-compatible API adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的 OpenAI 兼容 API 适配器",
+            "en": "OpenAI-compatible API adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,87 +1,87 @@
 {
-  "name": "koishi-plugin-chatluna-openai-adapter",
-  "description": "openai adapter for chatluna",
-  "version": "1.3.11",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-openai-adapter",
+    "description": "openai adapter for chatluna",
+    "version": "1.3.11",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-openai"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-openai#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-openai"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-openai#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的 OpenAI 适配器",
-      "en": "OpenAI adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的 OpenAI 适配器",
+            "en": "OpenAI adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,87 +1,87 @@
 {
-  "name": "koishi-plugin-chatluna-qwen-adapter",
-  "description": "qwen adapter for chatluna",
-  "version": "1.3.10",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-qwen-adapter",
+    "description": "qwen adapter for chatluna",
+    "version": "1.3.10",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-qwen"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-qwen#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-qwen"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-qwen#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的阿里云通义千问 API 适配器",
-      "en": "Tongyi Qianwen API adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的阿里云通义千问 API 适配器",
+            "en": "Tongyi Qianwen API adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,85 +1,85 @@
 {
-  "name": "koishi-plugin-chatluna-rmkv-adapter",
-  "description": "rwkv adapter for chatluna",
-  "version": "1.3.7",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-rmkv-adapter",
+    "description": "rwkv adapter for chatluna",
+    "version": "1.3.8",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-rwkv"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-rwkv#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "rwkv",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod-to-json-schema": "3.23.5"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-rwkv"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-rwkv#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "rwkv",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod-to-json-schema": "3.23.5"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的 RWKV 适配器（需后端配置）",
-      "en": "RWKV adapter for ChatLuna (backend required)"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的 RWKV 适配器（需后端配置）",
+            "en": "RWKV adapter for ChatLuna (backend required)"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,88 +1,88 @@
 {
-  "name": "koishi-plugin-chatluna-spark-adapter",
-  "description": "spark adapter for chatluna",
-  "version": "1.3.8",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-spark-adapter",
+    "description": "spark adapter for chatluna",
+    "version": "1.3.8",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-spark"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-spark#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-spark"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-spark#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "spark",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的讯飞星火 API 适配器",
-      "en": "iFLYTEK Spark API adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "spark",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的讯飞星火 API 适配器",
+            "en": "iFLYTEK Spark API adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,87 +1,87 @@
 {
-  "name": "koishi-plugin-chatluna-wenxin-adapter",
-  "description": "wenxin adapter for chatluna",
-  "version": "1.3.8",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-wenxin-adapter",
+    "description": "wenxin adapter for chatluna",
+    "version": "1.3.9",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-wenxin"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-wenxin#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-wenxin"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-wenxin#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的百度文心一言 API 适配器",
-      "en": "ERNIE Bot API adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的百度文心一言 API 适配器",
+            "en": "ERNIE Bot API adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,89 +1,89 @@
 {
-  "name": "koishi-plugin-chatluna-zhipu-adapter",
-  "description": "zhipu(chatglm) adapter for chatluna",
-  "version": "1.3.10",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-zhipu-adapter",
+    "description": "zhipu(chatglm) adapter for chatluna",
+    "version": "1.3.11",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/adapter-zhipu"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-zhipu#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@chatluna/v1-shared-adapter": "^1.0.30",
-    "@langchain/core": "^0.3.80",
-    "jsonwebtoken": "^9.0.2",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "@types/jsonwebtoken": "^9.0.10",
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的智谱 AI（ChatGLM）适配器",
-      "en": "Zhipu AI (ChatGLM) adapter for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/adapter-zhipu"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/adapter-zhipu#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@langchain/core": "^0.3.80",
+        "jsonwebtoken": "^9.0.2",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "@types/jsonwebtoken": "^9.0.10",
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的智谱 AI（ChatGLM）适配器",
+            "en": "Zhipu AI (ChatGLM) adapter for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,314 +1,314 @@
 {
-  "name": "koishi-plugin-chatluna",
-  "description": "chatluna for koishi",
-  "version": "1.3.33",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist",
-    "resources"
-  ],
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "require": "./lib/index.cjs",
-      "import": "./lib/index.mjs"
+    "name": "koishi-plugin-chatluna",
+    "description": "chatluna for koishi",
+    "version": "1.3.34",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist",
+        "resources"
+    ],
+    "type": "module",
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "require": "./lib/index.cjs",
+            "import": "./lib/index.mjs"
+        },
+        "./preset": {
+            "types": "./lib/preset.d.ts",
+            "import": "./lib/preset.mjs",
+            "require": "./lib/preset.cjs"
+        },
+        "./chains": {
+            "types": "./lib/chains/index.d.ts",
+            "import": "./lib/chains/index.mjs",
+            "require": "./lib/chains/index.cjs"
+        },
+        "./services/chat": {
+            "types": "./lib/services/chat.d.ts",
+            "import": "./lib/services/chat.mjs",
+            "require": "./lib/services/chat.cjs"
+        },
+        "./llm-core/prompt": {
+            "types": "./lib/llm-core/prompt/index.d.ts",
+            "import": "./lib/llm-core/prompt/index.mjs",
+            "require": "./lib/llm-core/prompt/index.cjs"
+        },
+        "./llm-core/memory/langchain": {
+            "types": "./lib/llm-core/memory/langchain/index.d.ts",
+            "import": "./lib/llm-core/memory/langchain/index.mjs",
+            "require": "./lib/llm-core/memory/langchain/index.cjs"
+        },
+        "./llm-core/chain/prompt": {
+            "types": "./lib/llm-core/chain/prompt.d.ts",
+            "import": "./lib/llm-core/chain/prompt.mjs",
+            "require": "./lib/llm-core/chain/prompt.cjs"
+        },
+        "./llm-core/agent": {
+            "types": "./lib/llm-core/agent/index.d.ts",
+            "import": "./lib/llm-core/agent/index.mjs",
+            "require": "./lib/llm-core/agent/index.cjs"
+        },
+        "./llm-core/platform/api": {
+            "types": "./lib/llm-core/platform/api.d.ts",
+            "import": "./lib/llm-core/platform/api.mjs",
+            "require": "./lib/llm-core/platform/api.cjs"
+        },
+        "./llm-core/platform/client": {
+            "types": "./lib/llm-core/platform/client.d.ts",
+            "import": "./lib/llm-core/platform/client.mjs",
+            "require": "./lib/llm-core/platform/client.cjs"
+        },
+        "./llm-core/platform/config": {
+            "types": "./lib/llm-core/platform/config.d.ts",
+            "import": "./lib/llm-core/platform/config.mjs",
+            "require": "./lib/llm-core/platform/config.cjs"
+        },
+        "./llm-core/platform/model": {
+            "types": "./lib/llm-core/platform/model.d.ts",
+            "import": "./lib/llm-core/platform/model.mjs",
+            "require": "./lib/llm-core/platform/model.cjs"
+        },
+        "./llm-core/platform/service": {
+            "types": "./lib/llm-core/platform/service.d.ts",
+            "import": "./lib/llm-core/platform/service.mjs",
+            "require": "./lib/llm-core/platform/service.cjs"
+        },
+        "./llm-core/platform/types": {
+            "types": "./lib/llm-core/platform/types.d.ts",
+            "import": "./lib/llm-core/platform/types.mjs",
+            "require": "./lib/llm-core/platform/types.cjs"
+        },
+        "./llm-core/vectorstores": {
+            "types": "./lib/llm-core/vectorstores/index.d.ts",
+            "import": "./lib/llm-core/vectorstores/index.mjs",
+            "require": "./lib/llm-core/vectorstores/index.cjs"
+        },
+        "./llm-core/memory/message": {
+            "types": "./lib/llm-core/memory/message/index.d.ts",
+            "import": "./lib/llm-core/memory/message/index.mjs",
+            "require": "./lib/llm-core/memory/message/index.cjs"
+        },
+        "./llm-core/retrievers": {
+            "types": "./lib/llm-core/retrievers/index.d.ts",
+            "import": "./lib/llm-core/retrievers/index.mjs",
+            "require": "./lib/llm-core/retrievers/index.cjs"
+        },
+        "./utils/string": {
+            "types": "./lib/utils/string.d.ts",
+            "import": "./lib/utils/string.mjs",
+            "require": "./lib/utils/string.cjs"
+        },
+        "./utils/error": {
+            "types": "./lib/utils/error.d.ts",
+            "import": "./lib/utils/error.mjs",
+            "require": "./lib/utils/error.cjs"
+        },
+        "./utils/logger": {
+            "types": "./lib/utils/logger.d.ts",
+            "import": "./lib/utils/logger.mjs",
+            "require": "./lib/utils/logger.cjs"
+        },
+        "./utils/request": {
+            "types": "./lib/utils/request.d.ts",
+            "import": "./lib/utils/request.mjs",
+            "require": "./lib/utils/request.cjs"
+        },
+        "./utils/sse": {
+            "types": "./lib/utils/sse.d.ts",
+            "import": "./lib/utils/sse.mjs",
+            "require": "./lib/utils/sse.cjs"
+        },
+        "./utils/koishi": {
+            "types": "./lib/utils/koishi.d.ts",
+            "import": "./lib/utils/koishi.mjs",
+            "require": "./lib/utils/koishi.cjs"
+        },
+        "./utils/langchain": {
+            "types": "./lib/utils/langchain.d.ts",
+            "import": "./lib/utils/langchain.mjs",
+            "require": "./lib/utils/langchain.cjs"
+        },
+        "./utils/types": {
+            "types": "./lib/utils/types.d.ts",
+            "import": "./lib/utils/types.mjs",
+            "require": "./lib/utils/types.cjs"
+        },
+        "./utils/lock": {
+            "types": "./lib/utils/lock.d.ts",
+            "import": "./lib/utils/lock.mjs",
+            "require": "./lib/utils/lock.cjs"
+        },
+        "./utils/queue": {
+            "types": "./lib/utils/queue.d.ts",
+            "import": "./lib/utils/queue.mjs",
+            "require": "./lib/utils/queue.cjs"
+        },
+        "./utils/stream": {
+            "types": "./lib/utils/stream.d.ts",
+            "import": "./lib/utils/stream.mjs",
+            "require": "./lib/utils/stream.cjs"
+        },
+        "./utils/schema": {
+            "types": "./lib/utils/schema.d.ts",
+            "import": "./lib/utils/schema.mjs",
+            "require": "./lib/utils/schema.cjs"
+        },
+        "./utils/object": {
+            "types": "./lib/utils/object.d.ts",
+            "import": "./lib/utils/object.mjs",
+            "require": "./lib/utils/object.cjs"
+        },
+        "./utils/pagination": {
+            "types": "./lib/utils/pagination.d.ts",
+            "import": "./lib/utils/pagination.mjs",
+            "require": "./lib/utils/pagination.cjs"
+        },
+        "./llm-core/model/in_memory": {
+            "types": "./lib/llm-core/model/in_memory.d.ts",
+            "import": "./lib/llm-core/model/in_memory.mjs",
+            "require": "./lib/llm-core/model/in_memory.cjs"
+        },
+        "./llm-core/utils/count_tokens": {
+            "types": "./lib/llm-core/utils/count_tokens.d.ts",
+            "import": "./lib/llm-core/utils/count_tokens.mjs",
+            "require": "./lib/llm-core/utils/count_tokens.cjs"
+        },
+        "./llm-core/utils/chunk": {
+            "types": "./lib/llm-core/utils/chunk.d.ts",
+            "import": "./lib/llm-core/utils/chunk.mjs",
+            "require": "./lib/llm-core/utils/chunk.cjs"
+        },
+        "./llm-core/chain/base": {
+            "types": "./lib/llm-core/chain/base.d.ts",
+            "import": "./lib/llm-core/chain/base.mjs",
+            "require": "./lib/llm-core/chain/base.cjs"
+        },
+        "./llm-core/chat/app": {
+            "types": "./lib/llm-core/chat/app.d.ts",
+            "import": "./lib/llm-core/chat/app.mjs",
+            "require": "./lib/llm-core/chat/app.cjs"
+        },
+        "./llm-core/model/base": {
+            "types": "./lib/llm-core/model/base.d.ts",
+            "import": "./lib/llm-core/model/base.mjs",
+            "require": "./lib/llm-core/model/base.cjs"
+        },
+        "./utils/promise": {
+            "types": "./lib/utils/promise.d.ts",
+            "import": "./lib/utils/promise.mjs",
+            "require": "./lib/utils/promise.cjs"
+        },
+        "./utils/base64": {
+            "types": "./lib/utils/base64.d.ts",
+            "import": "./lib/utils/base64.mjs",
+            "require": "./lib/utils/base64.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./preset": {
-      "types": "./lib/preset.d.ts",
-      "import": "./lib/preset.mjs",
-      "require": "./lib/preset.cjs"
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/core"
     },
-    "./chains": {
-      "types": "./lib/chains/index.d.ts",
-      "import": "./lib/chains/index.mjs",
-      "require": "./lib/chains/index.cjs"
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
     },
-    "./services/chat": {
-      "types": "./lib/services/chat.d.ts",
-      "import": "./lib/services/chat.mjs",
-      "require": "./lib/services/chat.cjs"
+    "scripts": {
+        "build": "atsc -b"
     },
-    "./llm-core/prompt": {
-      "types": "./lib/llm-core/prompt/index.d.ts",
-      "import": "./lib/llm-core/prompt/index.mjs",
-      "require": "./lib/llm-core/prompt/index.cjs"
+    "engines": {
+        "node": ">=18.0.0"
     },
-    "./llm-core/memory/langchain": {
-      "types": "./lib/llm-core/memory/langchain/index.d.ts",
-      "import": "./lib/llm-core/memory/langchain/index.mjs",
-      "require": "./lib/llm-core/memory/langchain/index.cjs"
+    "homepage": "https://github.com/ChatLunaLab/chatluna#readme",
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "ai",
+        "langchain"
+    ],
+    "dependencies": {
+        "@chatluna/shared-prompt-renderer": "^1.0.5",
+        "@langchain/core": "^0.3.80",
+        "@vue/reactivity": "^3.6.0-alpha.2",
+        "decimal.js": "^10.6.0",
+        "he": "^1.2.0",
+        "https-proxy-agent": "^7.0.6",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21",
+        "js-yaml": "^4.1.0",
+        "koishi-plugin-markdown": "^1.1.1",
+        "lru-cache": "^11.2.2",
+        "marked": "^15.0.12",
+        "socks": "^2.8.7",
+        "socks-proxy-agent": "^8.0.5",
+        "undici": "^6.21.3",
+        "ws": "^8.18.3",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
     },
-    "./llm-core/chain/prompt": {
-      "types": "./lib/llm-core/chain/prompt.d.ts",
-      "import": "./lib/llm-core/chain/prompt.mjs",
-      "require": "./lib/llm-core/chain/prompt.cjs"
+    "devDependencies": {
+        "@initencounter/sst": "^0.0.1",
+        "@initencounter/vits": "^0.0.3",
+        "@koishijs/cache": "^2.1.0",
+        "@koishijs/censor": "^1.1.0",
+        "@koishijs/plugin-adapter-qq": "^4.10.1",
+        "@koishijs/plugin-notifier": "^1.2.1",
+        "@types/he": "^1.2.3",
+        "@types/js-yaml": "^4.0.9",
+        "@types/qrcode": "^1.5.5",
+        "@types/useragent": "^2",
+        "atsc": "^2.1.0",
+        "koishi-plugin-adapter-onebot": "^6.8.0"
     },
-    "./llm-core/agent": {
-      "types": "./lib/llm-core/agent/index.d.ts",
-      "import": "./lib/llm-core/agent/index.mjs",
-      "require": "./lib/llm-core/agent/index.cjs"
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
-    "./llm-core/platform/api": {
-      "types": "./lib/llm-core/platform/api.d.ts",
-      "import": "./lib/llm-core/platform/api.mjs",
-      "require": "./lib/llm-core/platform/api.cjs"
+    "peerDependenciesMeta": {
+        "koishi-plugin-chatluna-storage-service": {
+            "optional": true
+        }
     },
-    "./llm-core/platform/client": {
-      "types": "./lib/llm-core/platform/client.d.ts",
-      "import": "./lib/llm-core/platform/client.mjs",
-      "require": "./lib/llm-core/platform/client.cjs"
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "./llm-core/platform/config": {
-      "types": "./lib/llm-core/platform/config.d.ts",
-      "import": "./lib/llm-core/platform/config.mjs",
-      "require": "./lib/llm-core/platform/config.cjs"
-    },
-    "./llm-core/platform/model": {
-      "types": "./lib/llm-core/platform/model.d.ts",
-      "import": "./lib/llm-core/platform/model.mjs",
-      "require": "./lib/llm-core/platform/model.cjs"
-    },
-    "./llm-core/platform/service": {
-      "types": "./lib/llm-core/platform/service.d.ts",
-      "import": "./lib/llm-core/platform/service.mjs",
-      "require": "./lib/llm-core/platform/service.cjs"
-    },
-    "./llm-core/platform/types": {
-      "types": "./lib/llm-core/platform/types.d.ts",
-      "import": "./lib/llm-core/platform/types.mjs",
-      "require": "./lib/llm-core/platform/types.cjs"
-    },
-    "./llm-core/vectorstores": {
-      "types": "./lib/llm-core/vectorstores/index.d.ts",
-      "import": "./lib/llm-core/vectorstores/index.mjs",
-      "require": "./lib/llm-core/vectorstores/index.cjs"
-    },
-    "./llm-core/memory/message": {
-      "types": "./lib/llm-core/memory/message/index.d.ts",
-      "import": "./lib/llm-core/memory/message/index.mjs",
-      "require": "./lib/llm-core/memory/message/index.cjs"
-    },
-    "./llm-core/retrievers": {
-      "types": "./lib/llm-core/retrievers/index.d.ts",
-      "import": "./lib/llm-core/retrievers/index.mjs",
-      "require": "./lib/llm-core/retrievers/index.cjs"
-    },
-    "./utils/string": {
-      "types": "./lib/utils/string.d.ts",
-      "import": "./lib/utils/string.mjs",
-      "require": "./lib/utils/string.cjs"
-    },
-    "./utils/error": {
-      "types": "./lib/utils/error.d.ts",
-      "import": "./lib/utils/error.mjs",
-      "require": "./lib/utils/error.cjs"
-    },
-    "./utils/logger": {
-      "types": "./lib/utils/logger.d.ts",
-      "import": "./lib/utils/logger.mjs",
-      "require": "./lib/utils/logger.cjs"
-    },
-    "./utils/request": {
-      "types": "./lib/utils/request.d.ts",
-      "import": "./lib/utils/request.mjs",
-      "require": "./lib/utils/request.cjs"
-    },
-    "./utils/sse": {
-      "types": "./lib/utils/sse.d.ts",
-      "import": "./lib/utils/sse.mjs",
-      "require": "./lib/utils/sse.cjs"
-    },
-    "./utils/koishi": {
-      "types": "./lib/utils/koishi.d.ts",
-      "import": "./lib/utils/koishi.mjs",
-      "require": "./lib/utils/koishi.cjs"
-    },
-    "./utils/langchain": {
-      "types": "./lib/utils/langchain.d.ts",
-      "import": "./lib/utils/langchain.mjs",
-      "require": "./lib/utils/langchain.cjs"
-    },
-    "./utils/types": {
-      "types": "./lib/utils/types.d.ts",
-      "import": "./lib/utils/types.mjs",
-      "require": "./lib/utils/types.cjs"
-    },
-    "./utils/lock": {
-      "types": "./lib/utils/lock.d.ts",
-      "import": "./lib/utils/lock.mjs",
-      "require": "./lib/utils/lock.cjs"
-    },
-    "./utils/queue": {
-      "types": "./lib/utils/queue.d.ts",
-      "import": "./lib/utils/queue.mjs",
-      "require": "./lib/utils/queue.cjs"
-    },
-    "./utils/stream": {
-      "types": "./lib/utils/stream.d.ts",
-      "import": "./lib/utils/stream.mjs",
-      "require": "./lib/utils/stream.cjs"
-    },
-    "./utils/schema": {
-      "types": "./lib/utils/schema.d.ts",
-      "import": "./lib/utils/schema.mjs",
-      "require": "./lib/utils/schema.cjs"
-    },
-    "./utils/object": {
-      "types": "./lib/utils/object.d.ts",
-      "import": "./lib/utils/object.mjs",
-      "require": "./lib/utils/object.cjs"
-    },
-    "./utils/pagination": {
-      "types": "./lib/utils/pagination.d.ts",
-      "import": "./lib/utils/pagination.mjs",
-      "require": "./lib/utils/pagination.cjs"
-    },
-    "./llm-core/model/in_memory": {
-      "types": "./lib/llm-core/model/in_memory.d.ts",
-      "import": "./lib/llm-core/model/in_memory.mjs",
-      "require": "./lib/llm-core/model/in_memory.cjs"
-    },
-    "./llm-core/utils/count_tokens": {
-      "types": "./lib/llm-core/utils/count_tokens.d.ts",
-      "import": "./lib/llm-core/utils/count_tokens.mjs",
-      "require": "./lib/llm-core/utils/count_tokens.cjs"
-    },
-    "./llm-core/utils/chunk": {
-      "types": "./lib/llm-core/utils/chunk.d.ts",
-      "import": "./lib/llm-core/utils/chunk.mjs",
-      "require": "./lib/llm-core/utils/chunk.cjs"
-    },
-    "./llm-core/chain/base": {
-      "types": "./lib/llm-core/chain/base.d.ts",
-      "import": "./lib/llm-core/chain/base.mjs",
-      "require": "./lib/llm-core/chain/base.cjs"
-    },
-    "./llm-core/chat/app": {
-      "types": "./lib/llm-core/chat/app.d.ts",
-      "import": "./lib/llm-core/chat/app.mjs",
-      "require": "./lib/llm-core/chat/app.cjs"
-    },
-    "./llm-core/model/base": {
-      "types": "./lib/llm-core/model/base.d.ts",
-      "import": "./lib/llm-core/model/base.mjs",
-      "require": "./lib/llm-core/model/base.cjs"
-    },
-    "./utils/promise": {
-      "types": "./lib/utils/promise.d.ts",
-      "import": "./lib/utils/promise.mjs",
-      "require": "./lib/utils/promise.cjs"
-    },
-    "./utils/base64": {
-      "types": "./lib/utils/base64.d.ts",
-      "import": "./lib/utils/base64.mjs",
-      "require": "./lib/utils/base64.cjs"
-    },
-    "./package.json": "./package.json"
-  },
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/core"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna#readme",
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "ai",
-    "langchain"
-  ],
-  "dependencies": {
-    "@chatluna/shared-prompt-renderer": "^1.0.5",
-    "@langchain/core": "^0.3.80",
-    "@vue/reactivity": "^3.6.0-alpha.2",
-    "decimal.js": "^10.6.0",
-    "he": "^1.2.0",
-    "https-proxy-agent": "^7.0.6",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21",
-    "js-yaml": "^4.1.0",
-    "koishi-plugin-markdown": "^1.1.1",
-    "lru-cache": "^11.2.2",
-    "marked": "^15.0.12",
-    "socks": "^2.8.7",
-    "socks-proxy-agent": "^8.0.5",
-    "undici": "^6.21.3",
-    "ws": "^8.18.3",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "@initencounter/sst": "^0.0.1",
-    "@initencounter/vits": "^0.0.3",
-    "@koishijs/cache": "^2.1.0",
-    "@koishijs/censor": "^1.1.0",
-    "@koishijs/plugin-adapter-qq": "^4.10.1",
-    "@koishijs/plugin-notifier": "^1.2.1",
-    "@types/he": "^1.2.3",
-    "@types/js-yaml": "^4.0.9",
-    "@types/qrcode": "^1.5.5",
-    "@types/useragent": "^2",
-    "atsc": "^2.1.0",
-    "koishi-plugin-adapter-onebot": "^6.8.0"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna-storage-service": "^1.0.6"
-  },
-  "peerDependenciesMeta": {
-    "koishi-plugin-chatluna-storage-service": {
-      "optional": true
-    }
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "多平台大语言模型聊天插件，支持多种模型和输出格式",
-      "en": "A bot plugin for LLM chat services with multi-model integration, extensibility, and various output formats"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "implements": [
-        "chatluna"
-      ],
-      "required": [
-        "database"
-      ],
-      "optional": [
-        "censor",
-        "vits",
-        "sst",
-        "chatluna_storage"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "多平台大语言模型聊天插件，支持多种模型和输出格式",
+            "en": "A bot plugin for LLM chat services with multi-model integration, extensibility, and various output formats"
+        },
+        "service": {
+            "implements": [
+                "chatluna"
+            ],
+            "required": [
+                "database"
+            ],
+            "optional": [
+                "censor",
+                "vits",
+                "sst",
+                "chatluna_storage"
+            ]
+        }
     }
-  }
 }

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -49,7 +49,7 @@
         "agent"
     ],
     "dependencies": {
-         "@koishijs/plugin-console": "^5.30.11",
+        "@koishijs/plugin-console": "^5.30.11",
         "@codemirror/commands": "^6.10.2",
         "koishi-plugin-chatluna-storage-service": "^1.0.6",
         "@codemirror/lang-javascript": "^6.2.5",
@@ -88,7 +88,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.33",
+        "koishi-plugin-chatluna": "^1.3.34",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,92 +1,92 @@
 {
-  "name": "koishi-plugin-chatluna-long-memory",
-  "description": "long memory for chatluna",
-  "version": "1.3.3",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist",
-    "resources"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-long-memory",
+    "description": "long memory for chatluna",
+    "version": "1.3.4",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist",
+        "resources"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/extension-long-memory"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/extension-long-memory#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "openai",
-    "chatluna",
-    "search"
-  ],
-  "dependencies": {
-    "@langchain/core": "^0.3.80",
-    "jieba-wasm": "^2.4.0",
-    "js-yaml": "^4.1.0",
-    "stopwords-iso": "^1.1.0",
-    "tiny-segmenter": "^0.2.0",
-    "zod": "3.25.76"
-  },
-  "devDependencies": {
-    "@types/tiny-segmenter": "^0.2.0",
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/extension-long-memory"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/extension-long-memory#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "openai",
+        "chatluna",
+        "search"
+    ],
+    "dependencies": {
+        "@langchain/core": "^0.3.80",
+        "jieba-wasm": "^2.4.0",
+        "js-yaml": "^4.1.0",
+        "stopwords-iso": "^1.1.0",
+        "tiny-segmenter": "^0.2.0",
+        "zod": "3.25.76"
+    },
+    "devDependencies": {
+        "@types/tiny-segmenter": "^0.2.0",
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 长期记忆服务，为主插件和伪装提供长期记忆支持",
-      "en": "long memory support for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 长期记忆服务，为主插件和伪装提供长期记忆支持",
+            "en": "long memory support for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -1,93 +1,93 @@
 {
-  "name": "koishi-plugin-chatluna-plugin-common",
-  "description": "plugin service for agent mode of chatluna",
-  "version": "1.3.7",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-plugin-common",
+    "description": "plugin service for agent mode of chatluna",
+    "version": "1.3.8",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/extension-tools"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/extension-tools#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/extension-tools"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/extension-tools#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatluna",
-    "vectorstore"
-  ],
-  "dependencies": {
-    "@langchain/core": "^0.3.80",
-    "micromatch": "^4.0.8",
-    "which": "^6.0.1",
-    "zod": "3.25.76"
-  },
-  "devDependencies": {
-    "@types/micromatch": "^4.0.9",
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33",
-    "koishi-plugin-chatluna-agent": "^1.0.0",
-    "koishi-plugin-chatluna-storage-service": "^1.0.6"
-  },
-  "peerDependenciesMeta": {
-    "koishi-plugin-chatluna-agent": {
-      "optional": true
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "koishi-plugin-chatluna-storage-service": {
-      "optional": true
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna Agent 模式的一部分功能集（网络请求、定时任务、Koishi 命令执行等）",
-      "en": "Core functionalities for ChatLuna's agent mode (image gen, code exec, network, file ops, scheduling, memory, Koishi cmds, etc.)"
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatluna",
+        "vectorstore"
+    ],
+    "dependencies": {
+        "@langchain/core": "^0.3.80",
+        "micromatch": "^4.0.8",
+        "which": "^6.0.1",
+        "zod": "3.25.76"
+    },
+    "devDependencies": {
+        "@types/micromatch": "^4.0.9",
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34",
+        "koishi-plugin-chatluna-agent": "^1.0.1",
+        "koishi-plugin-chatluna-storage-service": "^1.0.6"
+    },
+    "peerDependenciesMeta": {
+        "koishi-plugin-chatluna-agent": {
+            "optional": true
+        },
+        "koishi-plugin-chatluna-storage-service": {
+            "optional": true
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna Agent 模式的一部分功能集（网络请求、定时任务、Koishi 命令执行等）",
+            "en": "Core functionalities for ChatLuna's agent mode (image gen, code exec, network, file ops, scheduling, memory, Koishi cmds, etc.)"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -1,88 +1,88 @@
 {
-  "name": "koishi-plugin-chatluna-variable-extension",
-  "description": "variable extension for ChatLuna",
-  "version": "1.3.2",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist",
-    "resources"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-variable-extension",
+    "description": "variable extension for ChatLuna",
+    "version": "1.3.2",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist",
+        "resources"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/extension-variable"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/extension-variable#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "openai",
-    "chatluna",
-    "mcp"
-  ],
-  "dependencies": {
-    "@langchain/core": "^0.3.80",
-    "date-holidays": "^3.26.1",
-    "lunar-javascript": "^1.7.4"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/extension-variable"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/extension-variable#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "openai",
+        "chatluna",
+        "mcp"
+    ],
+    "dependencies": {
+        "@langchain/core": "^0.3.80",
+        "date-holidays": "^3.26.1",
+        "lunar-javascript": "^1.7.4"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 变量扩展支持",
-      "en": "ChatLuna variable extension support"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 变量扩展支持",
+            "en": "ChatLuna variable extension support"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -1,79 +1,79 @@
 {
-  "name": "koishi-plugin-chatluna-image-renderer",
-  "description": "image renderer for chatluna",
-  "version": "1.3.4",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist",
-    "resources"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-image-renderer",
+    "description": "image renderer for chatluna",
+    "version": "1.3.4",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist",
+        "resources"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/renderer-image"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/renderer-image#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "openai",
-    "chatluna",
-    "search"
-  ],
-  "dependencies": {
-    "highlight.js": "^11.11.1",
-    "katex": "^0.16.22",
-    "marked": "^15.0.12",
-    "marked-highlight": "^2.2.2",
-    "marked-katex-extension": "^5.1.5",
-    "qrcode": "^1.5.4"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9",
-    "koishi-plugin-puppeteer": "^3.9.0"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的图像渲染插件",
-      "en": "Image renderer plugin for ChatLuna"
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/renderer-image"
     },
-    "service": {
-      "required": [
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/renderer-image#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "openai",
         "chatluna",
-        "puppeteer"
-      ]
+        "search"
+    ],
+    "dependencies": {
+        "highlight.js": "^11.11.1",
+        "katex": "^0.16.22",
+        "marked": "^15.0.12",
+        "marked-highlight": "^2.2.2",
+        "marked-katex-extension": "^5.1.5",
+        "qrcode": "^1.5.4"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9",
+        "koishi-plugin-puppeteer": "^3.9.0"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的图像渲染插件",
+            "en": "Image renderer plugin for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna",
+                "puppeteer"
+            ]
+        }
     }
-  }
 }

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -1,79 +1,79 @@
 {
-  "name": "koishi-plugin-chatluna-embeddings-service",
-  "description": "embeddings service for chatluna",
-  "version": "1.3.2",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-embeddings-service",
+    "description": "embeddings service for chatluna",
+    "version": "1.3.2",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/service-embeddings"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/service-embeddings#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatluna",
-    "embeddings"
-  ],
-  "dependencies": {
-    "@langchain/core": "^0.3.80"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/service-embeddings"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/service-embeddings#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatluna",
+        "embeddings"
+    ],
+    "dependencies": {
+        "@langchain/core": "^0.3.80"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "为 ChatLuna 提供多种 Embeddings 模型和平台支持",
-      "en": "Embeddings service supporting multiple models and platforms for ChatLuna"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "为 ChatLuna 提供多种 Embeddings 模型和平台支持",
+            "en": "Embeddings service supporting multiple models and platforms for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ]
+        }
     }
-  }
 }

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -1,101 +1,101 @@
 {
-  "name": "koishi-plugin-chatluna-multimodal-service",
-  "description": "multimodal service for chatluna",
-  "version": "1.3.3",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist",
-    "resources"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-multimodal-service",
+    "description": "multimodal service for chatluna",
+    "version": "1.3.4",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist",
+        "resources"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/service-image"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/service-image#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "openai",
-    "chatluna",
-    "search"
-  ],
-  "dependencies": {
-    "@langchain/core": "^0.3.80",
-    "jimp": "^1.6.0",
-    "omggif": "^1.0.10",
-    "zod": "3.25.76"
-  },
-  "devDependencies": {
-    "@types/omggif": "^1.0.5",
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9",
-    "koishi-plugin-ffmpeg-path": "^2.0.0"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33",
-    "koishi-plugin-ffmpeg-path": "^2.0.0"
-  },
-  "peerDependenciesMeta": {
-    "koishi-plugin-ffmpeg-path": {
-      "optional": true
-    }
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/service-image"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/service-image#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "openai",
+        "chatluna",
+        "search"
+    ],
+    "dependencies": {
+        "@langchain/core": "^0.3.80",
+        "jimp": "^1.6.0",
+        "omggif": "^1.0.10",
+        "zod": "3.25.76"
+    },
+    "devDependencies": {
+        "@types/omggif": "^1.0.5",
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9",
+        "koishi-plugin-ffmpeg-path": "^2.0.0"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34",
+        "koishi-plugin-ffmpeg-path": "^2.0.0"
+    },
+    "peerDependenciesMeta": {
+        "koishi-plugin-ffmpeg-path": {
+            "optional": true
+        }
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 多模态支持服务，图片读取支持，GIF 图片支持，语音文件支持",
-      "en": "ChatLuna multimodal support service, provides image reading support for models that do not support images"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ],
-      "optional": [
-        "ffmpeg",
-        "silk"
-      ]
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 多模态支持服务，图片读取支持，GIF 图片支持，语音文件支持",
+            "en": "ChatLuna multimodal support service, provides image reading support for models that do not support images"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ],
+            "optional": [
+                "ffmpeg",
+                "silk"
+            ]
+        }
     }
-  }
 }

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -1,91 +1,91 @@
 {
-  "name": "koishi-plugin-chatluna-search-service",
-  "description": "search support for chatluna",
-  "version": "1.3.4",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-search-service",
+    "description": "search support for chatluna",
+    "version": "1.3.5",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/service-search"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/service-search#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/service-search"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/service-search#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "openai",
-    "chatluna",
-    "search"
-  ],
-  "dependencies": {
-    "@langchain/core": "^0.3.80",
-    "@langchain/textsplitters": "^0.1.0",
-    "html-entities": "^2.6.0",
-    "lru-cache": "^11.2.2",
-    "zod": "3.25.76"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9",
-    "koishi-plugin-puppeteer": "^3.9.0"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 的网络搜索服务插件，支持多源聚合搜索，包括 `Bing` | `Google` | `DuckDuckGo` | `Serper` | `Tavily` | `MediaWiki`",
-      "en": "Web search service plugin for ChatLuna. Support multi-source aggregation search, including `Bing` | `Google` | `DuckDuckGo` | `Serper` | `Tavily` | `MediaWiki`"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "service": {
-      "required": [
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "openai",
         "chatluna",
-        "puppeteer"
-      ]
+        "search"
+    ],
+    "dependencies": {
+        "@langchain/core": "^0.3.80",
+        "@langchain/textsplitters": "^0.1.0",
+        "html-entities": "^2.6.0",
+        "lru-cache": "^11.2.2",
+        "zod": "3.25.76"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9",
+        "koishi-plugin-puppeteer": "^3.9.0"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 的网络搜索服务插件，支持多源聚合搜索，包括 `Bing` | `Google` | `DuckDuckGo` | `Serper` | `Tavily` | `MediaWiki`",
+            "en": "Web search service plugin for ChatLuna. Support multi-source aggregation search, including `Bing` | `Google` | `DuckDuckGo` | `Serper` | `Tavily` | `MediaWiki`"
+        },
+        "service": {
+            "required": [
+                "chatluna",
+                "puppeteer"
+            ]
+        }
     }
-  }
 }

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -1,85 +1,85 @@
 {
-  "name": "koishi-plugin-chatluna-vector-store-service",
-  "description": "vector store service for chatluna",
-  "version": "1.3.3",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "koishi-plugin-chatluna-vector-store-service",
+    "description": "vector store service for chatluna",
+    "version": "1.3.3",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/service-vector-store"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/service-vector-store#readme",
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/service-vector-store"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/service-vector-store#readme",
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-    }
-  },
-  "dependencies": {
-    "@chatluna/luna-vdb": "^0.0.12",
-    "@langchain/community": "0.3.48",
-    "@langchain/core": "^0.3.80",
-    "@langchain/redis": "^0.1.3",
-    "redis": "^4.7.1",
-    "zod-to-json-schema": "3.23.5"
-  },
-  "devDependencies": {
-    "@zilliz/milvus2-sdk-node": "^2.6.2",
-    "atsc": "^2.1.0",
-    "faiss-node": "^0.5.1",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "@zilliz/milvus2-sdk-node": "^2.6.2",
-    "faiss-node": "^0.5.1",
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  },
-  "peerDependenciesMeta": {
-    "@zilliz/milvus2-sdk-node": {
-      "optional": true
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
-    "faiss-node": {
-      "optional": true
-    }
-  },
-  "koishi": {
-    "description": {
-      "zh": "ChatLuna 向量存储服务和 RAG 底层架构支持",
-      "en": "Vector storage service and RAG underlying architecture support for ChatLuna"
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
     },
-    "service": {
-      "required": [
-        "chatluna"
-      ],
-      "implements": [
-        "chatluna_rag"
-      ]
+    "dependencies": {
+        "@chatluna/luna-vdb": "^0.0.12",
+        "@langchain/community": "0.3.48",
+        "@langchain/core": "^0.3.80",
+        "@langchain/redis": "^0.1.3",
+        "redis": "^4.7.1",
+        "zod-to-json-schema": "3.23.5"
+    },
+    "devDependencies": {
+        "@zilliz/milvus2-sdk-node": "^2.6.2",
+        "atsc": "^2.1.0",
+        "faiss-node": "^0.5.1",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "@zilliz/milvus2-sdk-node": "^2.6.2",
+        "faiss-node": "^0.5.1",
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
+    },
+    "peerDependenciesMeta": {
+        "@zilliz/milvus2-sdk-node": {
+            "optional": true
+        },
+        "faiss-node": {
+            "optional": true
+        }
+    },
+    "koishi": {
+        "description": {
+            "zh": "ChatLuna 向量存储服务和 RAG 底层架构支持",
+            "en": "Vector storage service and RAG underlying architecture support for ChatLuna"
+        },
+        "service": {
+            "required": [
+                "chatluna"
+            ],
+            "implements": [
+                "chatluna_rag"
+            ]
+        }
     }
-  }
 }

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,75 +1,75 @@
 {
-  "name": "@chatluna/v1-shared-adapter",
-  "description": "chatluna shared adapter",
-  "version": "1.0.30",
-  "main": "lib/index.cjs",
-  "module": "lib/index.mjs",
-  "typings": "lib/index.d.ts",
-  "files": [
-    "lib",
-    "dist"
-  ],
-  "exports": {
-    ".": {
-      "types": "./lib/index.d.ts",
-      "import": "./lib/index.mjs",
-      "require": "./lib/index.cjs"
+    "name": "@chatluna/v1-shared-adapter",
+    "description": "chatluna shared adapter",
+    "version": "1.0.31",
+    "main": "lib/index.cjs",
+    "module": "lib/index.mjs",
+    "typings": "lib/index.d.ts",
+    "files": [
+        "lib",
+        "dist"
+    ],
+    "exports": {
+        ".": {
+            "types": "./lib/index.d.ts",
+            "import": "./lib/index.mjs",
+            "require": "./lib/index.cjs"
+        },
+        "./package.json": "./package.json"
     },
-    "./package.json": "./package.json"
-  },
-  "type": "module",
-  "author": "dingyi222666 <dingyi222666@foxmail.com>",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/ChatLunaLab/chatluna.git",
-    "directory": "packages/shared-adapter"
-  },
-  "license": "AGPL-3.0",
-  "bugs": {
-    "url": "https://github.com/ChatLunaLab/chatluna/issues"
-  },
-  "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/shared-adapter#readme",
-  "scripts": {
-    "build": "atsc -b"
-  },
-  "engines": {
-    "node": ">=18.0.0"
-  },
-  "resolutions": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "overrides": {
-    "@langchain/core": "^0.3.80",
-    "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
-  },
-  "pnpm": {
+    "type": "module",
+    "author": "dingyi222666 <dingyi222666@foxmail.com>",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/ChatLunaLab/chatluna.git",
+        "directory": "packages/shared-adapter"
+    },
+    "license": "AGPL-3.0",
+    "bugs": {
+        "url": "https://github.com/ChatLunaLab/chatluna/issues"
+    },
+    "homepage": "https://github.com/ChatLunaLab/chatluna/tree/v1-dev/packages/shared-adapter#readme",
+    "scripts": {
+        "build": "atsc -b"
+    },
+    "engines": {
+        "node": ">=18.0.0"
+    },
+    "resolutions": {
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
     "overrides": {
-      "@langchain/core": "^0.3.80",
-      "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        "@langchain/core": "^0.3.80",
+        "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+    },
+    "pnpm": {
+        "overrides": {
+            "@langchain/core": "^0.3.80",
+            "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
+        }
+    },
+    "keywords": [
+        "chatbot",
+        "koishi",
+        "plugin",
+        "service",
+        "chatgpt",
+        "gpt",
+        "chatluna",
+        "adapter"
+    ],
+    "dependencies": {
+        "@langchain/core": "^0.3.80",
+        "zod": "3.25.76",
+        "zod-to-json-schema": "^3.24.6"
+    },
+    "devDependencies": {
+        "atsc": "^2.1.0",
+        "koishi": "^4.18.9"
+    },
+    "peerDependencies": {
+        "koishi": "^4.18.9",
+        "koishi-plugin-chatluna": "^1.3.34"
     }
-  },
-  "keywords": [
-    "chatbot",
-    "koishi",
-    "plugin",
-    "service",
-    "chatgpt",
-    "gpt",
-    "chatluna",
-    "adapter"
-  ],
-  "dependencies": {
-    "@langchain/core": "^0.3.80",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.24.6"
-  },
-  "devDependencies": {
-    "atsc": "^2.1.0",
-    "koishi": "^4.18.9"
-  },
-  "peerDependencies": {
-    "koishi": "^4.18.9",
-    "koishi-plugin-chatluna": "^1.3.33"
-  }
 }


### PR DESCRIPTION
## Summary
- bump `koishi-plugin-chatluna` to `1.3.34` and `@chatluna/v1-shared-adapter` to `1.0.31`
- update adapter and extension package manifests to depend on the new ChatLuna release versions
- keep package metadata aligned across the monorepo for the `1.3.34` release

## Testing
- not run (package manifest updates only)