### PR TITLE
fix(extension-agent): forward MCP headers via requestInit

### DIFF
--- a/packages/extension-agent/src/mcp/transport.ts
+++ b/packages/extension-agent/src/mcp/transport.ts
@@ -17,6 +17,18 @@ export function createTransport(
     config: McpServerConfig
 ): Transport {
     const type = config.type ?? 'stdio'
+    const requestInit =
+        (config as StreamableHTTPClientTransportOptions).requestInit ?? {}
+    const transportConfig = {
+        ...config,
+        requestInit: {
+            ...requestInit,
+            headers: {
+                ...(requestInit.headers as Record<string, string>),
+                ...(config.headers ?? {})
+            }
+        }
+    }
 
     if (type === 'stdio') {
         return new StdioClientTransport({
@@ -31,14 +43,14 @@ export function createTransport(
     if (type === 'sse') {
         return new SSEClientTransport(
             new URL(config.url),
-            config as SSEClientTransportOptions
+            transportConfig as SSEClientTransportOptions
         )
     }
 
     if (type === 'http' || type === 'streamable_http') {
         return new StreamableHTTPClientTransport(
             new URL(config.url),
-            config as StreamableHTTPClientTransportOptions
+            transportConfig as StreamableHTTPClientTransportOptions
         )
     }
 

--- a/packages/extension-agent/src/mcp/transport.ts
+++ b/packages/extension-agent/src/mcp/transport.ts
@@ -19,14 +19,15 @@ export function createTransport(
     const type = config.type ?? 'stdio'
     const requestInit =
         (config as StreamableHTTPClientTransportOptions).requestInit ?? {}
+    const headers = new Headers(requestInit.headers)
+    for (const [k, v] of Object.entries(config.headers ?? {})) {
+        headers.set(k, v)
+    }
     const transportConfig = {
         ...config,
         requestInit: {
             ...requestInit,
-            headers: {
-                ...(requestInit.headers as Record<string, string>),
-                ...(config.headers ?? {})
-            }
+            headers
         }
     }
 


### PR DESCRIPTION
## Summary
- 修复 `extension-agent` 的 MCP HTTP/SSE 传输参数拼装逻辑，将 `config.headers` 显式合并到 `requestInit.headers`。
- 避免 `StreamableHTTPClientTransport` 与 `SSEClientTransport` 仅读取 `requestInit.headers` 时丢失鉴权头，导致服务端返回 `401 Unauthorized`。

## Verification
- 在本地 Koishi 实例复现并验证：修复前 `chatluna-agent` 连接同一 MCP 端点会报 `Error POSTing to endpoint (HTTP 401)`；修复后可正常注册工具。
- `yarn fast-build extension-agent` 仍存在上游分支既有类型错误（与本改动无关），本改动未新增新的构建报错项。
