### PR TITLE
fix(extension-agent): restore keep-alive sandbox reconnects and skill bin checks

### DIFF
--- a/packages/extension-agent/client/components/computer/computer-page.vue
+++ b/packages/extension-agent/client/components/computer/computer-page.vue
@@ -457,13 +457,10 @@ function cloneConfig(value: ComputerConfig): ComputerConfig {
 <style scoped>
 .computer-page {
     min-height: 100%;
-    width: min(100%, 1800px);
+    width: 100%;
+    min-width: 0;
     margin: 0 auto;
     padding-bottom: 56px;
-}
-
-.computer-page.compact {
-    width: min(100%, 1440px);
 }
 
 .toolbar-container {

--- a/packages/extension-agent/client/components/layout/agent-shell.vue
+++ b/packages/extension-agent/client/components/layout/agent-shell.vue
@@ -178,8 +178,9 @@ const saveSection = async (
 
 .content-wrapper {
     padding: 28px 96px 120px 28px;
-    width: min(100%, 1920px);
-    max-width: 1920px;
+    width: 100%;
+    min-width: 0;
+    box-sizing: border-box;
     margin: 0 auto;
 }
 

--- a/packages/extension-agent/client/components/mcp/mcp-page.vue
+++ b/packages/extension-agent/client/components/mcp/mcp-page.vue
@@ -101,13 +101,10 @@ const hideDesc = useHideDesc('mcp')
 <style scoped>
 .mcp-page {
     min-height: 100%;
-    width: min(100%, 1800px);
+    width: 100%;
+    min-width: 0;
     margin: 0 auto;
     padding-bottom: 56px;
-}
-
-.mcp-page.compact {
-    width: min(100%, 1440px);
 }
 
 .toolbar-container {

--- a/packages/extension-agent/client/components/skills/skills-page.vue
+++ b/packages/extension-agent/client/components/skills/skills-page.vue
@@ -186,12 +186,24 @@
                                     导出 ZIP
                                 </el-button>
                                 <el-button
+                                    class="danger-soft"
                                     size="small"
                                     plain
-                                    :disabled="!item.path"
-                                    @click="copyPath(item.path)"
+                                    type="danger"
+                                    :loading="skillBusy[item.id] === true"
+                                    :disabled="!canRemove(item)"
+                                    @click="removeSkill(item)"
                                 >
-                                    复制路径
+                                    删除
+                                </el-button>
+                                <el-button
+                                    v-if="hasDiagnostics(item)"
+                                    size="small"
+                                    plain
+                                    type="warning"
+                                    @click="openDiagnostics(item)"
+                                >
+                                    错误信息
                                 </el-button>
                                 <el-button
                                     v-if="item.homepage"
@@ -202,17 +214,6 @@
                                     打开主页
                                 </el-button>
                             </div>
-
-                            <el-button
-                                v-if="hasDiagnostics(item)"
-                                class="skill-action-error"
-                                size="small"
-                                plain
-                                type="warning"
-                                @click="openDiagnostics(item)"
-                            >
-                                错误信息
-                            </el-button>
                         </div>
                     </div>
                 </div>
@@ -266,7 +267,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
 import { send } from '@koishijs/client'
-import { ElMessage } from 'element-plus'
+import { ElMessage, ElMessageBox } from 'element-plus'
 import { MagicStick, Search } from '@element-plus/icons-vue'
 import CodeEditor from '../shared/code-editor.vue'
 import { useCompactMode, useHideDesc } from '../shared/use-hide-desc'
@@ -313,7 +314,7 @@ const props = withDefaults(
     }
 )
 
-defineEmits<{
+const emit = defineEmits<{
     refresh: []
 }>()
 
@@ -448,17 +449,51 @@ async function exportSkill(item: SkillInfo) {
     }
 }
 
-async function copyPath(path: string) {
+async function removeSkill(item: SkillInfo) {
     try {
-        await navigator.clipboard.writeText(path)
-        ElMessage.success('已复制路径。')
-    } catch {
-        ElMessage.error('复制失败，请手动复制。')
+        await ElMessageBox.confirm(
+            item.state === 'missing'
+                ? `确定要移除这个残留的 skill 配置项吗？\n\n${item.id}`
+                : `删除"${item.name}"后需要重新导入，确定继续吗？`,
+            '删除 Skill',
+            {
+                confirmButtonText: '删除',
+                cancelButtonText: '取消',
+                type: 'warning'
+            }
+        )
+
+        skillBusy.value[item.id] = true
+        await send('chatluna-agent/removeSkill', item.id)
+        emit('refresh')
+        ElMessage.success(
+            item.state === 'missing'
+                ? '已移除残留的 skill 配置。'
+                : '已删除该 skill。'
+        )
+    } catch (error) {
+        if (error !== 'cancel' && error !== 'close') {
+            ElMessage.error('删除失败，请稍后重试。')
+        }
+    } finally {
+        skillBusy.value[item.id] = false
     }
 }
 
 function canExport(item: SkillInfo) {
-    return item.path.length > 0 && item.state !== 'missing'
+    return item.path.length > 0 && item.state !== 'missing' && !item.remote
+}
+
+function canRemove(item: SkillInfo) {
+    if (item.state === 'missing') {
+        return true
+    }
+
+    if (item.remote) {
+        return true
+    }
+
+    return item.source === 'chatluna' && item.scope === 'data'
 }
 
 function hasDiagnostics(item: SkillInfo) {
@@ -538,13 +573,10 @@ function base64ToBlob(data: string, type: string) {
 <style scoped>
 .skills-page {
     min-height: 100%;
-    width: min(100%, 1800px);
+    width: 100%;
+    min-width: 0;
     margin: 0 auto;
     padding-bottom: 56px;
-}
-
-.skills-page.compact {
-    width: min(100%, 1440px);
 }
 
 .toolbar-container {
@@ -675,11 +707,59 @@ function base64ToBlob(data: string, type: string) {
     gap: 8px;
 }
 
-.skill-actions-main :deep(.el-button),
-.skill-action-error {
+.skill-actions-main :deep(.el-button) {
     width: 100%;
     min-width: 0;
     margin: 0;
+}
+
+.skill-actions-main :deep(.danger-soft.el-button) {
+    --el-button-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 92%
+    );
+    --el-button-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 68%
+    );
+    --el-button-text-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        var(--k-text-dark) 22%
+    );
+    --el-button-hover-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 86%
+    );
+    --el-button-hover-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 52%
+    );
+    --el-button-hover-text-color: var(--el-color-danger);
+    --el-button-active-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 82%
+    );
+    --el-button-active-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 44%
+    );
+    --el-button-disabled-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 95%
+    );
+    --el-button-disabled-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 82%
+    );
 }
 
 .skill-footer {

--- a/packages/extension-agent/client/components/skills/skills-page.vue
+++ b/packages/extension-agent/client/components/skills/skills-page.vue
@@ -168,46 +168,50 @@
                         </div>
 
                         <div class="skill-actions">
+                            <div class="skill-actions-main">
+                                <el-button
+                                    size="small"
+                                    plain
+                                    :disabled="!item.path"
+                                    @click="previewSkill(item)"
+                                >
+                                    查看内容
+                                </el-button>
+                                <el-button
+                                    size="small"
+                                    plain
+                                    :disabled="!canExport(item)"
+                                    @click="exportSkill(item)"
+                                >
+                                    导出 ZIP
+                                </el-button>
+                                <el-button
+                                    size="small"
+                                    plain
+                                    :disabled="!item.path"
+                                    @click="copyPath(item.path)"
+                                >
+                                    复制路径
+                                </el-button>
+                                <el-button
+                                    v-if="item.homepage"
+                                    size="small"
+                                    plain
+                                    @click="openLink(item.homepage)"
+                                >
+                                    打开主页
+                                </el-button>
+                            </div>
+
                             <el-button
                                 v-if="hasDiagnostics(item)"
+                                class="skill-action-error"
                                 size="small"
                                 plain
                                 type="warning"
                                 @click="openDiagnostics(item)"
                             >
                                 错误信息
-                            </el-button>
-                            <el-button
-                                size="small"
-                                plain
-                                :disabled="!item.path"
-                                @click="previewSkill(item)"
-                            >
-                                查看内容
-                            </el-button>
-                            <el-button
-                                size="small"
-                                plain
-                                :disabled="!canExport(item)"
-                                @click="exportSkill(item)"
-                            >
-                                导出 ZIP
-                            </el-button>
-                            <el-button
-                                size="small"
-                                plain
-                                :disabled="!item.path"
-                                @click="copyPath(item.path)"
-                            >
-                                复制路径
-                            </el-button>
-                            <el-button
-                                v-if="item.homepage"
-                                size="small"
-                                plain
-                                @click="openLink(item.homepage)"
-                            >
-                                打开主页
                             </el-button>
                         </div>
                     </div>
@@ -652,12 +656,30 @@ function base64ToBlob(data: string, type: string) {
     gap: 10px;
 }
 
-.settings-actions,
-.skill-actions {
+.settings-actions {
     display: flex;
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
+}
+
+.skill-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.skill-actions-main {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(108px, 1fr));
+    gap: 8px;
+}
+
+.skill-actions-main :deep(.el-button),
+.skill-action-error {
+    width: 100%;
+    min-width: 0;
+    margin: 0;
 }
 
 .skill-footer {

--- a/packages/extension-agent/client/components/sub-agent/sub-agent-catalog.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-catalog.vue
@@ -94,6 +94,18 @@
                         </el-tag>
                     </div>
 
+                    <div v-if="canRemove(item)" class="agent-actions">
+                        <el-button
+                            class="danger-soft"
+                            size="small"
+                            plain
+                            type="danger"
+                            @click.stop="$emit('remove', item)"
+                        >
+                            删除
+                        </el-button>
+                    </div>
+
                     <div
                         v-if="item.diagnostics.length > 0"
                         class="diagnostic-box"
@@ -124,11 +136,13 @@ const props = defineProps<{
     agents: SubAgentInfo[]
     compactMode: boolean
     hideDesc: boolean
+    removableIds: string[]
 }>()
 
 defineEmits<{
     select: [id: string]
     toggle: [item: SubAgentInfo, enabled: boolean]
+    remove: [item: SubAgentInfo]
 }>()
 
 const keyword = ref('')
@@ -166,6 +180,10 @@ function stateTag(state: SubAgentInfo['state']) {
     if (state === 'ready') return 'success'
     if (state === 'invalid') return 'warning'
     return 'info'
+}
+
+function canRemove(item: SubAgentInfo) {
+    return props.removableIds.includes(item.id)
 }
 </script>
 
@@ -349,6 +367,40 @@ function stateTag(state: SubAgentInfo['state']) {
     display: flex;
     flex-direction: column;
     gap: 12px;
+}
+
+.agent-actions {
+    display: flex;
+    justify-content: flex-end;
+}
+
+.agent-actions :deep(.danger-soft.el-button) {
+    --el-button-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 92%
+    );
+    --el-button-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 68%
+    );
+    --el-button-text-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        var(--k-text-dark) 22%
+    );
+    --el-button-hover-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 86%
+    );
+    --el-button-hover-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 52%
+    );
+    --el-button-hover-text-color: var(--el-color-danger);
 }
 
 .diagnostic-box {

--- a/packages/extension-agent/client/components/sub-agent/sub-agent-detail.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-detail.vue
@@ -15,6 +15,7 @@
                 <div class="editor-actions">
                     <el-button
                         v-if="canRemove"
+                        class="danger-soft"
                         type="danger"
                         plain
                         @click="$emit('remove')"
@@ -276,6 +277,35 @@ const toolOptions = computed(() => {
     align-items: center;
     gap: 8px;
     flex-wrap: wrap;
+}
+
+.editor-actions :deep(.danger-soft.el-button) {
+    --el-button-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 92%
+    );
+    --el-button-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 68%
+    );
+    --el-button-text-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        var(--k-text-dark) 22%
+    );
+    --el-button-hover-bg-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 86%
+    );
+    --el-button-hover-border-color: color-mix(
+        in srgb,
+        var(--el-color-danger),
+        transparent 52%
+    );
+    --el-button-hover-text-color: var(--el-color-danger);
 }
 
 .editor-body {

--- a/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
@@ -75,8 +75,10 @@
                         :agents="agents"
                         :compact-mode="compactMode"
                         :hide-desc="hideDesc"
+                        :removable-ids="removableIds"
                         @select="openDetail"
                         @toggle="toggleAgent"
+                        @remove="removeAgent"
                     />
                     <sub-agent-runs
                         v-else-if="listTab === 'runs'"
@@ -311,10 +313,12 @@ watch(
 const canRemoveSelected = computed(() => {
     const item = selectedAgent.value
     if (!item) return false
-    return (
-        item.source === 'preset' ||
-        (item.source === 'markdown' && item.scope === 'data')
-    )
+    return canRemoveAgent(item)
+})
+const removableIds = computed(() => {
+    return agents.value
+        .filter((item) => canRemoveAgent(item))
+        .map((item) => item.id)
 })
 const skillOptions = computed(() => {
     return Object.values(props.skills ?? {})
@@ -459,6 +463,12 @@ async function removeSelected() {
     const item = selectedAgent.value
     if (!item) return
 
+    await removeAgent(item)
+}
+
+async function removeAgent(item: SubAgentInfo) {
+    const selected = selectedId.value === item.id
+
     try {
         await ElMessageBox.confirm(
             `删除"${item.name}"后需要手动重新导入或重新创建，确定继续吗？`,
@@ -471,11 +481,13 @@ async function removeSelected() {
         )
 
         await send('chatluna-agent/removeSubAgent', item.id)
-        currentView.value = 'list'
+        if (selected) {
+            currentView.value = 'list'
+        }
         await loadExtraData()
         ElMessage.success('已删除该 sub-agent。')
     } catch (error) {
-        if (error !== 'cancel') {
+        if (error !== 'cancel' && error !== 'close') {
             ElMessage.error('删除失败，请稍后重试。')
         }
     }
@@ -564,18 +576,23 @@ function splitItems(text: string) {
             (item, idx, list) => item.length > 0 && list.indexOf(item) === idx
         )
 }
+
+function canRemoveAgent(item: SubAgentInfo) {
+    if (item.source === 'preset' || item.source === 'manual') {
+        return true
+    }
+
+    return item.source === 'markdown' && (item.scope === 'data' || item.remote)
+}
 </script>
 
 <style scoped>
 .sub-agent-page {
     min-height: 100%;
-    width: min(100%, 1800px);
+    width: 100%;
+    min-width: 0;
     margin: 0 auto;
     padding-bottom: 56px;
-}
-
-.sub-agent-page.compact {
-    width: min(100%, 1440px);
 }
 
 .toolbar-container {

--- a/packages/extension-agent/client/components/tool/tool-page.vue
+++ b/packages/extension-agent/client/components/tool/tool-page.vue
@@ -399,13 +399,10 @@ function cloneRule(rule?: PermissionRule): PermissionRule {
 <style scoped>
 .tool-page {
     min-height: 100%;
-    width: min(100%, 1800px);
+    width: 100%;
+    min-width: 0;
     margin: 0 auto;
     padding-bottom: 56px;
-}
-
-.tool-page.compact {
-    width: min(100%, 1440px);
 }
 
 .toolbar-container {

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.11",
+    "version": "1.0.12",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.4",
+    "version": "1.0.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/resources/skills/agent-config-admin/SKILL.md
+++ b/packages/extension-agent/resources/skills/agent-config-admin/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: agent-config-admin
 description: >-
-    Use this for agent admin work done through the virtual `agentcli` CLI:
+    Use this for agent admin work done through the dedicated `agentcli` tool:
     inspect or change its own skills, sub-agents, tools, MCP servers, MCP
     tools, permissions, routing, or sandbox-to-local sync. Also use it when a
     task needs to create or edit a skill or sub-agent together with config
@@ -17,9 +17,9 @@ storage.
 ## Core protocol
 
 - Do not guess config, paths, or effective permissions.
-- Use the `bash` tool for commands that start with `agentcli`.
-- Treat `agentcli` as a virtual CLI, not a real shell binary.
-- Do not mix `agentcli` with normal shell commands in the same bash call.
+- Use the `agentcli` tool for commands that start with `agentcli`.
+- Treat `agentcli` as a dedicated tool that accepts the same CLI syntax.
+- Do not mix `agentcli` work with normal shell commands in the same tool call.
 - Use `agentcli --help` or `agentcli <command> --help` when you need the exact command shape.
 - Before create, update, remove, or config work on skills, sub-agents, tools, or MCP, run the full activation sweep.
 - After the activation sweep, inspect the exact target with `agentcli show ...`.
@@ -54,7 +54,7 @@ storage.
 - If a preview shows the wrong target, do not apply it.
 - When changing permissions, always verify the result with `agentcli show subagent <selector> effective` or another matching `show` command.
 - When the task authors new skill or sub-agent files, verify both the file result and the admin result before saying the task is done.
-- If bash is unavailable, say so instead of inventing results.
+- If the `agentcli` tool is unavailable, say so instead of inventing results.
 
 ## Activation sweep
 
@@ -120,7 +120,7 @@ agentcli cancel pending
 ## Command chaining
 
 - `agentcli` command lines may contain `&`, `&&`, `|`, `|&`, `||`, and `;`.
-- Treat `|` and `|&` as command separators for multiple `agentcli` calls on one line. They do not provide stdin piping between virtual CLI commands.
+- Treat `|` and `|&` as command separators for multiple `agentcli` calls on one line. They do not provide stdin piping between `agentcli` tool commands.
 - Named preview commands accept multiple targets when the syntax uses `<name...>` or `<selector...>`.
 - `agentcli preview enable tool` and `agentcli preview disable tool` accept multiple tool names before `--main`.
 - `agentcli preview set tool <name...> authority <0-5>` updates required Koishi authority for one or more tools.

--- a/packages/extension-agent/src/cli/dispatch.ts
+++ b/packages/extension-agent/src/cli/dispatch.ts
@@ -1821,7 +1821,13 @@ async function collectSyncFiles(
         for (const localRoot of localRoots) {
             const targetPath = join(localRoot, ...file.split('/'))
             const current = await readFile(targetPath, 'utf-8').catch(
-                () => undefined
+                (err: NodeJS.ErrnoException) => {
+                    if (err.code === 'ENOENT') {
+                        return undefined
+                    }
+
+                    throw err
+                }
             )
 
             if (current === content) {

--- a/packages/extension-agent/src/cli/dispatch.ts
+++ b/packages/extension-agent/src/cli/dispatch.ts
@@ -11,11 +11,13 @@ import { logger } from '..'
 import type { ComputerSessionApi } from '../computer/types'
 import { getRemoteSkillsRoot } from '../computer/materialize'
 import {
+    DEFAULT_SKILL_DIRS,
     getConfigPath,
     getSkillsRootPath,
     getSubAgentsRootPath
 } from '../config/path'
 import type { McpServerConfig, PermissionRule, SubAgentInfo } from '../types'
+import { resolveTildeDir } from '../utils/path'
 import { normalizeAgentCliArgv } from './parser'
 import {
     AGENTCLI_SANDBOX_SUBAGENTS_ROOT,
@@ -1708,7 +1710,28 @@ async function buildSyncPlan(
     session: ComputerSessionApi,
     target: 'all' | 'skills' | 'subagents'
 ) {
-    const skillRoot = getSkillsRootPath(ctx.agent.ctx)
+    const skillRoots =
+        target === 'subagents'
+            ? []
+            : Array.from(
+                  new Map(
+                      [
+                          getSkillsRootPath(ctx.agent.ctx),
+                          ...DEFAULT_SKILL_DIRS.map((item) =>
+                              resolveTildeDir(ctx.agent.ctx.baseDir, item)
+                          ),
+                          ...ctx.agent.args.config.skills.dirs
+                              .map((item) => item.trim())
+                              .filter(Boolean)
+                              .map((item) =>
+                                  resolveTildeDir(ctx.agent.ctx.baseDir, item)
+                              )
+                      ].map((item) => [
+                          item.replaceAll('\\', '/').toLowerCase(),
+                          item
+                      ])
+                  ).values()
+              )
     const subAgentRoot = getSubAgentsRootPath(ctx.agent.ctx)
     const skill =
         target === 'subagents'
@@ -1717,7 +1740,7 @@ async function buildSyncPlan(
                   session,
                   'skill',
                   getRemoteSkillsRoot(),
-                  skillRoot
+                  skillRoots
               )
     const subagent =
         target === 'skills'
@@ -1726,17 +1749,19 @@ async function buildSyncPlan(
                   session,
                   'subagent',
                   AGENTCLI_SANDBOX_SUBAGENTS_ROOT,
-                  subAgentRoot
+                  [subAgentRoot]
               )
     const files = [...skill.files, ...subagent.files]
     const created = files.filter((item) => item.mode === 'create').length
     const updated = files.length - created
     const unchanged = skill.unchanged + subagent.unchanged
     const rows: [string, string][] = [['backend', session.backend]]
+    const info = ['Sync sandbox']
 
     if (target !== 'subagents') {
         rows.push(['skills.sandbox', getRemoteSkillsRoot()])
-        rows.push(['skills.local', skillRoot])
+        rows.push(['skills.primary', getSkillsRootPath(ctx.agent.ctx)])
+        rows.push(['skills.targets', String(skillRoots.length)])
     }
 
     if (target !== 'skills') {
@@ -1748,10 +1773,20 @@ async function buildSyncPlan(
     rows.push(['overwrite', String(updated)])
     rows.push(['unchanged', String(unchanged)])
 
+    info.push(...indentCli(renderCliPairs(rows)))
+
+    if (target !== 'subagents' && skillRoots.length > 0) {
+        info.push(
+            '',
+            'Skill targets',
+            ...indentCli(skillRoots.map((item) => item.replaceAll('\\', '/')))
+        )
+    }
+
     return {
         files,
         summary: `sync sandbox from ${session.backend}: ${created} new, ${updated} overwrite`,
-        info: ['Sync sandbox', ...indentCli(renderCliPairs(rows))],
+        info,
         preview:
             files.length > 12
                 ? [
@@ -1759,13 +1794,13 @@ async function buildSyncPlan(
                           .slice(0, 12)
                           .map(
                               (item) =>
-                                  `${item.mode} ${item.kind} ${item.path.replaceAll('\\', '/')}`
+                                  `${item.mode} ${item.kind} ${item.targetPath.replaceAll('\\', '/')}`
                           ),
                       `... ${files.length - 12} more`
                   ]
                 : files.map(
                       (item) =>
-                          `${item.mode} ${item.kind} ${item.path.replaceAll('\\', '/')}`
+                          `${item.mode} ${item.kind} ${item.targetPath.replaceAll('\\', '/')}`
                   )
     }
 }
@@ -1774,32 +1809,35 @@ async function collectSyncFiles(
     session: ComputerSessionApi,
     kind: AgentCliSyncFile['kind'],
     remoteRoot: string,
-    localRoot: string
+    localRoots: string[]
 ) {
     const files: AgentCliSyncFile[] = []
     let unchanged = 0
 
     for (const file of await listRemoteFiles(session, remoteRoot)) {
         const sourcePath = posix.join(remoteRoot, file)
-        const targetPath = join(localRoot, ...file.split('/'))
         const content = await session.readFile(sourcePath)
-        const current = await readFile(targetPath, 'utf-8').catch(
-            () => undefined
-        )
 
-        if (current === content) {
-            unchanged += 1
-            continue
+        for (const localRoot of localRoots) {
+            const targetPath = join(localRoot, ...file.split('/'))
+            const current = await readFile(targetPath, 'utf-8').catch(
+                () => undefined
+            )
+
+            if (current === content) {
+                unchanged += 1
+                continue
+            }
+
+            files.push({
+                kind,
+                path: file,
+                sourcePath,
+                targetPath,
+                content,
+                mode: current == null ? 'create' : 'update'
+            })
         }
-
-        files.push({
-            kind,
-            path: file,
-            sourcePath,
-            targetPath,
-            content,
-            mode: current == null ? 'create' : 'update'
-        })
     }
 
     return { files, unchanged }
@@ -1937,10 +1975,11 @@ function helpLines(args: string[] = []) {
     if (topic === 'sync') {
         return renderHelp({
             title: 'agentcli sync',
-            about: 'Stage sandbox skills or sub-agents so they can be written back to local storage.',
+            about: 'Stage sandbox skills or sub-agents so they can be written back to local storage and compatibility roots.',
             usage: ['agentcli sync [skills|subagents|all]'],
             notes: [
                 'Sync reads files from the current remote computer session.',
+                'Skill sync fans out to ChatLuna and compatibility directories such as .agents/skills, .openclaw/skills, .codex/skills, .claude/skills, and OpenCode skill roots.',
                 'Files are staged as a preview first; use `agentcli apply last` to write them locally.',
                 'If the preview shows overwrites, confirm with the user before applying it.'
             ],

--- a/packages/extension-agent/src/cli/render.ts
+++ b/packages/extension-agent/src/cli/render.ts
@@ -1,10 +1,11 @@
 /** @module cli/render */
 
 import type { PermissionRule } from '../types'
-import type {
-    AgentCliOverview,
-    AgentCliRunResult,
-    AgentCliSessionState
+import {
+    AGENTCLI_PROMPT_MARKER,
+    type AgentCliOverview,
+    type AgentCliRunResult,
+    type AgentCliSessionState
 } from './types'
 
 export function renderAgentCliPrompt(
@@ -13,7 +14,7 @@ export function renderAgentCliPrompt(
 ) {
     const backend = info.defaultBackend
     const lines = [
-        '[agentcli session]',
+        AGENTCLI_PROMPT_MARKER,
         ...indentCli(
             renderCliPairs([
                 ['skill', info.skill],
@@ -71,7 +72,7 @@ export function renderAgentCliPrompt(
         '',
         'Workflow',
         ...indentCli([
-            'Use the bash tool and run commands that start with `agentcli`.',
+            'Use the `agentcli` tool and pass full commands that start with `agentcli`.',
             'For create, update, or config work on skills, sub-agents, tools, or MCP, run the activation sweep first.',
             'Activation sweep: `agentcli show skills`, `agentcli show subagents`, `agentcli show tools`, `agentcli show mcp servers`, `agentcli show mcp tools`.',
             'Use local ChatLuna paths as the source of truth. Do not replace them with your own machine paths.',
@@ -81,12 +82,12 @@ export function renderAgentCliPrompt(
             'Then inspect the exact target with `agentcli show ...`.',
             'Stage changes with `agentcli preview ...`; repeated preview commands append until apply or cancel, many named preview commands accept multiple targets in one call, and tool authority uses Koishi levels 0-5.',
             'Load `skill-creator` or `sub-agent-creator` before authoring those files because `agentcli` cannot create them directly.',
-            'Command chains support `&`, `&&`, `|`, `|&`, `||`, and `;`. Pipe operators only separate agentcli calls; they do not stream stdin.',
+            'Command chains support `&`, `&&`, `|`, `|&`, `||`, and `;` inside the `command` string. Pipe operators only separate agentcli calls; they do not stream stdin.',
             'Use `agentcli sync` to bring sandbox skills and sub-agents back to local paths.',
             'If a sync preview shows overwrites, wait for the user to confirm before `agentcli apply last`.',
             'Commit with `agentcli apply last` or discard with `agentcli cancel pending`.',
             'Use `agentcli --help` or `agentcli <command> --help` when needed.',
-            'If bash is unavailable, say so instead of inventing results.'
+            'If the `agentcli` tool is unavailable in this conversation, say so instead of inventing results.'
         ])
     )
 

--- a/packages/extension-agent/src/cli/service.ts
+++ b/packages/extension-agent/src/cli/service.ts
@@ -5,6 +5,7 @@ import {
     countMessageTokens,
     PromptContextRuntime
 } from 'koishi-plugin-chatluna/llm-core/prompt'
+import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import { Context, Session } from 'koishi'
 import { getRemoteSkillsRoot } from '../computer/materialize'
 import {
@@ -16,16 +17,19 @@ import type { ChatLunaAgentService } from '../service'
 import { runAgentCliBlock } from './dispatch'
 import { parseAgentCliCommand } from './parser'
 import { renderAgentCliPrompt, renderAgentCliResult } from './render'
+import { AgentCliTool } from './tool'
 import {
+    AGENTCLI_PROMPT_MARKER,
     AGENTCLI_SANDBOX_SUBAGENTS_ROOT,
+    AGENTCLI_SKILL_NAME,
+    AGENTCLI_TOOL_NAME,
     type AgentCliOverview,
     type AgentCliSessionState
 } from './types'
 
-const SKILL_NAME = 'agent-config-admin'
-
 export class ChatLunaAgentCliService {
     private _promptDispose?: () => void
+    private _toolDispose?: () => void
     private _sessions = new Map<string, AgentCliSessionState>()
 
     constructor(
@@ -43,17 +47,23 @@ export class ChatLunaAgentCliService {
     }
 
     async start() {
+        this.syncTool()
         this.syncPrompt()
     }
 
     async stop() {
+        this._toolDispose?.()
+        this._toolDispose = undefined
         this._promptDispose?.()
         this._promptDispose = undefined
         this._sessions.clear()
     }
 
     isActive(conversationId: string) {
-        return this.getAgent().skills.hasActiveSkill(conversationId, SKILL_NAME)
+        return this.getAgent().skills.hasActiveSkill(
+            conversationId,
+            AGENTCLI_SKILL_NAME
+        )
     }
 
     async executeCommand(
@@ -62,7 +72,9 @@ export class ChatLunaAgentCliService {
         session: Session
     ) {
         if (!this.isActive(conversationId)) {
-            throw new Error(`${SKILL_NAME} is not active in this conversation`)
+            throw new Error(
+                `${AGENTCLI_SKILL_NAME} is not active in this conversation`
+            )
         }
 
         const block = parseAgentCliCommand(command)
@@ -81,6 +93,32 @@ export class ChatLunaAgentCliService {
             block
         )
         return renderAgentCliResult(result)
+    }
+
+    private syncTool() {
+        this._toolDispose?.()
+        this._toolDispose = undefined
+
+        const tool = new AgentCliTool(this)
+        this._toolDispose = this.ctx.chatluna.platform.registerTool(
+            AGENTCLI_TOOL_NAME,
+            {
+                description: tool.description,
+                createTool: () => new AgentCliTool(this),
+                selector: (history) => {
+                    return history.some((msg) =>
+                        getMessageContent(msg.content).startsWith(
+                            AGENTCLI_PROMPT_MARKER
+                        )
+                    )
+                },
+                meta: {
+                    source: 'extension',
+                    group: 'agent',
+                    tags: ['config']
+                }
+            }
+        )
     }
 
     private syncPrompt() {
@@ -119,7 +157,7 @@ export class ChatLunaAgentCliService {
         const agent = this.getAgent()
         const status = agent.getStatus()
         return {
-            skill: SKILL_NAME,
+            skill: AGENTCLI_SKILL_NAME,
             configPath: getConfigPath(agent.ctx),
             localSkillsDir: getSkillsRootPath(agent.ctx),
             localSubAgentsDir: getSubAgentsRootPath(agent.ctx),

--- a/packages/extension-agent/src/cli/tool.ts
+++ b/packages/extension-agent/src/cli/tool.ts
@@ -1,0 +1,58 @@
+/** @module cli/tool */
+
+import { StructuredTool } from '@langchain/core/tools'
+import type { ChatLunaToolRunnable } from 'koishi-plugin-chatluna/llm-core/platform/types'
+import { z } from 'zod'
+import { getErrorMessage } from '../utils/shell'
+import type { ChatLunaAgentCliService } from './service'
+import { AGENTCLI_TOOL_NAME } from './types'
+import { Session, User } from 'koishi'
+
+export class AgentCliTool extends StructuredTool {
+    name = AGENTCLI_TOOL_NAME
+
+    description =
+        'Run ChatLuna agent control commands with the same `agentcli ...` ' +
+        'syntax used in the shell. Pass the full command string, keep the ' +
+        '`agentcli` prefix, and keep chaining operators like `&&`, `||`, ' +
+        '`;`, `|`, and `|&` unchanged.'
+
+    schema = z.object({
+        command: z
+            .string()
+            .describe(
+                'The full agentcli command to execute. Keep the `agentcli` prefix and syntax unchanged.'
+            )
+    })
+
+    constructor(private readonly service: ChatLunaAgentCliService) {
+        super()
+    }
+
+    async _call(
+        input: z.infer<typeof this.schema>,
+        _: unknown,
+        runConfig?: ChatLunaToolRunnable
+    ) {
+        const conversationId = runConfig?.configurable?.conversationId
+        const session = runConfig?.configurable?.session
+
+        if (
+            !conversationId ||
+            !session ||
+            ((session as Session<User.Field>).user?.authority ?? 0) < 3
+        ) {
+            return 'Error: agentcli is unavailable in this tool context'
+        }
+
+        try {
+            return await this.service.executeCommand(
+                input.command,
+                conversationId,
+                session
+            )
+        } catch (err) {
+            return `Error: agentcli failed: ${getErrorMessage(err)}`
+        }
+    }
+}

--- a/packages/extension-agent/src/cli/types.ts
+++ b/packages/extension-agent/src/cli/types.ts
@@ -11,6 +11,9 @@ import type { ChatLunaAgentService } from '../service'
 export type AgentCliPermission = 'read' | 'write' | 'dangerous'
 export type AgentCliOperator = '&' | '&&' | '|' | '|&' | '||' | ';'
 
+export const AGENTCLI_TOOL_NAME = 'agentcli'
+export const AGENTCLI_SKILL_NAME = 'agent-config-admin'
+export const AGENTCLI_PROMPT_MARKER = '[agentcli session]'
 export const AGENTCLI_SANDBOX_SUBAGENTS_ROOT = '~/.chatluna/agents'
 
 export interface AgentCliCall {

--- a/packages/extension-agent/src/computer/backends/e2b.ts
+++ b/packages/extension-agent/src/computer/backends/e2b.ts
@@ -643,18 +643,28 @@ export class E2BComputerSession implements ComputerSessionApi {
         sandbox?: SandboxWrapper
     ) {
         const current = sandbox ?? (await this.ensureSandbox())
+        let result: Awaited<ReturnType<SandboxWrapper['commands']['run']>>
+        let runErr: unknown
 
         try {
-            return await current.commands.run(command, options)
-        } finally {
-            try {
-                await current.setTimeout(this.cfg.timeoutMs)
-            } catch (err) {
-                if (!isMissingSandboxError(err)) {
-                    throw err
-                }
+            result = await current.commands.run(command, options)
+        } catch (err) {
+            runErr = err
+        }
+
+        try {
+            await current.setTimeout(this.cfg.timeoutMs)
+        } catch (err) {
+            if (!runErr && !isMissingSandboxError(err)) {
+                throw err
             }
         }
+
+        if (runErr) {
+            throw runErr
+        }
+
+        return result
     }
 
     private ensureDesktopSandbox() {
@@ -709,16 +719,7 @@ function isMissingSandboxError(err: unknown) {
         return false
     }
 
-    if (err.name === 'NotFoundError') {
-        return true
-    }
-
-    const msg = err.message.toLowerCase()
-    return (
-        msg.includes('not found') ||
-        msg.includes('not running anymore') ||
-        msg.includes('terminated')
-    )
+    return err.name === 'NotFoundError'
 }
 
 function wrapSandbox(sandbox: E2BSandbox): SandboxWrapper {

--- a/packages/extension-agent/src/computer/backends/e2b.ts
+++ b/packages/extension-agent/src/computer/backends/e2b.ts
@@ -27,6 +27,7 @@ import {
 
 interface SandboxWrapper {
     sandboxId: string
+    internal: E2BSandbox
     files: E2BSandbox['files']
     commands: E2BSandbox['commands']
     pty: E2BSandbox['pty']
@@ -72,15 +73,26 @@ export class E2BComputerSession implements ComputerSessionApi {
             throw new Error('E2B apiKey is empty.')
         }
 
+        let sandbox: SandboxWrapper
+
         if (this._sandboxId && this.cfg.keepAlive) {
-            this._sandbox = wrapSandbox(
-                await E2BSandbox.connect(this._sandboxId, {
-                    apiKey,
-                    timeoutMs: this.cfg.timeoutMs
-                })
-            )
+            try {
+                sandbox = wrapSandbox(
+                    await E2BSandbox.connect(this._sandboxId, {
+                        apiKey,
+                        timeoutMs: this.cfg.timeoutMs
+                    })
+                )
+            } catch {
+                sandbox = wrapSandbox(
+                    await E2BSandbox.create(this.cfg.template, {
+                        apiKey,
+                        timeoutMs: this.cfg.timeoutMs
+                    })
+                )
+            }
         } else {
-            this._sandbox = wrapSandbox(
+            sandbox = wrapSandbox(
                 await E2BSandbox.create(this.cfg.template, {
                     apiKey,
                     timeoutMs: this.cfg.timeoutMs
@@ -88,20 +100,26 @@ export class E2BComputerSession implements ComputerSessionApi {
             )
         }
 
-        this._sandboxId = this._sandbox.sandboxId
-        await this._sandbox.setTimeout(this.cfg.timeoutMs)
-        const current = await this._sandbox.commands.run('pwd', {
-            timeoutMs: 5000
-        } as CommandStartOpts)
+        this._sandbox = sandbox
+        this._sandboxId = sandbox.sandboxId
+        await sandbox.setTimeout(this.cfg.timeoutMs)
+        const current = await this.run(
+            'pwd',
+            {
+                timeoutMs: 5000
+            } as CommandStartOpts,
+            sandbox
+        )
         this._home = current.stdout.trim() || '/'
 
         if (this.options.cwd) {
             const cwd = this.resolvePath(this.options.cwd)
-            const stat = await this._sandbox.commands.run(
+            const stat = await this.run(
                 `if [ -d ${quoteShell(cwd)} ]; then printf __dir__; fi`,
                 {
                     timeoutMs: 5000
-                } as CommandStartOpts
+                } as CommandStartOpts,
+                sandbox
             )
             if (stat.stdout.trim() === '__dir__') {
                 this._root = cwd
@@ -276,9 +294,7 @@ export class E2BComputerSession implements ComputerSessionApi {
         const cwd = options.workdir
             ? this.resolvePath(options.workdir)
             : this._cwd
-        const result = await (
-            await this.ensureSandbox()
-        ).commands.run(command, {
+        const result = await this.run(command, {
             cwd,
             timeoutMs: options.timeout,
             envs: options.env
@@ -465,9 +481,33 @@ export class E2BComputerSession implements ComputerSessionApi {
     private async ensureSandbox() {
         if (!this._sandbox) {
             await this.connect()
+            return this._sandbox
         }
 
+        try {
+            if (await this._sandbox.internal.isRunning()) {
+                return this._sandbox
+            }
+        } catch {}
+
+        this._connected = false
+        await this.connect()
+
         return this._sandbox
+    }
+
+    private async run(
+        command: string,
+        options?: CommandStartOpts,
+        sandbox?: SandboxWrapper
+    ) {
+        const current = sandbox ?? (await this.ensureSandbox())
+
+        try {
+            return await current.commands.run(command, options)
+        } finally {
+            await current.setTimeout(SANDBOX_COMMAND_TIMEOUT).catch(() => {})
+        }
     }
 
     private ensureDesktopSandbox() {
@@ -523,7 +563,8 @@ function wrapSandbox(sandbox: E2BSandbox): SandboxWrapper {
         pause: async (apiKey) => {
             await sandbox.betaPause(apiKey ? { apiKey } : undefined)
         },
-        kill: () => sandbox.kill()
+        kill: () => sandbox.kill(),
+        internal: sandbox
         // desktop: sandbox instanceof DesktopSandbox ? sandbox : undefined
     }
 }
@@ -541,3 +582,5 @@ const CAPABILITIES = [
     'desktop_screenshot',
     'desktop_action'
 ] as const
+
+const SANDBOX_COMMAND_TIMEOUT = 30_000

--- a/packages/extension-agent/src/computer/backends/e2b.ts
+++ b/packages/extension-agent/src/computer/backends/e2b.ts
@@ -8,12 +8,14 @@ import {
     CommandHandle,
     CommandResult,
     CommandStartOpts,
-    NotFoundError,
-    Sandbox as E2BSandbox
+    Sandbox as E2BSandbox,
+    NotFoundError
 } from 'e2b'
 import mimeTypes from 'mime-types'
+import { Context } from 'koishi'
 import { buildPosixBackgroundCommand, quoteShell } from './types'
 import { E2BBackendConfig } from '../../types'
+import { getErrorMessage } from '../../utils/shell'
 import {
     ComputerSessionApi,
     DesktopAction,
@@ -51,6 +53,7 @@ export class E2BComputerSession implements ComputerSessionApi {
     private _sandboxId?: string
 
     constructor(
+        private ctx: Context,
         private cfg: E2BBackendConfig,
         private options: { cwd?: string },
         id = randomUUID()
@@ -176,56 +179,75 @@ export class E2BComputerSession implements ComputerSessionApi {
     }
 
     async readFile(filePath: string, offset?: number, limit?: number) {
-        const target = this.resolvePath(filePath)
-        const stat = await this.execute(
-            `if [ -d ${quoteShell(target)} ]; then printf __dir__; fi`,
-            { timeout: 5000 }
-        )
-        if (stat.stdout.trim() === '__dir__') {
-            const result = await this.execute(
-                `find ${quoteShell(target)} -mindepth 1 -maxdepth 1 \\( -type d -printf '%p/\\n' -o -type f -printf '%p\\n' \\) | sort`
+        try {
+            const target = this.resolvePath(filePath)
+            const stat = await this.execute(
+                `if [ -d ${quoteShell(target)} ]; then printf __dir__; fi`,
+                { timeout: 5000 }
             )
-            return result.stdout.trim()
-        }
+            if (stat.stdout.trim() === '__dir__') {
+                const result = await this.execute(
+                    `find ${quoteShell(target)} -mindepth 1 -maxdepth 1 \\( -type d -printf '%p/\\n' -o -type f -printf '%p\\n' \\) | sort`
+                )
+                return result.stdout.trim()
+            }
 
-        const raw = await (await this.ensureSandbox()).files.read(target)
-        const text = String(raw)
-        if (offset == null && limit == null) {
-            return text
-        }
+            const raw = await (await this.ensureSandbox()).files.read(target)
+            const text = String(raw)
+            if (offset == null && limit == null) {
+                return text
+            }
 
-        const lines = text.split('\n')
-        const start = offset != null ? Math.max(0, offset - 1) : 0
-        const end =
-            limit != null ? Math.min(lines.length, start + limit) : lines.length
-        return lines
-            .slice(start, end)
-            .map((line, idx) => `${start + idx + 1}: ${line}`)
-            .join('\n')
+            const lines = text.split('\n')
+            const start = offset != null ? Math.max(0, offset - 1) : 0
+            const end = limit != null ? start + limit : lines.length
+            return lines
+                .slice(start, end)
+                .map((line, idx) => `${start + idx + 1}: ${line}`)
+                .join('\n')
+        } catch (err) {
+            this.ctx.logger.error(err)
+            throw new Error(
+                `Failed to read ${filePath}: ${getErrorMessage(err)}`
+            )
+        }
     }
 
     async writeFile(filePath: string, content: FileContent) {
-        const target = this.resolvePath(filePath)
-        if (typeof content === 'string') {
-            await (await this.ensureSandbox()).files.write(target, content)
-            return
-        }
-
-        const dir = posix.dirname(target)
-        const tmp = `${target}.${randomUUID()}.base64`
-
-        await this.execute(`mkdir -p ${quoteShell(dir)}`)
-        await this.writeFile(tmp, Buffer.from(content).toString('base64'))
-
         try {
-            const result = await this.execute(
-                `base64 -d ${quoteShell(tmp)} > ${quoteShell(target)}`
-            )
-            if (result.exitCode !== 0) {
-                throw new Error(result.stderr || `Failed to write ${filePath}`)
+            const target = this.resolvePath(filePath)
+            const sandbox = await this.ensureSandbox()
+            if (typeof content === 'string') {
+                await sandbox.files.write(target, content)
+                return
             }
-        } finally {
-            await this.execute(`rm -f ${quoteShell(tmp)}`).catch(() => {})
+
+            const dir = posix.dirname(target)
+            const tmp = `${target}.${randomUUID()}.base64`
+
+            await this.execute(`mkdir -p ${quoteShell(dir)}`)
+            await sandbox.files.write(
+                tmp,
+                Buffer.from(content).toString('base64')
+            )
+
+            try {
+                const result = await this.execute(
+                    `base64 -d ${quoteShell(tmp)} > ${quoteShell(target)}`
+                )
+                if (result.exitCode !== 0) {
+                    throw new Error(
+                        result.stderr || `Failed to write ${filePath}`
+                    )
+                }
+            } finally {
+                await this.execute(`rm -f ${quoteShell(tmp)}`).catch(() => {})
+            }
+        } catch (err) {
+            this.ctx.logger.error(err)
+            throw new Error(
+                `Failed to write ${filePath}: ${getErrorMessage(err)}`
+            )
         }
     }
 
@@ -281,28 +303,38 @@ export class E2BComputerSession implements ComputerSessionApi {
     }
 
     async grep(pattern: string, searchPath?: string, include?: string) {
-        const dir = searchPath ? this.resolvePath(searchPath) : this._root
-        const cmd = include
-            ? `find ${quoteShell(dir)} -type f | grep -E ${quoteShell(include)} | xargs -r grep -nE ${quoteShell(pattern)}`
-            : `grep -R -nE ${quoteShell(pattern)} ${quoteShell(dir)}`
-        const result = await this.execute(cmd)
-        return [result.stdout, result.stderr]
-            .filter(Boolean)
-            .join('\n')
-            .split('\n')
-            .filter(Boolean)
+        try {
+            const dir = searchPath ? this.resolvePath(searchPath) : this._root
+            const cmd = include
+                ? `find ${quoteShell(dir)} -type f | grep -E ${quoteShell(include)} | xargs -r grep -nE ${quoteShell(pattern)}`
+                : `grep -R -nE ${quoteShell(pattern)} ${quoteShell(dir)}`
+            const result = await this.execute(cmd)
+            return [result.stdout, result.stderr]
+                .filter(Boolean)
+                .join('\n')
+                .split('\n')
+                .filter(Boolean)
+        } catch (err) {
+            this.ctx.logger.error(err)
+            throw new Error(`Failed to grep: ${getErrorMessage(err)}`)
+        }
     }
 
     async glob(pattern: string, searchPath?: string) {
-        const dir = searchPath ? this.resolvePath(searchPath) : this._root
-        const result = await this.execute(
-            `find ${quoteShell(dir)} -type f | grep -E ${quoteShell(pattern)}`
-        )
-        return [result.stdout, result.stderr]
-            .filter(Boolean)
-            .join('\n')
-            .split('\n')
-            .filter(Boolean)
+        try {
+            const dir = searchPath ? this.resolvePath(searchPath) : this._root
+            const result = await this.execute(
+                `find ${quoteShell(dir)} -type f | grep -E ${quoteShell(pattern)}`
+            )
+            return [result.stdout, result.stderr]
+                .filter(Boolean)
+                .join('\n')
+                .split('\n')
+                .filter(Boolean)
+        } catch (err) {
+            this.ctx.logger.error(err)
+            throw new Error(`Failed to glob: ${getErrorMessage(err)}`)
+        }
     }
 
     async execute(command: string, options: ExecuteOptions = {}) {
@@ -319,67 +351,110 @@ export class E2BComputerSession implements ComputerSessionApi {
     }
 
     async readAsset(filePath: string) {
-        const result = await this.execute(
-            `base64 ${quoteShell(this.resolvePath(filePath))} | tr -d '\n'`
-        )
-        return result.stdout.trim()
+        try {
+            const result = await this.execute(
+                `base64 ${quoteShell(this.resolvePath(filePath))} | tr -d '\n'`
+            )
+            return result.stdout.trim()
+        } catch (err) {
+            this.ctx.logger.error(err)
+            throw new Error(
+                `Failed to read asset ${filePath}: ${getErrorMessage(err)}`
+            )
+        }
     }
 
     async openAsset(filePath: string) {
-        const sandbox = await this.ensureSandbox()
-        const target = this.resolvePath(filePath)
-        const info = await sandbox.files.getInfo(target)
-        const stream = await sandbox.files.read(target, {
-            format: 'stream'
-        })
-        const mimeType = mimeTypes.lookup(filePath)
-        return {
-            stream: Readable.fromWeb(
-                stream as unknown as globalThis.ReadableStream<Uint8Array>
-            ),
-            size: info.size,
-            mimeType: mimeType === false ? undefined : mimeType
+        try {
+            const sandbox = await this.ensureSandbox()
+            const target = this.resolvePath(filePath)
+            const info = await sandbox.files.getInfo(target)
+            const stream = await sandbox.files.read(target, {
+                format: 'stream'
+            })
+            const mimeType = mimeTypes.lookup(filePath)
+            return {
+                stream: Readable.fromWeb(
+                    stream as unknown as globalThis.ReadableStream<Uint8Array>
+                ),
+                size: info.size,
+                mimeType: mimeType === false ? undefined : mimeType
+            }
+        } catch (err) {
+            this.ctx.logger.error(err)
+            throw new Error(
+                `Failed to open asset ${filePath}: ${getErrorMessage(err)}`
+            )
         }
     }
 
     async createTerminal(options: TerminalOptions = {}) {
-        const sandbox = await this.ensureSandbox()
-        const callbacks = new Set<(data: string) => void>()
-        const cwd = options.cwd ? this.resolvePath(options.cwd) : this._cwd
-        const handle = await sandbox.pty.create({
-            cols: options.cols ?? 80,
-            rows: options.rows ?? 24,
-            cwd,
-            timeoutMs: this.cfg.timeoutMs,
-            onData: (data) => {
-                const text = Buffer.from(data).toString('utf8')
-                for (const callback of callbacks) {
-                    callback(text)
+        try {
+            const sandbox = await this.ensureSandbox()
+            const callbacks = new Set<(data: string) => void>()
+            const cwd = options.cwd ? this.resolvePath(options.cwd) : this._cwd
+            const handle = await sandbox.pty.create({
+                cols: options.cols ?? 80,
+                rows: options.rows ?? 24,
+                cwd,
+                timeoutMs: this.cfg.timeoutMs,
+                onData: (data) => {
+                    const text = Buffer.from(data).toString('utf8')
+                    for (const callback of callbacks) {
+                        callback(text)
+                    }
                 }
-            }
-        })
+            })
+            const ctx = this.ctx
 
-        return {
-            id: String(handle.pid),
-            async onData(callback) {
-                callbacks.add(callback)
-                return () => {
-                    callbacks.delete(callback)
+            return {
+                id: String(handle.pid),
+                async onData(callback) {
+                    callbacks.add(callback)
+                    return () => {
+                        callbacks.delete(callback)
+                    }
+                },
+                async sendInput(data) {
+                    try {
+                        await sandbox.pty.sendInput(
+                            handle.pid,
+                            Buffer.from(data, 'utf8')
+                        )
+                    } catch (err) {
+                        ctx.logger.error(err)
+                        throw new Error(
+                            `Failed to send terminal input: ${getErrorMessage(err)}`
+                        )
+                    }
+                },
+                async resize(cols, rows) {
+                    try {
+                        await sandbox.pty.resize(handle.pid, { cols, rows })
+                    } catch (err) {
+                        ctx.logger.error(err)
+                        throw new Error(
+                            `Failed to resize terminal: ${getErrorMessage(err)}`
+                        )
+                    }
+                },
+                async kill() {
+                    try {
+                        await handle.kill()
+                    } catch (err) {
+                        ctx.logger.error(err)
+                        throw new Error(
+                            `Failed to kill terminal: ${getErrorMessage(err)}`
+                        )
+                    }
                 }
-            },
-            async sendInput(data) {
-                await sandbox.pty.sendInput(
-                    handle.pid,
-                    Buffer.from(data, 'utf8')
-                )
-            },
-            async resize(cols, rows) {
-                await sandbox.pty.resize(handle.pid, { cols, rows })
-            },
-            async kill() {
-                await handle.kill()
-            }
-        } satisfies TerminalHandle
+            } satisfies TerminalHandle
+        } catch (err) {
+            this.ctx.logger.error(err)
+            throw new Error(
+                `Failed to create terminal: ${getErrorMessage(err)}`
+            )
+        }
     }
 
     async prepareBackgroundCommand(
@@ -476,12 +551,30 @@ export class E2BComputerSession implements ComputerSessionApi {
             return undefined
         }
 
-        await desktop.stream.start()
-        return {
-            url: desktop.stream.getUrl({ autoConnect: true, resize: 'scale' }),
-            async stop() {
-                await desktop.stream.stop()
+        try {
+            await desktop.stream.start()
+            const ctx = this.ctx
+            return {
+                url: desktop.stream.getUrl({
+                    autoConnect: true,
+                    resize: 'scale'
+                }),
+                async stop() {
+                    try {
+                        await desktop.stream.stop()
+                    } catch (err) {
+                        ctx.logger.error(err)
+                        throw new Error(
+                            `Failed to stop desktop stream: ${getErrorMessage(err)}`
+                        )
+                    }
+                }
             }
+        } catch (err) {
+            this.ctx.logger.error(err)
+            throw new Error(
+                `Failed to start desktop stream: ${getErrorMessage(err)}`
+            )
         }
     }
 
@@ -504,9 +597,7 @@ export class E2BComputerSession implements ComputerSessionApi {
                 return this._sandbox
             }
         } catch (err) {
-            if (!isMissingSandboxError(err)) {
-                throw err
-            }
+            this.ctx.logger.error(err)
         }
 
         this._connected = false

--- a/packages/extension-agent/src/computer/backends/e2b.ts
+++ b/packages/extension-agent/src/computer/backends/e2b.ts
@@ -46,6 +46,7 @@ export class E2BComputerSession implements ComputerSessionApi {
     readonly capabilities = [...CAPABILITIES]
 
     private _connected = false
+    private _connecting?: Promise<void>
     private _home = '/'
     private _root: string
     private _cwd: string
@@ -68,83 +69,113 @@ export class E2BComputerSession implements ComputerSessionApi {
     }
 
     async connect() {
-        if (!this.cfg.enabled) {
-            throw new Error('E2B backend is disabled.')
+        if (this._connecting) {
+            await this._connecting
+            return
         }
 
-        const apiKey = this.resolveSecret(this.cfg.apiKey)
-        if (!apiKey) {
-            throw new Error('E2B apiKey is empty.')
-        }
+        const task = (async () => {
+            if (!this.cfg.enabled) {
+                throw new Error('E2B backend is disabled.')
+            }
 
-        let sandbox: SandboxWrapper
+            const apiKey = this.resolveSecret(this.cfg.apiKey)
+            if (!apiKey) {
+                throw new Error('E2B apiKey is empty.')
+            }
 
-        if (this._sandboxId && this.cfg.keepAlive) {
+            let sandbox: SandboxWrapper | undefined
+            let created = false
+
             try {
-                sandbox = wrapSandbox(
-                    await E2BSandbox.connect(this._sandboxId, {
-                        apiKey,
-                        timeoutMs: this.cfg.timeoutMs
-                    })
-                )
-            } catch (err) {
-                if (!isMissingSandboxError(err)) {
-                    throw err
+                if (this._sandboxId && this.cfg.keepAlive) {
+                    try {
+                        sandbox = wrapSandbox(
+                            await E2BSandbox.connect(this._sandboxId, {
+                                apiKey,
+                                timeoutMs: this.cfg.timeoutMs
+                            })
+                        )
+                    } catch (err) {
+                        if (!isMissingSandboxError(err)) {
+                            throw err
+                        }
+
+                        sandbox = wrapSandbox(
+                            await E2BSandbox.create(this.cfg.template, {
+                                apiKey,
+                                timeoutMs: this.cfg.timeoutMs
+                            })
+                        )
+                        created = true
+                    }
+                } else {
+                    sandbox = wrapSandbox(
+                        await E2BSandbox.create(this.cfg.template, {
+                            apiKey,
+                            timeoutMs: this.cfg.timeoutMs
+                        })
+                    )
+                    created = true
                 }
 
-                sandbox = wrapSandbox(
-                    await E2BSandbox.create(this.cfg.template, {
-                        apiKey,
-                        timeoutMs: this.cfg.timeoutMs
-                    })
+                await sandbox.setTimeout(this.cfg.timeoutMs)
+                const current = await this.run(
+                    'pwd',
+                    {
+                        timeoutMs: 5000
+                    } as CommandStartOpts,
+                    sandbox
                 )
+                this._home = current.stdout.trim() || '/'
+
+                if (this.options.cwd) {
+                    const cwd = this.resolvePath(this.options.cwd)
+                    const stat = await this.run(
+                        `if [ -d ${quoteShell(cwd)} ]; then printf __dir__; fi`,
+                        {
+                            timeoutMs: 5000
+                        } as CommandStartOpts,
+                        sandbox
+                    )
+                    if (stat.stdout.trim() === '__dir__') {
+                        this._root = cwd
+                        this._cwd = cwd
+                    } else {
+                        this._root = this._home
+                        this._cwd = this._root
+                    }
+                } else {
+                    this._root = this._home
+                    this._cwd = this._root
+                }
+
+                this._sandbox = sandbox
+                this._sandboxId = sandbox.sandboxId
+                this._connected = true
+            } catch (err) {
+                this._sandbox = undefined
+                this._connected = false
+                if (created && sandbox) {
+                    await sandbox.kill().catch(() => undefined)
+                }
+                throw err
             }
-        } else {
-            sandbox = wrapSandbox(
-                await E2BSandbox.create(this.cfg.template, {
-                    apiKey,
-                    timeoutMs: this.cfg.timeoutMs
-                })
-            )
-        }
+        })()
 
-        this._sandbox = sandbox
-        this._sandboxId = sandbox.sandboxId
-        await sandbox.setTimeout(this.cfg.timeoutMs)
-        const current = await this.run(
-            'pwd',
-            {
-                timeoutMs: 5000
-            } as CommandStartOpts,
-            sandbox
-        )
-        this._home = current.stdout.trim() || '/'
-
-        if (this.options.cwd) {
-            const cwd = this.resolvePath(this.options.cwd)
-            const stat = await this.run(
-                `if [ -d ${quoteShell(cwd)} ]; then printf __dir__; fi`,
-                {
-                    timeoutMs: 5000
-                } as CommandStartOpts,
-                sandbox
-            )
-            if (stat.stdout.trim() === '__dir__') {
-                this._root = cwd
-                this._cwd = cwd
-            } else {
-                this._root = this._home
-                this._cwd = this._root
+        this._connecting = task
+        try {
+            await task
+        } finally {
+            if (this._connecting === task) {
+                this._connecting = undefined
             }
-        } else {
-            this._root = this._home
-            this._cwd = this._root
         }
-
-        this._connected = true
     }
 
     async disconnect() {
+        await this._connecting?.catch(() => undefined)
+
         if (!this._sandbox) {
             this._connected = false
             return

--- a/packages/extension-agent/src/computer/backends/e2b.ts
+++ b/packages/extension-agent/src/computer/backends/e2b.ts
@@ -8,6 +8,7 @@ import {
     CommandHandle,
     CommandResult,
     CommandStartOpts,
+    NotFoundError,
     Sandbox as E2BSandbox
 } from 'e2b'
 import mimeTypes from 'mime-types'
@@ -83,7 +84,11 @@ export class E2BComputerSession implements ComputerSessionApi {
                         timeoutMs: this.cfg.timeoutMs
                     })
                 )
-            } catch {
+            } catch (err) {
+                if (!isMissingSandboxError(err)) {
+                    throw err
+                }
+
                 sandbox = wrapSandbox(
                     await E2BSandbox.create(this.cfg.template, {
                         apiKey,
@@ -147,13 +152,23 @@ export class E2BComputerSession implements ComputerSessionApi {
             await desktop.stream.stop().catch(() => undefined)
         }
 
-        if (this.cfg.keepAlive) {
-            await this._sandbox.pause(this.resolveSecret(this.cfg.apiKey))
-        } else {
-            await this._sandbox.kill()
-        }
+        try {
+            if (this.cfg.keepAlive) {
+                await this._sandbox.pause(this.resolveSecret(this.cfg.apiKey))
+            } else {
+                await this._sandbox.kill()
+                this._sandboxId = undefined
+            }
+        } catch (err) {
+            if (!isMissingSandboxError(err)) {
+                throw err
+            }
 
-        this._connected = false
+            this._sandboxId = undefined
+        } finally {
+            this._sandbox = undefined
+            this._connected = false
+        }
     }
 
     isConnected() {
@@ -488,7 +503,11 @@ export class E2BComputerSession implements ComputerSessionApi {
             if (await this._sandbox.internal.isRunning()) {
                 return this._sandbox
             }
-        } catch {}
+        } catch (err) {
+            if (!isMissingSandboxError(err)) {
+                throw err
+            }
+        }
 
         this._connected = false
         await this.connect()
@@ -506,7 +525,13 @@ export class E2BComputerSession implements ComputerSessionApi {
         try {
             return await current.commands.run(command, options)
         } finally {
-            await current.setTimeout(SANDBOX_COMMAND_TIMEOUT).catch(() => {})
+            try {
+                await current.setTimeout(this.cfg.timeoutMs)
+            } catch (err) {
+                if (!isMissingSandboxError(err)) {
+                    throw err
+                }
+            }
         }
     }
 
@@ -553,6 +578,27 @@ function mapCommandResult(result: CommandResult | CommandHandle) {
     }
 }
 
+function isMissingSandboxError(err: unknown) {
+    if (err instanceof NotFoundError) {
+        return true
+    }
+
+    if (!(err instanceof Error)) {
+        return false
+    }
+
+    if (err.name === 'NotFoundError') {
+        return true
+    }
+
+    const msg = err.message.toLowerCase()
+    return (
+        msg.includes('not found') ||
+        msg.includes('not running anymore') ||
+        msg.includes('terminated')
+    )
+}
+
 function wrapSandbox(sandbox: E2BSandbox): SandboxWrapper {
     return {
         sandboxId: sandbox.sandboxId,
@@ -582,5 +628,3 @@ const CAPABILITIES = [
     'desktop_screenshot',
     'desktop_action'
 ] as const
-
-const SANDBOX_COMMAND_TIMEOUT = 30_000

--- a/packages/extension-agent/src/computer/backends/local/shell.ts
+++ b/packages/extension-agent/src/computer/backends/local/shell.ts
@@ -142,7 +142,7 @@ function buildWindowsPowerShellCommand(command: string) {
     ].join('; ')
 }
 
-function findPowerShell(): string | undefined {
+export function findPowerShell(): string | undefined {
     return (
         which.sync('pwsh.exe', { nothrow: true }) ??
         which.sync('pwsh', { nothrow: true }) ??
@@ -160,7 +160,7 @@ function buildUtf8Env(
     }
 }
 
-async function findGitBash(): Promise<string | null> {
+export async function findGitBash(): Promise<string | null> {
     if (process.platform !== 'win32') {
         return null
     }

--- a/packages/extension-agent/src/computer/materialize.ts
+++ b/packages/extension-agent/src/computer/materialize.ts
@@ -2,7 +2,11 @@
 
 import { readFile } from 'fs/promises'
 import path, { posix } from 'path'
-import { listSkillResources, ScannedSkill } from '../skills/scan'
+import {
+    listSkillResources,
+    REMOTE_SKILLS_ROOT,
+    ScannedSkill
+} from '../skills/scan'
 import { ComputerSessionApi } from './types'
 
 export class SkillMaterializer {
@@ -13,12 +17,24 @@ export class SkillMaterializer {
             return skill.dir
         }
 
+        if (skill.remote) {
+            return skill.dir
+        }
+
         return getRemoteSkillDir(skill.name)
     }
 
     async materialize(skill: ScannedSkill, session: ComputerSessionApi) {
         const root = this.getPath(skill, session)
         if (session.backend === 'local') {
+            return root
+        }
+
+        if (skill.remote) {
+            const map =
+                this._items.get(session.sessionId) ?? new Map<string, string>()
+            map.set(skill.id, root)
+            this._items.set(session.sessionId, map)
             return root
         }
 
@@ -72,5 +88,3 @@ export function getRemoteSkillDir(name: string) {
 function normalizeRemotePath(value: string) {
     return value.replaceAll('\\', '/')
 }
-
-const REMOTE_SKILLS_ROOT = '~/.chatluna/skills'

--- a/packages/extension-agent/src/computer/session.ts
+++ b/packages/extension-agent/src/computer/session.ts
@@ -14,6 +14,8 @@ export class ComputerSessionStore {
         }
     >()
 
+    private _creating = new Map<string, Promise<ComputerSessionApi>>()
+
     list() {
         return Array.from(this._items.values()).map((item) => ({
             ...item.info
@@ -48,24 +50,43 @@ export class ComputerSessionStore {
             return current.session
         }
 
-        const session = await create()
-        const now = Date.now()
+        const pending = this._creating.get(key)
+        if (pending) {
+            const session = await pending
+            const item = this._items.get(key)
+            if (item) {
+                item.info.lastActiveAt = Date.now()
+                item.info.cwd = item.session.cwd
+            }
+            return session
+        }
 
-        this._items.set(key, {
-            info: {
-                id: session.sessionId,
-                backend: session.backend,
-                userId: input.userId,
-                conversationId: input.conversationId,
-                createdAt: now,
-                lastActiveAt: now,
-                cwd: session.cwd
-            },
-            session,
-            active: 0
-        })
+        const task = create()
+            .then((session) => {
+                const now = Date.now()
 
-        return session
+                this._items.set(key, {
+                    info: {
+                        id: session.sessionId,
+                        backend: session.backend,
+                        userId: input.userId,
+                        conversationId: input.conversationId,
+                        createdAt: now,
+                        lastActiveAt: now,
+                        cwd: session.cwd
+                    },
+                    session,
+                    active: 0
+                })
+
+                return session
+            })
+            .finally(() => {
+                this._creating.delete(key)
+            })
+
+        this._creating.set(key, task)
+        return task
     }
 
     touchBySessionId(sessionId: string) {

--- a/packages/extension-agent/src/computer/tools/bash.ts
+++ b/packages/extension-agent/src/computer/tools/bash.ts
@@ -7,7 +7,6 @@ import type { ComputerBackgroundJobInfo } from '../../types'
 import { parseAgentCliCommand } from '../../cli/parser'
 import { getErrorMessage } from '../../utils/shell'
 import { ComputerToolBase } from './base'
-import { Session, User } from 'koishi'
 
 export class BashTool extends ComputerToolBase {
     name = 'bash'
@@ -21,6 +20,7 @@ Rules:
 - Certain high-risk commands require explicit user confirmation
 - Commands in the blocked list are always rejected
 - If a command may take a while, keep running, or exceed the normal timeout, prefer background=true and query it later yourself
+- Do not use this tool for agentcli commands; there is a dedicated agentcli tool
 
 When to use:
 - File listing, searching (ls, find, grep, rg, fd)
@@ -102,32 +102,9 @@ When to use:
 
         try {
             if (action === 'run' && parseAgentCliCommand(input.command ?? '')) {
-                const cli = this.computer.ctx.chatluna_agent?.cli
-                const conversationId = toolConfig?.configurable?.conversationId
-                if (
-                    !cli ||
-                    !conversationId ||
-                    !session ||
-                    // only admin can use agentcli
-                    ((session as Session<User.Field>).user?.authority ?? 0) < 3
-                ) {
-                    return this.formatResult(
-                        false,
-                        'agentcli is unavailable in this tool context'
-                    )
-                }
-
-                if (input.background) {
-                    return this.formatResult(
-                        false,
-                        'agentcli does not support background execution'
-                    )
-                }
-
-                return await cli.executeCommand(
-                    input.command,
-                    conversationId,
-                    session
+                return this.formatResult(
+                    false,
+                    'Use the dedicated agentcli tool for commands that start with `agentcli`.'
                 )
             }
 

--- a/packages/extension-agent/src/config/defaults.ts
+++ b/packages/extension-agent/src/config/defaults.ts
@@ -13,6 +13,7 @@ import { DEFAULT_SKILL_DIRS } from './path'
 
 export function getDefaultToolAuthority(name?: string) {
     if (
+        name === 'agentcli' ||
         name === 'bash' ||
         name === 'file_edit' ||
         name === 'file_read' ||

--- a/packages/extension-agent/src/config/defaults.ts
+++ b/packages/extension-agent/src/config/defaults.ts
@@ -9,6 +9,7 @@ import {
     ToolConfig,
     ToolItemConfig
 } from '../types'
+import { DEFAULT_SKILL_DIRS } from './path'
 
 export function getDefaultToolAuthority(name?: string) {
     if (
@@ -181,12 +182,7 @@ export function getDefaultConfig(): AgentConfig {
             tools: {}
         },
         skills: {
-            dirs: [
-                '~/.agents/skills',
-                '~/.codex/skills',
-                '~/.claude/skills',
-                '~/.config/opencode/skills'
-            ],
+            dirs: [...DEFAULT_SKILL_DIRS],
             items: {}
         },
         computer: createDefaultComputerConfig(),

--- a/packages/extension-agent/src/config/path.ts
+++ b/packages/extension-agent/src/config/path.ts
@@ -3,6 +3,19 @@
 import { Context } from 'koishi'
 import { resolve } from 'path'
 
+export const DEFAULT_SKILL_DIRS = [
+    './.agents/skills',
+    './.openclaw/skills',
+    './.codex/skills',
+    './.claude/skills',
+    './.opencode/skills',
+    '~/.agents/skills',
+    '~/.openclaw/skills',
+    '~/.codex/skills',
+    '~/.claude/skills',
+    '~/.config/opencode/skills'
+]
+
 export function getConfigPath(ctx: Context): string {
     return resolve(ctx.baseDir, 'data/chatluna/agent/config.json')
 }

--- a/packages/extension-agent/src/index.ts
+++ b/packages/extension-agent/src/index.ts
@@ -34,12 +34,7 @@ export interface Config extends ChatLunaPlugin.Config {}
 
 export const inject = {
     required: ['chatluna', 'console'],
-    optional: [
-        'chatluna_storage',
-        'chatluna_agent',
-        'chatluna_agent_webui',
-        'server'
-    ]
+    optional: ['chatluna_storage', 'chatluna_agent', 'server']
 }
 
 export const name = 'chatluna-agent'

--- a/packages/extension-agent/src/service/computer.ts
+++ b/packages/extension-agent/src/service/computer.ts
@@ -475,7 +475,7 @@ export class ChatLunaAgentComputerService {
 
         const result = await session
             .execute(
-                `sh -lc ${quoteShell(`command -v ${quoteShell(name)} >/dev/null 2>&1`)}`,
+                `sh -lc ${quoteShell(`command -v ${name} >/dev/null 2>&1`)}`,
                 {
                     timeout: 5000
                 }

--- a/packages/extension-agent/src/service/computer.ts
+++ b/packages/extension-agent/src/service/computer.ts
@@ -51,7 +51,9 @@ import { PublishFileTool } from '../computer/tools/publish_file'
 import { GrepTool } from '../computer/tools/grep'
 import { GlobTool } from '../computer/tools/glob'
 import { BashTool } from '../computer/tools/bash'
-import { quoteShell } from '../utils/shell'
+import { scanRemoteSkills as scanRemoteSkillCatalog } from '../skills/scan'
+import { scanRemoteMarkdownAgents as scanRemoteSubAgentCatalog } from '../sub-agent/scan'
+import { quoteShell, quoteShellPath } from '../utils/shell'
 
 export class ChatLunaAgentComputerService {
     private _sessions = new ComputerSessionStore()
@@ -641,6 +643,32 @@ export class ChatLunaAgentComputerService {
         return await session.glob(input.pattern, input.path)
     }
 
+    async scanRemoteSkills() {
+        const session = await this.getRemoteScanSession()
+        if (!session) {
+            return []
+        }
+
+        return await scanRemoteSkillCatalog(session, this.ctx, this.config)
+    }
+
+    async scanRemoteSubAgents() {
+        const session = await this.getRemoteScanSession()
+        if (!session) {
+            return []
+        }
+
+        return await scanRemoteSubAgentCatalog(session, this.config.subAgent)
+    }
+
+    async removeRemoteSkill(dir: string) {
+        await this.removeRemoteEntry(dir)
+    }
+
+    async removeRemoteSubAgent(path: string) {
+        await this.removeRemoteEntry(path)
+    }
+
     async readMaterializedSkillFile(
         session: ComputerSessionApi,
         filePath: string,
@@ -773,6 +801,49 @@ export class ChatLunaAgentComputerService {
         })
     }
 
+    private async getRemoteScanSession() {
+        const backend = this.resolveProvider(
+            this.config.computer.defaultProvider
+        )
+        if (!backend || backend === 'local') {
+            return undefined
+        }
+
+        return await this.getOrCreateSession({
+            backend,
+            conversationId: `console:remote-scan:${backend}`,
+            userId: `console:remote-scan:${backend}`
+        })
+    }
+
+    private async removeRemoteEntry(path: string) {
+        const session = await this.getRemoteScanSession()
+        if (!session) {
+            throw new Error('Remote computer backend is not available.')
+        }
+
+        const target = path.replaceAll('\\', '/')
+        if (
+            target.length < 2 ||
+            target === '/' ||
+            target === '~' ||
+            /^~?\/?\.?$/.test(target)
+        ) {
+            throw new Error(`Refusing to remove unsafe path: ${path}`)
+        }
+
+        const result = await session.execute(
+            `if [ -d ${quoteShellPath(target)} ]; then rm -rf ${quoteShellPath(target)}; elif [ -e ${quoteShellPath(target)} ]; then rm -f ${quoteShellPath(target)}; fi`,
+            {
+                timeout: 15000
+            }
+        )
+
+        if (result.exitCode !== 0) {
+            throw new Error(result.stderr.trim() || `Failed to remove ${path}`)
+        }
+    }
+
     private resolveSessionInput(
         runConfig?: ChatLunaToolRunnable,
         backend?: ComputerBackendType
@@ -901,6 +972,7 @@ export class ChatLunaAgentComputerService {
         }
 
         return new E2BComputerSession(
+            this.ctx,
             {
                 ...this.config.computer.e2b,
                 apiKey: this.resolveSecret(this.config.computer.e2b.apiKey)

--- a/packages/extension-agent/src/service/computer.ts
+++ b/packages/extension-agent/src/service/computer.ts
@@ -3,6 +3,7 @@
 import { randomUUID } from 'node:crypto'
 import path from 'node:path'
 import { SystemMessage } from '@langchain/core/messages'
+import which from 'which'
 import type { ChatLunaToolRunnable } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import {
     countMessageTokens,
@@ -25,6 +26,7 @@ import {
     ComputerSessionStore
 } from '../computer/session'
 import { LocalComputerSession } from '../computer/backends/local'
+import { findGitBash, findPowerShell } from '../computer/backends/local/shell'
 import { OpenTerminalComputerSession } from '../computer/backends/open_terminal'
 import { E2BComputerSession } from '../computer/backends/e2b'
 import {
@@ -49,6 +51,7 @@ import { PublishFileTool } from '../computer/tools/publish_file'
 import { GrepTool } from '../computer/tools/grep'
 import { GlobTool } from '../computer/tools/glob'
 import { BashTool } from '../computer/tools/bash'
+import { quoteShell } from '../utils/shell'
 
 export class ChatLunaAgentComputerService {
     private _sessions = new ComputerSessionStore()
@@ -405,6 +408,79 @@ export class ChatLunaAgentComputerService {
                 )
             )
         )
+    }
+
+    async hasBin(name: string, backend?: ComputerBackendType) {
+        const type = backend ?? this.resolveProvider()
+        if (!type || !isAvailableBackend(this._status.backends[type])) {
+            return false
+        }
+
+        if (type === 'local') {
+            if (!this.config.computer.local.dangerouslySkipPermissions) {
+                if (
+                    this.config.computer.local.blockedCommands.some(
+                        (item) => item.toLowerCase() === name.toLowerCase()
+                    )
+                ) {
+                    return false
+                }
+
+                if (
+                    this.config.computer.local.allowedCommands.length > 0 &&
+                    !this.config.computer.local.allowedCommands.some(
+                        (item) => item.toLowerCase() === name.toLowerCase()
+                    )
+                ) {
+                    return false
+                }
+            }
+
+            if (process.platform === 'win32') {
+                const bin = name.toLowerCase()
+                if (
+                    bin === 'bash' ||
+                    bin === 'bash.exe' ||
+                    bin === 'sh' ||
+                    bin === 'sh.exe'
+                ) {
+                    return (await findGitBash()) != null
+                }
+
+                if (
+                    bin === 'pwsh' ||
+                    bin === 'pwsh.exe' ||
+                    bin === 'powershell' ||
+                    bin === 'powershell.exe'
+                ) {
+                    return findPowerShell() != null
+                }
+
+                if (bin === 'cmd' || bin === 'cmd.exe') {
+                    return true
+                }
+            }
+
+            return which.sync(name, { nothrow: true }) != null
+        }
+
+        const session = await this.getOrCreateSession({ backend: type }).catch(
+            () => undefined
+        )
+        if (!session) {
+            return false
+        }
+
+        const result = await session
+            .execute(
+                `sh -lc ${quoteShell(`command -v ${quoteShell(name)} >/dev/null 2>&1`)}`,
+                {
+                    timeout: 5000
+                }
+            )
+            .catch(() => undefined)
+
+        return result?.exitCode === 0
     }
 
     listAvailableBackends(): ComputerBackendType[] {

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -190,7 +190,7 @@ export class ChatLunaAgentService extends Service {
                 createHashId(
                     join(getSkillsRootPath(this.ctx), name, 'SKILL.md')
                 )
-            ] = { enabled: true }
+            ] = { enabled: true, remote: false }
         }
 
         await this.updateConfig('skills', skills, async () => {
@@ -251,7 +251,11 @@ export class ChatLunaAgentService extends Service {
             dirs: [...this.args.config.skills.dirs],
             items: { ...this.args.config.skills.items }
         }
-        skills.items[id] = { enabled }
+        const info = this.skills.listSkills().find((item) => item.id === id)
+        skills.items[id] = {
+            enabled,
+            remote: info?.remote === true || skills.items[id]?.remote === true
+        }
         await this.updateConfig('skills', skills, async () => {
             await this.skills.reload()
         })

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -378,6 +378,16 @@ export class ChatLunaAgentService extends Service {
                 throw new Error('Sub-agent path is missing')
             }
 
+            if (info.remote) {
+                await this.computer.removeRemoteSubAgent(info.path)
+                const subAgent = structuredClone(this.args.config.subAgent)
+                delete subAgent.items[id]
+                await this.updateConfig('subAgent', subAgent, async () => {
+                    await this.subAgent.reload()
+                })
+                return
+            }
+
             const root = resolve(getSubAgentsRootPath(this.ctx))
             const file = resolve(info.path)
             if (!file.startsWith(root)) {

--- a/packages/extension-agent/src/service/skills.ts
+++ b/packages/extension-agent/src/service/skills.ts
@@ -20,7 +20,12 @@ import {
     SkillToolService
 } from '../types'
 import { syncBundledSkills } from '../skills/builtin'
-import { ensureSkillsRoot, ScannedSkill, scanSkills } from '../skills/scan'
+import {
+    ensureSkillsRoot,
+    listRemoteSkillResources,
+    ScannedSkill,
+    scanSkills
+} from '../skills/scan'
 import { renderAvailableSkills, renderSkillContent } from '../skills/render'
 import { getSlashSkillName, stripSlashSkillName } from '../skills/slash'
 import {
@@ -102,7 +107,13 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
 
     async reload() {
         await syncBundledSkills(this.ctx)
-        const scanned = await scanSkills(this.ctx, this.config)
+        const local = await scanSkills(this.ctx, this.config)
+        const remote = this.ctx.chatluna_agent
+            ? await this.ctx.chatluna_agent.computer
+                  .scanRemoteSkills()
+                  .catch(() => [])
+            : []
+        const scanned = [...local, ...(remote ?? [])]
         this._skills = new Map(scanned.map((s) => [s.id, s]))
         this._catalog = buildSkillCatalog(scanned, this.config.skills.items)
         this._visibleByName = new Map(
@@ -118,21 +129,22 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
     }
 
     getStatus(): SkillsStatus {
+        const catalog = this.getDisplayCatalog()
         return {
             enabled: true,
             root: getSkillsRootPath(this.ctx),
-            total: this._catalog.length,
-            visible: this._catalog.filter((s) => s.visible).length,
-            modelEnabled: this._catalog.filter((s) => s.modelEnabled).length,
+            total: catalog.length,
+            visible: catalog.filter((s) => s.visible).length,
+            modelEnabled: catalog.filter((s) => s.modelEnabled).length,
             activeConversations: Array.from(this._active.values()).filter(
                 (s) => s.size > 0
             ).length,
-            catalog: Object.fromEntries(this._catalog.map((s) => [s.id, s]))
+            catalog: Object.fromEntries(catalog.map((s) => [s.id, s]))
         }
     }
 
     listSkills() {
-        return [...this._catalog]
+        return this.getDisplayCatalog()
     }
 
     listVisibleSkills() {
@@ -185,13 +197,18 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
 
     async exportSkill(id: string): Promise<SkillExportResult | undefined> {
         const skill = this._skills.get(id)
-        if (!skill?.path) return undefined
+        if (!skill?.path || skill.remote) return undefined
         return await exportSkillArchive(id, skill.dir)
     }
 
     async removeSkill(id: string): Promise<string | undefined> {
         const skill = this._skills.get(id)
         if (!skill) return undefined
+
+        if (skill.remote) {
+            await this.ctx.chatluna_agent?.computer.removeRemoteSkill(skill.dir)
+            return skill.name
+        }
 
         if (skill.source !== 'chatluna' || skill.scope !== 'data') {
             throw new Error('Only imported local skills can be removed here')
@@ -307,10 +324,65 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
             session != null
                 ? await computer?.materializer.materialize(skill, session)
                 : undefined
+        const resources =
+            session != null && skill.remote
+                ? await listRemoteSkillResources(session, skillDir ?? skill.dir)
+                : undefined
 
         return await renderSkillContent(skill, true, {
-            skillDir
+            skillDir,
+            resources
         })
+    }
+
+    private async getPromptActiveSkills(
+        conversationId: string,
+        remote: boolean
+    ) {
+        const current = this._active.get(conversationId)
+        if (!current) {
+            return [] as SkillInfo[]
+        }
+
+        const items = this._catalog.filter((s) => current.has(s.id))
+        if (!remote) {
+            return items
+        }
+
+        const computer = this.ctx.chatluna_agent?.computer
+        const session = await computer
+            ?.getOrCreateSession({ conversationId })
+            .catch(() => undefined)
+
+        return await Promise.all(
+            items.map(async (item) => {
+                if (item.remote || !session || !computer) {
+                    return {
+                        ...item,
+                        dir: item.remote
+                            ? item.dir
+                            : getRemoteSkillDir(item.name)
+                    }
+                }
+
+                const skill = this._skills.get(item.id)
+                if (!skill) {
+                    return {
+                        ...item,
+                        dir: getRemoteSkillDir(item.name)
+                    }
+                }
+
+                const dir = await computer.materializer
+                    .materialize(skill, session)
+                    .catch(() => getRemoteSkillDir(item.name))
+
+                return {
+                    ...item,
+                    dir
+                }
+            })
+        )
     }
 
     private pruneActiveSkills() {
@@ -331,6 +403,10 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
                 this._active.delete(conversationId)
             }
         }
+    }
+
+    private getDisplayCatalog() {
+        return this._catalog.filter((item) => !item.shadowedBy)
     }
 
     private syncTool() {
@@ -373,19 +449,10 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
                     : this._catalog
                           .filter((s) => s.modelEnabled)
                           .map((item) => (remote ? { ...item, dir: '' } : item))
-                const current = this._active.get(conversationId)
-                const active = current
-                    ? this._catalog
-                          .filter((s) => current.has(s.id))
-                          .map((item) =>
-                              remote
-                                  ? {
-                                        ...item,
-                                        dir: getRemoteSkillDir(item.name)
-                                    }
-                                  : item
-                          )
-                    : []
+                const active = await this.getPromptActiveSkills(
+                    conversationId,
+                    remote
+                )
 
                 if (skills.length > 0 || active.length > 0 || !sub) {
                     const msg = renderAvailableSkills(

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -32,7 +32,7 @@ import {
     SubAgentTaskSession,
     touchTaskSession
 } from '../sub-agent/session'
-import { ensureSubAgentsRoot } from '../sub-agent/scan'
+import { ensureSubAgentsRoot, REMOTE_SUBAGENTS_ROOT } from '../sub-agent/scan'
 import { TaskTool } from '../sub-agent/tool'
 import {
     AgentConfig,
@@ -451,11 +451,17 @@ export class ChatLunaAgentSubAgentService {
     }
 
     private async refreshCatalog() {
+        const remote = this.ctx.chatluna_agent
+            ? await this.ctx.chatluna_agent.computer
+                  .scanRemoteSubAgents()
+                  .catch(() => [])
+            : []
         const items = await buildSubAgentCatalog(
             this.ctx,
             this.config.subAgent,
             this.permission,
-            this._manual.values()
+            this._manual.values(),
+            remote
         )
         this._catalog = new Map(items.map((item) => [item.id, item]))
         this.syncTool()
@@ -534,7 +540,7 @@ export class ChatLunaAgentSubAgentService {
                 const msg = renderAvailableSubAgents(
                     agents,
                     remote
-                        ? '~/.chatluna/agents'
+                        ? REMOTE_SUBAGENTS_ROOT
                         : getSubAgentsRootPath(this.ctx),
                     remote ? 'remote' : 'local'
                 )

--- a/packages/extension-agent/src/skills/catalog.ts
+++ b/packages/extension-agent/src/skills/catalog.ts
@@ -53,7 +53,7 @@ export function buildSkillCatalog(
             continue
         }
 
-        if (/^[a-f0-9]{16}$/i.test(id)) {
+        if (item.remote) {
             continue
         }
 
@@ -63,6 +63,7 @@ export function buildSkillCatalog(
             description: '',
             path: '',
             dir: '',
+            remote: false,
             source: 'chatluna',
             scope: 'data',
             state: 'missing',

--- a/packages/extension-agent/src/skills/catalog.ts
+++ b/packages/extension-agent/src/skills/catalog.ts
@@ -23,6 +23,7 @@ export function buildSkillCatalog(
             description: skill.description,
             path: skill.path,
             dir: skill.dir,
+            remote: skill.remote,
             source: skill.source,
             scope: skill.scope,
             state: skill.state,
@@ -49,6 +50,10 @@ export function buildSkillCatalog(
 
     for (const [id, item] of Object.entries(configItems)) {
         if (skillMap.has(id)) {
+            continue
+        }
+
+        if (/^[a-f0-9]{16}$/i.test(id)) {
             continue
         }
 

--- a/packages/extension-agent/src/skills/import.ts
+++ b/packages/extension-agent/src/skills/import.ts
@@ -126,7 +126,7 @@ async function previewMaterializedSource(
     diagnostics: string[]
 ): Promise<SkillImportPreviewResult> {
     const entries = await collectPreviewEntries(root)
-    const scanned = await scanSkillRoot(root)
+    const scanned = await scanSkillRoot(root, ctx)
     const skills = scanned.map((item): SkillImportPreviewItem => {
         const dir = item.dir
             .slice(root.length)
@@ -323,7 +323,7 @@ async function previewGithub(ctx: Context, url: string) {
         const target = info.subpath
             ? `${info.owner}/${info.repo}/${info.subpath}`
             : `${info.owner}/${info.repo}`
-        const scanned = await scanSkillRoot(tmp)
+        const scanned = await scanSkillRoot(tmp, ctx)
         const skills = scanned.map(
             (item): SkillImportPreviewItem => ({
                 dir:

--- a/packages/extension-agent/src/skills/import.ts
+++ b/packages/extension-agent/src/skills/import.ts
@@ -36,6 +36,7 @@ export async function previewSkillsImport(
         const source = await materializeImportSource(ctx, input, tmp)
 
         return await previewMaterializedSource(
+            ctx,
             source.root,
             input.type,
             input.name,
@@ -61,6 +62,7 @@ export async function importSkills(
     try {
         const source = await materializeImportSource(ctx, input, tmp)
         const preview = await previewMaterializedSource(
+            ctx,
             source.root,
             input.type,
             input.type === 'zip'
@@ -120,6 +122,7 @@ export async function importSkills(
 }
 
 async function previewMaterializedSource(
+    ctx: Context,
     root: string,
     source: SkillImportInput['type'],
     target: string,

--- a/packages/extension-agent/src/skills/render.ts
+++ b/packages/extension-agent/src/skills/render.ts
@@ -87,9 +87,12 @@ export async function renderSkillContent(
     loaded = false,
     options: {
         skillDir?: string
+        resources?: string[]
     } = {}
 ) {
-    const resources = await listSkillResources(skill.dir)
+    const resources =
+        options.resources ??
+        (await listSkillResources(skill.dir).catch(() => [] as string[]))
     const lines = [
         `<skill_content name="${escapeXml(skill.name)}">`,
         loaded

--- a/packages/extension-agent/src/skills/render.ts
+++ b/packages/extension-agent/src/skills/render.ts
@@ -90,9 +90,7 @@ export async function renderSkillContent(
         resources?: string[]
     } = {}
 ) {
-    const resources =
-        options.resources ??
-        (await listSkillResources(skill.dir).catch(() => [] as string[]))
+    const resources = options.resources ?? (await listSkillResources(skill.dir))
     const lines = [
         `<skill_content name="${escapeXml(skill.name)}">`,
         loaded

--- a/packages/extension-agent/src/skills/scan.ts
+++ b/packages/extension-agent/src/skills/scan.ts
@@ -20,6 +20,7 @@ import { collectFilesRecursive } from '../utils/fs'
 import { extractFrontmatter } from '../utils/frontmatter'
 import { createHashId } from '../utils/id'
 import { isPathInside, resolveTildeDir, toPathKey } from '../utils/path'
+import { computeRemoteDir, isRemotePathInside } from '../utils/remote_path'
 import { quoteShellPath } from '../utils/shell'
 
 const execFileAsync = promisify(execFile)
@@ -202,7 +203,7 @@ export async function listRemoteSkillResources(
     dir: string
 ) {
     const result = await session.execute(
-        `[ -d ${quoteShellPath(dir)} ] && find ${quoteShellPath(dir)} -type f ! -name SKILL.md -printf '%P\n' || true`,
+        `root=${quoteShellPath(dir)} && [ -d "$root" ] && find "$root" -type f ! -name SKILL.md -print | awk -v root="$root" 'index($0, root "/") == 1 { print substr($0, length(root) + 2) }' || true`,
         {
             timeout: 10000
         }
@@ -760,9 +761,11 @@ function getRemoteScanTargets(
     session: ComputerSessionApi,
     cfg: AgentConfig['skills']
 ) {
-    const scope = normalizeRemoteBase(session.getScopePath())
+    const scope = session.getScopePath().replaceAll('\\', '/').trim() || '~'
     const dirs = [...DEFAULT_SKILL_DIRS, ...cfg.dirs]
-    const seen = new Set([normalizeRemoteKey(REMOTE_SKILLS_ROOT)])
+    const seen = new Set([
+        REMOTE_SKILLS_ROOT.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
+    ])
     const targets: ScanTarget[] = [
         {
             root: REMOTE_SKILLS_ROOT,
@@ -779,8 +782,8 @@ function getRemoteScanTargets(
             continue
         }
 
-        const dir = resolveRemoteDir(scope, item)
-        const key = normalizeRemoteKey(dir)
+        const dir = computeRemoteDir(scope, item)
+        const key = dir.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
         if (seen.has(key)) {
             continue
         }
@@ -839,56 +842,4 @@ function detectRemoteSkillScope(scope: string, dir: string): SkillScope {
 
 function createSkillId(file: string) {
     return createHashId(file)
-}
-
-function resolveRemoteDir(scope: string, dir: string) {
-    const value = dir.replaceAll('\\', '/').trim()
-    if (value === '~' || value.startsWith('~/')) {
-        return value
-    }
-
-    if (value.startsWith('/')) {
-        return posix.normalize(value)
-    }
-
-    if (
-        [
-            '.agents/',
-            '.openclaw/',
-            '.codex/',
-            '.claude/',
-            '.config/opencode/'
-        ].some((item) => value.startsWith(item))
-    ) {
-        return `~/${value}`
-    }
-
-    if (scope === '~') {
-        return `~/${trimRemotePrefix(value)}`
-    }
-
-    if (scope.startsWith('~/')) {
-        return `${scope.replace(/\/+$/, '')}/${trimRemotePrefix(value)}`
-    }
-
-    return posix.resolve(scope || '/', value)
-}
-
-function trimRemotePrefix(value: string) {
-    return value.replace(/^\.\//, '').replace(/^\//, '')
-}
-
-function normalizeRemoteBase(value: string) {
-    const next = value.replaceAll('\\', '/').trim()
-    return next || '~'
-}
-
-function normalizeRemoteKey(value: string) {
-    return value.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
-}
-
-function isRemotePathInside(path: string, root: string) {
-    const target = normalizeRemoteKey(path)
-    const base = normalizeRemoteKey(root)
-    return target === base || target.startsWith(`${base}/`)
 }

--- a/packages/extension-agent/src/skills/scan.ts
+++ b/packages/extension-agent/src/skills/scan.ts
@@ -81,7 +81,7 @@ export async function scanSkills(
     const bins = new Map<string, boolean>()
     const skills = (
         await Promise.all(
-            targets.map((target) => scanTarget(target, cfg, bins))
+            targets.map((target) => scanTarget(ctx, target, cfg, bins))
         )
     ).flat()
 
@@ -96,7 +96,10 @@ export async function getSkillRoots(ctx: Context, cfg: AgentConfig['skills']) {
     return (await getScanTargets(ctx, cfg)).map((t) => t.root)
 }
 
-export async function scanSkillRoot(root: string): Promise<ScannedSkill[]> {
+export async function scanSkillRoot(
+    root: string,
+    ctx?: Context
+): Promise<ScannedSkill[]> {
     const bins = new Map<string, boolean>()
     const files = await collectFilesRecursive(root)
     const dirs = Array.from(
@@ -122,7 +125,8 @@ export async function scanSkillRoot(root: string): Promise<ScannedSkill[]> {
                     items: {}
                 },
                 undefined,
-                bins
+                bins,
+                ctx
             )
         )
     )
@@ -137,6 +141,7 @@ export async function listSkillResources(dir: string): Promise<string[]> {
 }
 
 async function scanTarget(
+    ctx: Context,
     target: ScanTarget,
     cfg: AgentConfig,
     bins: Map<string, boolean>
@@ -150,7 +155,7 @@ async function scanTarget(
             const file = join(target.root, entry.name, 'SKILL.md')
             const info = await stat(file).catch(() => undefined)
             if (!info?.isFile()) return undefined
-            return parseSkill(file, target, cfg.skills, cfg, bins)
+            return parseSkill(file, target, cfg.skills, cfg, bins, ctx)
         })
     )
 
@@ -162,7 +167,8 @@ async function parseSkill(
     target: ScanTarget,
     cfg: AgentConfig['skills'],
     agentCfg?: AgentConfig,
-    bins = new Map<string, boolean>()
+    bins = new Map<string, boolean>(),
+    ctx?: Context
 ): Promise<ScannedSkill> {
     const diagnostics: string[] = []
     const dir = dirname(file)
@@ -248,7 +254,12 @@ async function parseSkill(
 
     const metadata = pickMetadata(frontmatter.metadata)
     const allowedTools = parseAllowedTools(frontmatter['allowed-tools'])
-    const availableResult = await checkAvailability(openclaw, agentCfg, bins)
+    const availableResult = await checkAvailability(
+        openclaw,
+        agentCfg,
+        bins,
+        ctx
+    )
     const implicitInvocation =
         frontmatter['disable-model-invocation'] === true
             ? false
@@ -471,7 +482,8 @@ function parseStringList(value: unknown) {
 async function checkAvailability(
     metadata: OpenClawMetadata,
     cfg?: AgentConfig,
-    bins = new Map<string, boolean>()
+    bins = new Map<string, boolean>(),
+    ctx?: Context
 ) {
     const diagnostics: string[] = []
     const install = metadata.install?.filter(
@@ -491,7 +503,7 @@ async function checkAvailability(
     if (metadata.requires?.bins?.length) {
         const missing: string[] = []
         for (const bin of metadata.requires.bins) {
-            if (!(await hasBin(bin, bins))) missing.push(bin)
+            if (!(await hasBin(bin, bins, ctx))) missing.push(bin)
         }
         if (missing.length) {
             diagnostics.push(`Missing required binaries: ${missing.join(', ')}`)
@@ -501,7 +513,7 @@ async function checkAvailability(
     if (metadata.requires?.anyBins?.length) {
         let matched = false
         for (const bin of metadata.requires.anyBins) {
-            if (await hasBin(bin, bins)) {
+            if (await hasBin(bin, bins, ctx)) {
                 matched = true
                 break
             }
@@ -544,7 +556,22 @@ async function checkAvailability(
     }
 }
 
-async function hasBin(name: string, cache: Map<string, boolean>) {
+async function hasBin(
+    name: string,
+    cache: Map<string, boolean>,
+    ctx?: Context
+) {
+    const computer = ctx?.chatluna_agent?.computer
+    if (computer) {
+        const key = `computer:${name}`
+        const cached = cache.get(key)
+        if (cached != null) return cached
+
+        const ok = await computer.hasBin(name).catch(() => false)
+        cache.set(key, ok)
+        return ok
+    }
+
     const key = `${process.platform}:${name}`
     const cached = cache.get(key)
     if (cached != null) return cached

--- a/packages/extension-agent/src/skills/scan.ts
+++ b/packages/extension-agent/src/skills/scan.ts
@@ -4,9 +4,10 @@ import { execFile } from 'child_process'
 import { mkdir, readdir, readFile, stat } from 'fs/promises'
 import { load } from 'js-yaml'
 import { Context } from 'koishi'
-import { basename, dirname, join } from 'path'
+import { basename, dirname, join, posix } from 'path'
 import { promisify } from 'util'
 import { DEFAULT_SKILL_DIRS, getSkillsRootPath } from '../config/path'
+import { ComputerSessionApi } from '../computer/types'
 import {
     AgentConfig,
     SkillInstallAction,
@@ -19,8 +20,10 @@ import { collectFilesRecursive } from '../utils/fs'
 import { extractFrontmatter } from '../utils/frontmatter'
 import { createHashId } from '../utils/id'
 import { isPathInside, resolveTildeDir, toPathKey } from '../utils/path'
+import { quoteShellPath } from '../utils/shell'
 
 const execFileAsync = promisify(execFile)
+export const REMOTE_SKILLS_ROOT = '~/.chatluna/skills'
 
 export interface ScannedSkill {
     id: string
@@ -28,6 +31,7 @@ export interface ScannedSkill {
     description: string
     path: string
     dir: string
+    remote: boolean
     source: SkillSource
     scope: SkillScope
     state: SkillState
@@ -56,6 +60,7 @@ interface ScanTarget {
     source: SkillSource
     scope: SkillScope
     priority: number
+    remote: boolean
 }
 
 interface OpenClawMetadata {
@@ -92,6 +97,57 @@ export async function scanSkills(
     )
 }
 
+export async function scanRemoteSkills(
+    session: ComputerSessionApi,
+    ctx: Context,
+    cfg: AgentConfig
+): Promise<ScannedSkill[]> {
+    const targets = getRemoteScanTargets(session, cfg.skills)
+    const bins = new Map<string, boolean>()
+    const seen = new Set<string>()
+    const skills = (
+        await Promise.all(
+            targets.map(async (target) => {
+                const files = await listRemoteSkillFiles(session, target.root)
+                return await Promise.all(
+                    files.map(async (file) => {
+                        if (seen.has(file)) {
+                            return undefined
+                        }
+
+                        seen.add(file)
+                        const dir = posix.dirname(file)
+                        const raw = await session.readFile(file).catch(() => '')
+                        const extra = await session
+                            .readFile(posix.join(dir, 'agents', 'openai.yaml'))
+                            .catch(() => undefined)
+
+                        return await parseSkillText({
+                            file,
+                            dir,
+                            target,
+                            cfg: cfg.skills,
+                            agentCfg: cfg,
+                            bins,
+                            ctx,
+                            raw,
+                            extra
+                        })
+                    })
+                )
+            })
+        )
+    )
+        .flat(2)
+        .filter((item): item is ScannedSkill => item != null)
+
+    return skills.sort((a, b) =>
+        a.priority !== b.priority
+            ? a.priority - b.priority
+            : a.path.localeCompare(b.path)
+    )
+}
+
 export async function getSkillRoots(ctx: Context, cfg: AgentConfig['skills']) {
     return (await getScanTargets(ctx, cfg)).map((t) => t.root)
 }
@@ -118,7 +174,8 @@ export async function scanSkillRoot(
                     root,
                     source: 'custom',
                     scope: 'project',
-                    priority: 0
+                    priority: 0,
+                    remote: false
                 },
                 {
                     dirs: [],
@@ -138,6 +195,28 @@ export async function listSkillResources(dir: string): Promise<string[]> {
         excludeNames: ['SKILL.md'],
         relative: true
     })
+}
+
+export async function listRemoteSkillResources(
+    session: ComputerSessionApi,
+    dir: string
+) {
+    const result = await session.execute(
+        `[ -d ${quoteShellPath(dir)} ] && find ${quoteShellPath(dir)} -type f ! -name SKILL.md -printf '%P\n' || true`,
+        {
+            timeout: 10000
+        }
+    )
+
+    if (result.stderr.trim()) {
+        throw new Error(result.stderr.trim())
+    }
+
+    return result.stdout
+        .split('\n')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b))
 }
 
 async function scanTarget(
@@ -170,33 +249,61 @@ async function parseSkill(
     bins = new Map<string, boolean>(),
     ctx?: Context
 ): Promise<ScannedSkill> {
-    const diagnostics: string[] = []
     const dir = dirname(file)
-    const fallbackName = basename(dir)
     const raw = await readFile(file, 'utf-8').catch(() => '')
 
-    if (!raw) {
+    return await parseSkillText({
+        file,
+        dir,
+        target,
+        cfg,
+        agentCfg,
+        bins,
+        ctx,
+        raw,
+        extra: await readFile(
+            join(dir, 'agents', 'openai.yaml'),
+            'utf-8'
+        ).catch(() => undefined)
+    })
+}
+
+async function parseSkillText(input: {
+    file: string
+    dir: string
+    target: ScanTarget
+    cfg: AgentConfig['skills']
+    agentCfg?: AgentConfig
+    bins: Map<string, boolean>
+    ctx?: Context
+    raw: string
+    extra?: string
+}): Promise<ScannedSkill> {
+    const diagnostics: string[] = []
+    const fallbackName = basename(input.dir)
+
+    if (!input.raw) {
         return createInvalidSkill({
-            file,
-            dir,
-            target,
-            cfg,
+            file: input.file,
+            dir: input.dir,
+            target: input.target,
+            cfg: input.cfg,
             diagnostics: ['Failed to read SKILL.md or file is empty'],
-            raw,
+            raw: input.raw,
             body: ''
         })
     }
 
-    const parsed = extractFrontmatter(raw)
+    const parsed = extractFrontmatter(input.raw)
     if (!parsed) {
         return createInvalidSkill({
-            file,
-            dir,
-            target,
-            cfg,
+            file: input.file,
+            dir: input.dir,
+            target: input.target,
+            cfg: input.cfg,
             diagnostics: ['SKILL.md is missing valid YAML frontmatter'],
-            raw,
-            body: raw.trim()
+            raw: input.raw,
+            body: input.raw.trim()
         })
     }
 
@@ -211,17 +318,17 @@ async function parseSkill(
         )
 
         return createInvalidSkill({
-            file,
-            dir,
-            target,
-            cfg,
+            file: input.file,
+            dir: input.dir,
+            target: input.target,
+            cfg: input.cfg,
             diagnostics,
-            raw,
+            raw: input.raw,
             body: parsed.body
         })
     }
 
-    const extra = await readExtraMetadata(dir)
+    const extra = parseExtraMetadata(input.extra)
     diagnostics.push(...extra.diagnostics)
     const openclaw = parseOpenClawMetadata(frontmatter.metadata)
 
@@ -250,17 +357,17 @@ async function parseSkill(
     const allowedTools = parseAllowedTools(frontmatter['allowed-tools'])
     const availableResult = await checkAvailability(
         openclaw,
-        agentCfg,
-        bins,
-        ctx
+        input.agentCfg,
+        input.bins,
+        input.ctx
     )
     const implicitInvocation =
         frontmatter['disable-model-invocation'] === true
             ? false
             : extra.allowImplicitInvocation !== false
     const userInvocable = frontmatter['user-invocable'] !== false
-    const id = createSkillId(file)
-    const enabled = cfg.items[id]?.enabled !== false
+    const id = createSkillId(input.file)
+    const enabled = input.cfg.items[id]?.enabled !== false
     const state: SkillState = description ? 'ready' : 'invalid'
 
     diagnostics.push(...availableResult.diagnostics)
@@ -269,10 +376,11 @@ async function parseSkill(
         id,
         name,
         description,
-        path: file,
-        dir,
-        source: target.source,
-        scope: target.scope,
+        path: input.file,
+        dir: input.dir,
+        source: input.target.source,
+        scope: input.target.scope,
+        remote: input.target.remote,
         state,
         enabled,
         available: availableResult.available,
@@ -299,8 +407,8 @@ async function parseSkill(
         allowedTools,
         diagnostics,
         body: parsed.body,
-        raw,
-        priority: target.priority
+        raw: input.raw,
+        priority: input.target.priority
     }
 }
 
@@ -323,6 +431,7 @@ function createInvalidSkill(input: {
         dir: input.dir,
         source: input.target.source,
         scope: input.target.scope,
+        remote: input.target.remote,
         state: 'invalid',
         enabled: input.cfg.items[id]?.enabled !== false,
         available: false,
@@ -335,15 +444,11 @@ function createInvalidSkill(input: {
     }
 }
 
-async function readExtraMetadata(dir: string): Promise<{
+function parseExtraMetadata(content?: string): {
     allowImplicitInvocation?: boolean
     diagnostics: string[]
-}> {
+} {
     const diagnostics: string[] = []
-    const content = await readFile(
-        join(dir, 'agents', 'openai.yaml'),
-        'utf-8'
-    ).catch(() => undefined)
 
     if (!content) return { diagnostics }
 
@@ -363,6 +468,26 @@ async function readExtraMetadata(dir: string): Promise<{
         return { diagnostics }
     }
 }
+
+async function listRemoteSkillFiles(session: ComputerSessionApi, root: string) {
+    const result = await session.execute(
+        `[ -d ${quoteShellPath(root)} ] && find ${quoteShellPath(root)} -type f -name SKILL.md -print || true`,
+        {
+            timeout: 10000
+        }
+    )
+
+    if (result.stderr.trim()) {
+        throw new Error(result.stderr.trim())
+    }
+
+    return result.stdout
+        .split('\n')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b))
+}
+
 function parseAllowedTools(value: unknown) {
     if (typeof value !== 'string' || !value.trim()) return undefined
 
@@ -601,7 +726,13 @@ async function getScanTargets(
     const dirs = [...DEFAULT_SKILL_DIRS, ...cfg.dirs]
     const seen = new Set([toPathKey(root)])
     const targets: ScanTarget[] = [
-        { root, source: 'chatluna', scope: 'data', priority: 0 }
+        {
+            root,
+            source: 'chatluna',
+            scope: 'data',
+            priority: 0,
+            remote: false
+        }
     ]
 
     for (let idx = 0; idx < dirs.length; idx++) {
@@ -617,7 +748,50 @@ async function getScanTargets(
             root: dir,
             source: detectSkillSource(item, dir),
             scope: detectSkillScope(ctx, dir),
-            priority: 100 + idx
+            priority: 100 + idx,
+            remote: false
+        })
+    }
+
+    return targets
+}
+
+function getRemoteScanTargets(
+    session: ComputerSessionApi,
+    cfg: AgentConfig['skills']
+) {
+    const scope = normalizeRemoteBase(session.getScopePath())
+    const dirs = [...DEFAULT_SKILL_DIRS, ...cfg.dirs]
+    const seen = new Set([normalizeRemoteKey(REMOTE_SKILLS_ROOT)])
+    const targets: ScanTarget[] = [
+        {
+            root: REMOTE_SKILLS_ROOT,
+            source: 'chatluna',
+            scope: 'data',
+            priority: 0,
+            remote: true
+        }
+    ]
+
+    for (let idx = 0; idx < dirs.length; idx++) {
+        const item = dirs[idx].trim()
+        if (!item) {
+            continue
+        }
+
+        const dir = resolveRemoteDir(scope, item)
+        const key = normalizeRemoteKey(dir)
+        if (seen.has(key)) {
+            continue
+        }
+
+        seen.add(key)
+        targets.push({
+            root: dir,
+            source: detectSkillSource(item, dir),
+            scope: detectRemoteSkillScope(scope, dir),
+            priority: 100 + idx,
+            remote: true
         })
     }
 
@@ -656,6 +830,65 @@ function detectSkillScope(ctx: Context, dir: string): SkillScope {
     if (isPathInside(dir, ctx.baseDir)) return 'project'
     return 'user'
 }
+
+function detectRemoteSkillScope(scope: string, dir: string): SkillScope {
+    if (isRemotePathInside(dir, REMOTE_SKILLS_ROOT)) return 'data'
+    if (isRemotePathInside(dir, scope)) return 'project'
+    return 'user'
+}
+
 function createSkillId(file: string) {
     return createHashId(file)
+}
+
+function resolveRemoteDir(scope: string, dir: string) {
+    const value = dir.replaceAll('\\', '/').trim()
+    if (value === '~' || value.startsWith('~/')) {
+        return value
+    }
+
+    if (value.startsWith('/')) {
+        return posix.normalize(value)
+    }
+
+    if (
+        [
+            '.agents/',
+            '.openclaw/',
+            '.codex/',
+            '.claude/',
+            '.config/opencode/'
+        ].some((item) => value.startsWith(item))
+    ) {
+        return `~/${value}`
+    }
+
+    if (scope === '~') {
+        return `~/${trimRemotePrefix(value)}`
+    }
+
+    if (scope.startsWith('~/')) {
+        return `${scope.replace(/\/+$/, '')}/${trimRemotePrefix(value)}`
+    }
+
+    return posix.resolve(scope || '/', value)
+}
+
+function trimRemotePrefix(value: string) {
+    return value.replace(/^\.\//, '').replace(/^\//, '')
+}
+
+function normalizeRemoteBase(value: string) {
+    const next = value.replaceAll('\\', '/').trim()
+    return next || '~'
+}
+
+function normalizeRemoteKey(value: string) {
+    return value.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
+}
+
+function isRemotePathInside(path: string, root: string) {
+    const target = normalizeRemoteKey(path)
+    const base = normalizeRemoteKey(root)
+    return target === base || target.startsWith(`${base}/`)
 }

--- a/packages/extension-agent/src/skills/scan.ts
+++ b/packages/extension-agent/src/skills/scan.ts
@@ -6,7 +6,7 @@ import { load } from 'js-yaml'
 import { Context } from 'koishi'
 import { basename, dirname, join } from 'path'
 import { promisify } from 'util'
-import { getSkillsRootPath } from '../config/path'
+import { DEFAULT_SKILL_DIRS, getSkillsRootPath } from '../config/path'
 import {
     AgentConfig,
     SkillInstallAction,
@@ -233,12 +233,6 @@ async function parseSkill(
         typeof frontmatter.description === 'string'
             ? frontmatter.description.trim()
             : ''
-
-    if (name.toLowerCase() !== fallbackName.toLowerCase()) {
-        diagnostics.push(
-            `Frontmatter name '${name}' does not match directory '${fallbackName}'`
-        )
-    }
 
     if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(name)) {
         diagnostics.push('Skill name should match ^[a-z0-9]+(-[a-z0-9]+)*$')
@@ -604,13 +598,14 @@ async function getScanTargets(
     cfg: AgentConfig['skills']
 ): Promise<ScanTarget[]> {
     const root = getSkillsRootPath(ctx)
+    const dirs = [...DEFAULT_SKILL_DIRS, ...cfg.dirs]
     const seen = new Set([toPathKey(root)])
     const targets: ScanTarget[] = [
         { root, source: 'chatluna', scope: 'data', priority: 0 }
     ]
 
-    for (let idx = 0; idx < cfg.dirs.length; idx++) {
-        const item = cfg.dirs[idx].trim()
+    for (let idx = 0; idx < dirs.length; idx++) {
+        const item = dirs[idx].trim()
         if (!item) continue
 
         const dir = resolveTildeDir(ctx.baseDir, item)
@@ -634,6 +629,12 @@ function detectSkillSource(raw: string, dir: string): SkillSource {
 
     if (value.includes('/.claude/skills') || value.endsWith('/claude/skills')) {
         return 'claude'
+    }
+    if (
+        value.includes('/.openclaw/skills') ||
+        value.endsWith('/openclaw/skills')
+    ) {
+        return 'openclaw'
     }
     if (value.includes('/.agents/skills') || value.endsWith('/agents/skills')) {
         return 'universal'

--- a/packages/extension-agent/src/sub-agent/catalog.ts
+++ b/packages/extension-agent/src/sub-agent/catalog.ts
@@ -1,7 +1,7 @@
 /** @module sub-agent/catalog */
 
 import { Context } from 'koishi'
-import { AgentConfig, ManualSubAgentInput } from '../types'
+import { AgentConfig, ManualSubAgentInput, SubAgentInfo } from '../types'
 import { ChatLunaAgentPermissionService } from '../service/permissions'
 import { applyShadowing } from '../utils/shadow'
 import { createManualAgent } from './manual'
@@ -12,12 +12,14 @@ export async function buildSubAgentCatalog(
     ctx: Context,
     cfg: AgentConfig['subAgent'],
     permission: ChatLunaAgentPermissionService,
-    manual: Iterable<ManualSubAgentInput>
+    manual: Iterable<ManualSubAgentInput>,
+    extra: SubAgentInfo[] = []
 ) {
     const items = [
         ...[...manual].map((item) => createManualAgent(ctx, item)),
         ...getBuiltinAgents(cfg),
         ...(await scanMarkdownAgents(ctx, cfg)),
+        ...extra,
         ...getPresetAgents(ctx, cfg)
     ].map((item) => ({
         ...item,

--- a/packages/extension-agent/src/sub-agent/scan.ts
+++ b/packages/extension-agent/src/sub-agent/scan.ts
@@ -2,22 +2,26 @@
 
 import { mkdir, readFile, stat } from 'fs/promises'
 import { Context } from 'koishi'
-import { basename } from 'path'
+import { basename, posix } from 'path'
 import { createSubAgentItemConfig } from '../config/defaults'
 import { getSubAgentsRootPath } from '../config/path'
+import { ComputerSessionApi } from '../computer/types'
 import { AgentConfig, SubAgentInfo } from '../types'
 import { collectFilesRecursive } from '../utils/fs'
 import { createHashId } from '../utils/id'
 import { isPathInside, resolveTildeDir, toPathKey } from '../utils/path'
+import { quoteShellPath } from '../utils/shell'
 import { parseAgentFrontmatter } from './parse'
 
 export { getBuiltinAgents } from './builtin'
+export const REMOTE_SUBAGENTS_ROOT = '~/.chatluna/agents'
 
 interface ScanTarget {
     root: string
     scope: 'data' | 'project' | 'user'
     priority: number
     hint?: 'chatluna' | 'claude' | 'opencode'
+    remote: boolean
 }
 
 export const WRITE_TOOL_PATTERNS = [
@@ -54,6 +58,45 @@ export async function scanMarkdownAgents(
     })
 }
 
+export async function scanRemoteMarkdownAgents(
+    session: ComputerSessionApi,
+    cfg: AgentConfig['subAgent']
+) {
+    const targets = getRemoteScanTargets(session, cfg)
+    const seen = new Set<string>()
+    const list = (
+        await Promise.all(
+            targets.map(async (target) => {
+                const files = await listRemoteMarkdownFiles(
+                    session,
+                    target.root
+                )
+                return await Promise.all(
+                    files.map(async (file) => {
+                        if (seen.has(file)) {
+                            return undefined
+                        }
+
+                        seen.add(file)
+                        const raw = await session.readFile(file).catch(() => '')
+                        return parseMarkdownAgentText(file, raw, target, cfg)
+                    })
+                )
+            })
+        )
+    )
+        .flat(2)
+        .filter((item) => item != null) as SubAgentInfo[]
+
+    return list.sort((a, b) => {
+        if (a.priority !== b.priority) {
+            return a.priority - b.priority
+        }
+
+        return (a.path ?? '').localeCompare(b.path ?? '')
+    })
+}
+
 function getScanTargets(ctx: Context, cfg: AgentConfig['subAgent']) {
     const root = getSubAgentsRootPath(ctx)
     const seen = new Set([toPathKey(root)])
@@ -62,7 +105,8 @@ function getScanTargets(ctx: Context, cfg: AgentConfig['subAgent']) {
             root,
             scope: 'data',
             priority: 0,
-            hint: 'chatluna'
+            hint: 'chatluna',
+            remote: false
         }
     ]
 
@@ -83,7 +127,49 @@ function getScanTargets(ctx: Context, cfg: AgentConfig['subAgent']) {
             root: dir,
             scope: detectScope(ctx, dir),
             priority: 100 + idx,
-            hint: detectHint(item, dir)
+            hint: detectHint(item, dir),
+            remote: false
+        })
+    }
+
+    return targets
+}
+
+function getRemoteScanTargets(
+    session: ComputerSessionApi,
+    cfg: AgentConfig['subAgent']
+) {
+    const scope = normalizeRemoteBase(session.getScopePath())
+    const seen = new Set([normalizeRemoteKey(REMOTE_SUBAGENTS_ROOT)])
+    const targets: ScanTarget[] = [
+        {
+            root: REMOTE_SUBAGENTS_ROOT,
+            scope: 'data',
+            priority: 0,
+            hint: 'chatluna',
+            remote: true
+        }
+    ]
+
+    for (let idx = 0; idx < cfg.dirs.length; idx++) {
+        const item = cfg.dirs[idx]?.trim()
+        if (!item) {
+            continue
+        }
+
+        const dir = resolveRemoteDir(scope, item)
+        const key = normalizeRemoteKey(dir)
+        if (seen.has(key)) {
+            continue
+        }
+
+        seen.add(key)
+        targets.push({
+            root: dir,
+            scope: detectRemoteScope(scope, dir),
+            priority: 100 + idx,
+            hint: detectHint(item, dir),
+            remote: true
         })
     }
 
@@ -109,6 +195,16 @@ async function parseMarkdownAgent(
     cfg: AgentConfig['subAgent']
 ) {
     const raw = await readFile(file, 'utf-8').catch(() => '')
+
+    return parseMarkdownAgentText(file, raw, target, cfg)
+}
+
+function parseMarkdownAgentText(
+    file: string,
+    raw: string,
+    target: ScanTarget,
+    cfg: AgentConfig['subAgent']
+) {
     const id = createAgentId(file)
     const parsed = parseAgentFrontmatter(
         raw,
@@ -155,6 +251,7 @@ async function parseMarkdownAgent(
         state: parsed.state,
         enabled: item.enabled,
         hidden: item.hidden ?? false,
+        remote: target.remote,
         path: file,
         scope: target.scope,
         priority: target.priority,
@@ -186,6 +283,18 @@ function detectScope(ctx: Context, dir: string) {
     return 'user'
 }
 
+function detectRemoteScope(scope: string, dir: string) {
+    if (isRemotePathInside(dir, REMOTE_SUBAGENTS_ROOT)) {
+        return 'data' as const
+    }
+
+    if (isRemotePathInside(dir, scope)) {
+        return 'project' as const
+    }
+
+    return 'user' as const
+}
+
 function detectHint(raw: string, dir: string) {
     const value = `${raw}\n${dir}`.replaceAll('\\', '/').toLowerCase()
     if (value.includes('/.claude/agents') || value.endsWith('/claude/agents')) {
@@ -204,4 +313,74 @@ function detectHint(raw: string, dir: string) {
 
 function createAgentId(file: string) {
     return createHashId(file)
+}
+
+async function listRemoteMarkdownFiles(
+    session: ComputerSessionApi,
+    root: string
+) {
+    const result = await session.execute(
+        `[ -d ${quoteShellPath(root)} ] && find ${quoteShellPath(root)} -type f -name '*.md' -print || true`,
+        {
+            timeout: 10000
+        }
+    )
+
+    if (result.stderr.trim()) {
+        throw new Error(result.stderr.trim())
+    }
+
+    return result.stdout
+        .split('\n')
+        .map((item) => item.trim())
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b))
+}
+
+function resolveRemoteDir(scope: string, dir: string) {
+    const value = dir.replaceAll('\\', '/').trim()
+    if (value === '~' || value.startsWith('~/')) {
+        return value
+    }
+
+    if (value.startsWith('/')) {
+        return posix.normalize(value)
+    }
+
+    if (
+        ['.agents/', '.codex/', '.claude/', '.config/opencode/'].some((item) =>
+            value.startsWith(item)
+        )
+    ) {
+        return `~/${value}`
+    }
+
+    if (scope === '~') {
+        return `~/${trimRemotePrefix(value)}`
+    }
+
+    if (scope.startsWith('~/')) {
+        return `${scope.replace(/\/+$/, '')}/${trimRemotePrefix(value)}`
+    }
+
+    return posix.resolve(scope || '/', value)
+}
+
+function trimRemotePrefix(value: string) {
+    return value.replace(/^\.\//, '').replace(/^\//, '')
+}
+
+function normalizeRemoteBase(value: string) {
+    const next = value.replaceAll('\\', '/').trim()
+    return next || '~'
+}
+
+function normalizeRemoteKey(value: string) {
+    return value.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
+}
+
+function isRemotePathInside(path: string, root: string) {
+    const target = normalizeRemoteKey(path)
+    const base = normalizeRemoteKey(root)
+    return target === base || target.startsWith(`${base}/`)
 }

--- a/packages/extension-agent/src/sub-agent/scan.ts
+++ b/packages/extension-agent/src/sub-agent/scan.ts
@@ -2,7 +2,7 @@
 
 import { mkdir, readFile, stat } from 'fs/promises'
 import { Context } from 'koishi'
-import { basename, posix } from 'path'
+import { basename } from 'path'
 import { createSubAgentItemConfig } from '../config/defaults'
 import { getSubAgentsRootPath } from '../config/path'
 import { ComputerSessionApi } from '../computer/types'
@@ -10,6 +10,7 @@ import { AgentConfig, SubAgentInfo } from '../types'
 import { collectFilesRecursive } from '../utils/fs'
 import { createHashId } from '../utils/id'
 import { isPathInside, resolveTildeDir, toPathKey } from '../utils/path'
+import { computeRemoteDir, isRemotePathInside } from '../utils/remote_path'
 import { quoteShellPath } from '../utils/shell'
 import { parseAgentFrontmatter } from './parse'
 
@@ -139,8 +140,10 @@ function getRemoteScanTargets(
     session: ComputerSessionApi,
     cfg: AgentConfig['subAgent']
 ) {
-    const scope = normalizeRemoteBase(session.getScopePath())
-    const seen = new Set([normalizeRemoteKey(REMOTE_SUBAGENTS_ROOT)])
+    const scope = session.getScopePath().replaceAll('\\', '/').trim() || '~'
+    const seen = new Set([
+        REMOTE_SUBAGENTS_ROOT.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
+    ])
     const targets: ScanTarget[] = [
         {
             root: REMOTE_SUBAGENTS_ROOT,
@@ -157,8 +160,8 @@ function getRemoteScanTargets(
             continue
         }
 
-        const dir = resolveRemoteDir(scope, item)
-        const key = normalizeRemoteKey(dir)
+        const dir = computeRemoteDir(scope, item)
+        const key = dir.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
         if (seen.has(key)) {
             continue
         }
@@ -335,52 +338,4 @@ async function listRemoteMarkdownFiles(
         .map((item) => item.trim())
         .filter(Boolean)
         .sort((a, b) => a.localeCompare(b))
-}
-
-function resolveRemoteDir(scope: string, dir: string) {
-    const value = dir.replaceAll('\\', '/').trim()
-    if (value === '~' || value.startsWith('~/')) {
-        return value
-    }
-
-    if (value.startsWith('/')) {
-        return posix.normalize(value)
-    }
-
-    if (
-        ['.agents/', '.codex/', '.claude/', '.config/opencode/'].some((item) =>
-            value.startsWith(item)
-        )
-    ) {
-        return `~/${value}`
-    }
-
-    if (scope === '~') {
-        return `~/${trimRemotePrefix(value)}`
-    }
-
-    if (scope.startsWith('~/')) {
-        return `${scope.replace(/\/+$/, '')}/${trimRemotePrefix(value)}`
-    }
-
-    return posix.resolve(scope || '/', value)
-}
-
-function trimRemotePrefix(value: string) {
-    return value.replace(/^\.\//, '').replace(/^\//, '')
-}
-
-function normalizeRemoteBase(value: string) {
-    const next = value.replaceAll('\\', '/').trim()
-    return next || '~'
-}
-
-function normalizeRemoteKey(value: string) {
-    return value.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
-}
-
-function isRemotePathInside(path: string, root: string) {
-    const target = normalizeRemoteKey(path)
-    const base = normalizeRemoteKey(root)
-    return target === base || target.startsWith(`${base}/`)
 }

--- a/packages/extension-agent/src/types/skills.ts
+++ b/packages/extension-agent/src/types/skills.ts
@@ -13,6 +13,7 @@ export interface SkillConfig {
 
 export type SkillSource =
     | 'chatluna'
+    | 'openclaw'
     | 'codex'
     | 'universal'
     | 'claude'

--- a/packages/extension-agent/src/types/skills.ts
+++ b/packages/extension-agent/src/types/skills.ts
@@ -52,6 +52,7 @@ export interface SkillInfo {
     description: string
     path: string
     dir: string
+    remote?: boolean
     source: SkillSource
     scope: SkillScope
     state: SkillState

--- a/packages/extension-agent/src/types/skills.ts
+++ b/packages/extension-agent/src/types/skills.ts
@@ -9,6 +9,7 @@ export interface SkillsConfig {
 
 export interface SkillConfig {
     enabled: boolean
+    remote?: boolean
 }
 
 export type SkillSource =

--- a/packages/extension-agent/src/types/sub_agent.ts
+++ b/packages/extension-agent/src/types/sub_agent.ts
@@ -46,6 +46,7 @@ export interface SubAgentInfo {
     state: 'ready' | 'invalid' | 'missing'
     enabled: boolean
     hidden: boolean
+    remote?: boolean
     path?: string
     scope?: 'data' | 'project' | 'user'
     priority: number

--- a/packages/extension-agent/src/utils/remote_path.ts
+++ b/packages/extension-agent/src/utils/remote_path.ts
@@ -1,0 +1,43 @@
+/** @module utils/remote_path */
+
+import { posix } from 'path'
+
+export function computeRemoteDir(scope: string, dir: string) {
+    const value = dir.replaceAll('\\', '/').trim()
+    if (value === '~' || value.startsWith('~/')) {
+        return value
+    }
+
+    if (value.startsWith('/')) {
+        return posix.normalize(value)
+    }
+
+    if (
+        [
+            '.agents/',
+            '.openclaw/',
+            '.codex/',
+            '.claude/',
+            '.config/opencode/'
+        ].some((item) => value.startsWith(item))
+    ) {
+        return `~/${value}`
+    }
+
+    const next = value.replace(/^\.\//, '').replace(/^\//, '')
+    if (scope === '~') {
+        return `~/${next}`
+    }
+
+    if (scope.startsWith('~/')) {
+        return `${scope.replace(/\/+$/, '')}/${next}`
+    }
+
+    return posix.resolve(scope || '/', value)
+}
+
+export function isRemotePathInside(path: string, root: string) {
+    const target = path.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
+    const base = root.replaceAll('\\', '/').replace(/\/+$/, '') || '/'
+    return target === base || target.startsWith(`${base}/`)
+}

--- a/packages/extension-agent/src/utils/shadow.ts
+++ b/packages/extension-agent/src/utils/shadow.ts
@@ -7,8 +7,11 @@ export function applyShadowing<
     T extends {
         name: string
         id: string
-        enabled: boolean
-        state: string
+        enabled?: boolean
+        disabled?: boolean
+        hidden?: boolean
+        invalid?: boolean
+        state?: string
         available?: boolean
         priority: number
         remote?: boolean
@@ -24,14 +27,23 @@ export function applyShadowing<
 
     const result: (T & { shadowedBy?: string })[] = []
     for (const list of groups.values()) {
-        list.sort((a, b) => {
+        const candidates = list.filter((item) => {
+            if (item.enabled === false) return false
+            if (item.disabled === true) return false
+            if (item.hidden === true) return false
+            if (item.invalid === true) return false
+            if (item.state != null && item.state !== 'ready') return false
+            return item.available !== false
+        })
+
+        candidates.sort((a, b) => {
             if ((a.remote === true) !== (b.remote === true)) {
                 return a.remote === true ? 1 : -1
             }
 
             return a.priority - b.priority
         })
-        const winner = list[0]
+        const winner = candidates[0]
 
         for (const item of list) {
             result.push({

--- a/packages/extension-agent/src/utils/shadow.ts
+++ b/packages/extension-agent/src/utils/shadow.ts
@@ -11,6 +11,7 @@ export function applyShadowing<
         state: string
         available?: boolean
         priority: number
+        remote?: boolean
     }
 >(items: T[]): (T & { shadowedBy?: string })[] {
     const groups = new Map<string, T[]>()
@@ -23,13 +24,14 @@ export function applyShadowing<
 
     const result: (T & { shadowedBy?: string })[] = []
     for (const list of groups.values()) {
-        list.sort((a, b) => a.priority - b.priority)
-        const winner = list.find(
-            (item) =>
-                item.enabled &&
-                item.state === 'ready' &&
-                item.available !== false
-        )
+        list.sort((a, b) => {
+            if ((a.remote === true) !== (b.remote === true)) {
+                return a.remote === true ? 1 : -1
+            }
+
+            return a.priority - b.priority
+        })
+        const winner = list[0]
 
         for (const item of list) {
             result.push({

--- a/packages/extension-agent/src/utils/shell.ts
+++ b/packages/extension-agent/src/utils/shell.ts
@@ -8,6 +8,23 @@ export function quoteShell(value: string): string {
     return `'${value.replaceAll("'", `'\\''`)}'`
 }
 
+export function quoteShellPath(value: string): string {
+    if (value === '~') {
+        return '$HOME'
+    }
+
+    if (value.startsWith('~/')) {
+        return `"$HOME/${value
+            .slice(2)
+            .replaceAll('\\', '/')
+            .replaceAll('"', '\\"')
+            .replaceAll('`', '\\`')
+            .replaceAll('$', '\\$')}"`
+    }
+
+    return quoteShell(value)
+}
+
 /** 安全提取 error.message。 */
 export function getErrorMessage(err: unknown): string {
     return err instanceof Error ? err.message : String(err)

--- a/packages/extension-agent/src/utils/shell.ts
+++ b/packages/extension-agent/src/utils/shell.ts
@@ -10,7 +10,7 @@ export function quoteShell(value: string): string {
 
 export function quoteShellPath(value: string): string {
     if (value === '~') {
-        return '$HOME'
+        return '"$HOME"'
     }
 
     if (value.startsWith('~/')) {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -68,7 +68,7 @@
     "peerDependencies": {
         "koishi": "^4.18.9",
         "koishi-plugin-chatluna": "^1.3.34",
-        "koishi-plugin-chatluna-agent": "^1.0.1",
+        "koishi-plugin-chatluna-agent": "^1.0.12",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {


### PR DESCRIPTION
## Summary
- reconnect kept-alive E2B sandboxes when the previous instance is gone and reset sandbox timeouts after command runs
- check required skill binaries through the active computer backend so local, Windows shell, and remote sandbox environments report availability correctly
- clean up the skills page action layout so the primary actions stay aligned and diagnostics remain easy to access