### PR TITLE
fix(adapter-gemini): preserve all system segments in system instruction

### DIFF
--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -112,7 +112,9 @@ export function extractSystemMessages(
         .slice(0, lastSystemMessageIndex + 1)
         .filter((msg) => msg.role === 'system')
 
-    const modelMessages = messages.slice(lastSystemMessageIndex + 1)
+    const modelMessages = messages.filter(
+        (msg, idx) => idx > lastSystemMessageIndex || msg.role !== 'system'
+    )
 
     return [
         {

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -108,10 +108,9 @@ export function extractSystemMessages(
         return [undefined, messages]
     }
 
-    const systemMessages = messages.slice(
-        0,
-        Math.max(1, lastSystemMessageIndex)
-    )
+    const systemMessages = messages
+        .slice(0, lastSystemMessageIndex + 1)
+        .filter((msg) => msg.role === 'system')
 
     const modelMessages = messages.slice(lastSystemMessageIndex + 1)
 

--- a/packages/adapter-gemini/src/utils.ts
+++ b/packages/adapter-gemini/src/utils.ts
@@ -112,9 +112,14 @@ export function extractSystemMessages(
         .slice(0, lastSystemMessageIndex + 1)
         .filter((msg) => msg.role === 'system')
 
-    const modelMessages = messages.filter(
-        (msg, idx) => idx > lastSystemMessageIndex || msg.role !== 'system'
-    )
+    const modelMessages = [
+        ...messages
+            .slice(0, lastSystemMessageIndex)
+            .filter((msg) => msg.role !== 'system'),
+        ...messages
+            .slice(lastSystemMessageIndex + 1)
+            .filter((msg) => msg.role !== 'system')
+    ]
 
     return [
         {


### PR DESCRIPTION
## 变更说明
- 修复 Gemini 适配器提取 system message 的切片边界问题，避免最后一条 system 提示被丢弃。
- 仅将 `role=system` 的消息合并到 `system_instruction.parts`，避免把前置非 system 消息混入系统指令。
- 保持 `contents` 仍从最后一条 system 之后开始，兼容现有对话上下文组织方式。

## 背景
在多段系统提示场景（例如后注入的 skills 提示）下，原逻辑会遗漏最后一段 system 指令，导致 Gemini 实际接收到的系统指令不完整。
