### PR TITLE
fix(extension-agent): align e2b backend with current sdk

### DIFF
--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.1",
+    "version": "1.0.4",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -49,9 +49,7 @@
         "agent"
     ],
     "dependencies": {
-        "@koishijs/plugin-console": "^5.30.11",
         "@codemirror/commands": "^6.10.2",
-        "koishi-plugin-chatluna-storage-service": "^1.0.6",
         "@codemirror/lang-javascript": "^6.2.5",
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-markdown": "^6.5.0",
@@ -60,17 +58,18 @@
         "@codemirror/language": "^6.12.2",
         "@codemirror/state": "^6.5.4",
         "@codemirror/view": "^6.39.17",
-        "@e2b/desktop": "^2.2.2",
         "@element-plus/icons-vue": "^2.3.2",
+        "@koishijs/plugin-console": "^5.30.11",
         "@langchain/core": "^0.3.80",
         "@modelcontextprotocol/sdk": "^1.23.0",
         "@types/shell-quote": "^1.7.5",
         "@xterm/addon-fit": "^0.10.0",
         "codemirror": "^6.0.2",
-        "e2b": "^2.14.1",
+        "e2b": "2.2.1",
         "fflate": "^0.8.2",
         "highlight.js": "^11.11.1",
         "js-yaml": "^4.1.0",
+        "koishi-plugin-chatluna-storage-service": "^1.0.6",
         "micromatch": "^4.0.8",
         "mime-types": "^3.0.1",
         "shell-quote": "^1.8.3",
@@ -102,11 +101,17 @@
     },
     "overrides": {
         "@langchain/core": "^0.3.80",
+        "e2b": {
+            "chalk": "4.1.2"
+        },
         "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
     },
     "pnpm": {
         "overrides": {
             "@langchain/core": "^0.3.80",
+            "e2b": {
+                "chalk": "4.1.2"
+            },
             "js-tiktoken": "npm:@dingyi222666/js-tiktoken@^1.0.21"
         }
     },

--- a/packages/extension-agent/src/computer/backends/e2b.ts
+++ b/packages/extension-agent/src/computer/backends/e2b.ts
@@ -4,8 +4,12 @@ import { randomUUID } from 'crypto'
 import { Buffer } from 'node:buffer'
 import { posix } from 'path'
 import { Readable } from 'node:stream'
-import { CommandHandle, CommandResult, Sandbox as E2BSandbox } from 'e2b'
-import { Sandbox as DesktopSandbox } from '@e2b/desktop'
+import {
+    CommandHandle,
+    CommandResult,
+    CommandStartOpts,
+    Sandbox as E2BSandbox
+} from 'e2b'
 import mimeTypes from 'mime-types'
 import { buildPosixBackgroundCommand, quoteShell } from './types'
 import { E2BBackendConfig } from '../../types'
@@ -29,7 +33,7 @@ interface SandboxWrapper {
     setTimeout(timeoutMs: number): Promise<void>
     pause(apiKey?: string): Promise<void>
     kill(): Promise<void>
-    desktop?: DesktopSandbox
+    desktop?: never
 }
 
 export class E2BComputerSession implements ComputerSessionApi {
@@ -70,27 +74,17 @@ export class E2BComputerSession implements ComputerSessionApi {
 
         if (this._sandboxId && this.cfg.keepAlive) {
             this._sandbox = wrapSandbox(
-                this.usesDesktop()
-                    ? await DesktopSandbox.connect(this._sandboxId, {
-                          apiKey,
-                          timeoutMs: this.cfg.timeoutMs
-                      })
-                    : await E2BSandbox.connect(this._sandboxId, {
-                          apiKey,
-                          timeoutMs: this.cfg.timeoutMs
-                      })
+                await E2BSandbox.connect(this._sandboxId, {
+                    apiKey,
+                    timeoutMs: this.cfg.timeoutMs
+                })
             )
         } else {
             this._sandbox = wrapSandbox(
-                this.usesDesktop()
-                    ? await DesktopSandbox.create(this.cfg.desktopTemplate, {
-                          apiKey,
-                          timeoutMs: this.cfg.timeoutMs
-                      })
-                    : await E2BSandbox.create(this.cfg.template, {
-                          apiKey,
-                          timeoutMs: this.cfg.timeoutMs
-                      })
+                await E2BSandbox.create(this.cfg.template, {
+                    apiKey,
+                    timeoutMs: this.cfg.timeoutMs
+                })
             )
         }
 
@@ -98,7 +92,7 @@ export class E2BComputerSession implements ComputerSessionApi {
         await this._sandbox.setTimeout(this.cfg.timeoutMs)
         const current = await this._sandbox.commands.run('pwd', {
             timeoutMs: 5000
-        })
+        } as CommandStartOpts)
         this._home = current.stdout.trim() || '/'
 
         if (this.options.cwd) {
@@ -107,7 +101,7 @@ export class E2BComputerSession implements ComputerSessionApi {
                 `if [ -d ${quoteShell(cwd)} ]; then printf __dir__; fi`,
                 {
                     timeoutMs: 5000
-                }
+                } as CommandStartOpts
             )
             if (stat.stdout.trim() === '__dir__') {
                 this._root = cwd
@@ -288,7 +282,7 @@ export class E2BComputerSession implements ComputerSessionApi {
             cwd,
             timeoutMs: options.timeout,
             envs: options.env
-        })
+        } as CommandStartOpts)
         this._cwd = cwd
         return mapCommandResult(result)
     }
@@ -366,37 +360,39 @@ export class E2BComputerSession implements ComputerSessionApi {
     }
 
     async getDesktopInfo(): Promise<DesktopInfo | undefined> {
-        const desktop = this.ensureDesktopSandbox()
-        if (!desktop) {
-            return undefined
-        }
+        // const desktop = this.ensureDesktopSandbox()
+        // if (!desktop) {
+        //     return undefined
+        // }
 
-        await desktop.stream.start().catch(() => undefined)
-        const size = await desktop.getScreenSize()
-        return {
-            width: size.width,
-            height: size.height,
-            streamUrl: desktop.stream.getUrl({
-                autoConnect: true,
-                resize: 'scale'
-            })
-        }
+        // await desktop.stream.start().catch(() => undefined)
+        // const size = await desktop.getScreenSize()
+        // return {
+        //     width: size.width,
+        //     height: size.height,
+        //     streamUrl: desktop.stream.getUrl({
+        //         autoConnect: true,
+        //         resize: 'scale'
+        //     })
+        // }
+        return null
     }
 
     async screenshot(): Promise<ScreenshotResult> {
-        const desktop = this.ensureDesktopSandbox()
-        if (!desktop) {
-            throw new Error('Desktop is not enabled for this E2B session.')
-        }
+        // const desktop = this.ensureDesktopSandbox()
+        // if (!desktop) {
+        throw new Error('Desktop is not enabled for this E2B session.')
+        // }
 
-        const bytes = await desktop.screenshot('bytes')
-        const size = await desktop.getScreenSize()
-        return {
-            data: Buffer.from(bytes).toString('base64'),
-            mimeType: 'image/png',
-            width: size.width,
-            height: size.height
-        }
+        // const bytes = await desktop.screenshot('bytes')
+        // const size = await desktop.getScreenSize()
+        // return {
+        //     data: Buffer.from(bytes).toString('base64'),
+        //     mimeType: 'image/png',
+        //     width: size.width,
+        //     height: size.height
+        // }
+        //
     }
 
     async desktopAction(action: DesktopAction) {
@@ -405,42 +401,42 @@ export class E2BComputerSession implements ComputerSessionApi {
             throw new Error('Desktop is not enabled for this E2B session.')
         }
 
-        if (action.type === 'click') {
-            if (action.button === 'right') {
-                await desktop.rightClick(action.x, action.y)
-                return
-            }
-            if (action.button === 'middle') {
-                await desktop.middleClick(action.x, action.y)
-                return
-            }
-            await desktop.leftClick(action.x, action.y)
-            return
-        }
+        // if (action.type === 'click') {
+        //     if (action.button === 'right') {
+        //         await desktop.rightClick(action.x, action.y)
+        //         return
+        //     }
+        //     if (action.button === 'middle') {
+        //         await desktop.middleClick(action.x, action.y)
+        //         return
+        //     }
+        //     await desktop.leftClick(action.x, action.y)
+        //     return
+        // }
 
-        if (action.type === 'type') {
-            await desktop.write(action.text)
-            return
-        }
+        // if (action.type === 'type') {
+        //     await desktop.write(action.text)
+        //     return
+        // }
 
-        if (action.type === 'key') {
-            await desktop.press(action.key)
-            return
-        }
+        // if (action.type === 'key') {
+        //     await desktop.press(action.key)
+        //     return
+        // }
 
-        if (action.type === 'scroll') {
-            const direction = action.deltaY < 0 ? 'up' : 'down'
-            await desktop.scroll(
-                direction,
-                Math.max(1, Math.abs(action.deltaY))
-            )
-            return
-        }
+        // if (action.type === 'scroll') {
+        //     const direction = action.deltaY < 0 ? 'up' : 'down'
+        //     await desktop.scroll(
+        //         direction,
+        //         Math.max(1, Math.abs(action.deltaY))
+        //     )
+        //     return
+        // }
 
-        await desktop.drag(
-            [action.startX, action.startY],
-            [action.endX, action.endY]
-        )
+        // await desktop.drag(
+        //     [action.startX, action.startY],
+        //     [action.endX, action.endY]
+        // )
     }
 
     async getDesktopStream(): Promise<StreamHandle | undefined> {
@@ -475,7 +471,7 @@ export class E2BComputerSession implements ComputerSessionApi {
     }
 
     private ensureDesktopSandbox() {
-        return this._sandbox?.desktop
+        return undefined
     }
 
     private usesDesktop() {
@@ -517,7 +513,7 @@ function mapCommandResult(result: CommandResult | CommandHandle) {
     }
 }
 
-function wrapSandbox(sandbox: E2BSandbox | DesktopSandbox): SandboxWrapper {
+function wrapSandbox(sandbox: E2BSandbox): SandboxWrapper {
     return {
         sandboxId: sandbox.sandboxId,
         files: sandbox.files,
@@ -525,10 +521,10 @@ function wrapSandbox(sandbox: E2BSandbox | DesktopSandbox): SandboxWrapper {
         pty: sandbox.pty,
         setTimeout: (timeoutMs) => sandbox.setTimeout(timeoutMs),
         pause: async (apiKey) => {
-            await sandbox.pause(apiKey ? { apiKey } : undefined)
+            await sandbox.betaPause(apiKey ? { apiKey } : undefined)
         },
-        kill: () => sandbox.kill(),
-        desktop: sandbox instanceof DesktopSandbox ? sandbox : undefined
+        kill: () => sandbox.kill()
+        // desktop: sandbox instanceof DesktopSandbox ? sandbox : undefined
     }
 }
 


### PR DESCRIPTION
## Summary
- pin the `e2b` dependency to the supported SDK line and add the nested `chalk` override it expects
- update the backend to use the current E2B command and pause APIs
- remove desktop-only E2B integration paths that are unavailable with this SDK target