### PR TITLE
feat(extension-tools): add OneBot file sender tool and improve agent/open-terminal robustness

### DIFF
--- a/packages/core/src/llm-core/agent/creator.ts
+++ b/packages/core/src/llm-core/agent/creator.ts
@@ -34,6 +34,7 @@ export interface CreateAgentExecutorOptions {
     tools: ComputedRef<StructuredTool[]>
     prompt: ChatLunaChatPrompt
     agentMode: 'react' | 'tool-calling'
+    maxIterations?: number
     returnIntermediateSteps?: boolean
     handleParsingErrors?: boolean
     instructions?: ComputedRef<string>
@@ -84,6 +85,7 @@ export function createAgentExecutor(
         AgentExecutor.fromAgentAndTools({
             agent: cfg.value.agent,
             tools: cfg.value.tools,
+            maxIterations: options.maxIterations,
             returnIntermediateSteps: options.returnIntermediateSteps,
             handleParsingErrors: options.handleParsingErrors
         })

--- a/packages/extension-agent/client/components/computer/configuration-panel.vue
+++ b/packages/extension-agent/client/components/computer/configuration-panel.vue
@@ -666,6 +666,29 @@ function tagType(state: ComputerStatus['backends']['local']['state']) {
     max-height: min(70vh, 720px);
     overflow: auto;
     padding-right: 4px;
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--k-color-divider), #71717a 40%)
+        transparent;
+}
+
+.guide-dialog::-webkit-scrollbar {
+    width: 10px;
+}
+
+.guide-dialog::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+.guide-dialog::-webkit-scrollbar-thumb {
+    background: color-mix(in srgb, var(--k-color-divider), #71717a 40%);
+    border-radius: 10px;
+    border: 2px solid transparent;
+    background-clip: content-box;
+}
+
+.guide-dialog::-webkit-scrollbar-thumb:hover {
+    background: color-mix(in srgb, var(--k-color-divider), #52525b 58%);
+    background-clip: content-box;
 }
 
 .guide-intro,

--- a/packages/extension-agent/client/components/computer/configuration-panel.vue
+++ b/packages/extension-agent/client/components/computer/configuration-panel.vue
@@ -400,6 +400,7 @@ const guide = computed<GuideContent>(() => {
                         '  -p 8000:8000 \\',
                         '  -v open-terminal:/home/user \\',
                         '  -e OPEN_TERMINAL_API_KEY=your-secret-key \\',
+                        '  -e OPEN_TERMINAL_BINARY_MIME_PREFIXES=image,audio,video,application/pdf,application/zip,application/vnd.openxmlformats-officedocument.,application/octet-stream \\',
                         '  ghcr.io/open-webui/open-terminal'
                     ].join('\n')
                 },

--- a/packages/extension-agent/client/components/computer/configuration-panel.vue
+++ b/packages/extension-agent/client/components/computer/configuration-panel.vue
@@ -663,6 +663,9 @@ function tagType(state: ComputerStatus['backends']['local']['state']) {
     display: flex;
     flex-direction: column;
     gap: 18px;
+    max-height: min(70vh, 720px);
+    overflow: auto;
+    padding-right: 4px;
 }
 
 .guide-intro,

--- a/packages/extension-agent/src/computer/backends/e2b.ts
+++ b/packages/extension-agent/src/computer/backends/e2b.ts
@@ -5,11 +5,13 @@ import { Buffer } from 'node:buffer'
 import { posix } from 'path'
 import { Readable } from 'node:stream'
 import {
+    CommandExitError,
     CommandHandle,
     CommandResult,
     CommandStartOpts,
     Sandbox as E2BSandbox,
-    NotFoundError
+    NotFoundError,
+    TimeoutError
 } from 'e2b'
 import mimeTypes from 'mime-types'
 import { Context } from 'koishi'
@@ -21,6 +23,7 @@ import {
     DesktopAction,
     DesktopInfo,
     ExecuteOptions,
+    ExecuteResult,
     FileContent,
     ScreenshotResult,
     StreamHandle,
@@ -378,7 +381,7 @@ export class E2BComputerSession implements ComputerSessionApi {
             envs: options.env
         } as CommandStartOpts)
         this._cwd = cwd
-        return mapCommandResult(result)
+        return result
     }
 
     async readAsset(filePath: string) {
@@ -641,15 +644,34 @@ export class E2BComputerSession implements ComputerSessionApi {
         command: string,
         options?: CommandStartOpts,
         sandbox?: SandboxWrapper
-    ) {
+    ): Promise<ExecuteResult> {
         const current = sandbox ?? (await this.ensureSandbox())
-        let result: Awaited<ReturnType<SandboxWrapper['commands']['run']>>
+        let handle: CommandHandle | undefined
+        let result: CommandResult | undefined
         let runErr: unknown
+        let timedOut = false
 
         try {
-            result = await current.commands.run(command, options)
+            handle = (await current.commands.run(command, {
+                ...options
+            } as CommandStartOpts & { background: true })) as CommandHandle
+            result = await handle.wait()
         } catch (err) {
-            runErr = err
+            if (err instanceof CommandExitError) {
+                result = err
+            } else if (
+                err instanceof TimeoutError ||
+                (err instanceof Error && err.name === 'TimeoutError')
+            ) {
+                timedOut = true
+                result = {
+                    exitCode: handle?.exitCode ?? 1,
+                    stdout: handle?.stdout ?? '',
+                    stderr: handle?.stderr ?? ''
+                }
+            } else {
+                runErr = err
+            }
         }
 
         try {
@@ -664,7 +686,11 @@ export class E2BComputerSession implements ComputerSessionApi {
             throw runErr
         }
 
-        return result
+        if (!result) {
+            throw new Error('Command finished without a result.')
+        }
+
+        return mapCommandResult(result, timedOut)
     }
 
     private ensureDesktopSandbox() {
@@ -700,13 +726,16 @@ export class E2BComputerSession implements ComputerSessionApi {
     }
 }
 
-function mapCommandResult(result: CommandResult | CommandHandle) {
+function mapCommandResult(
+    result: CommandResult | CommandHandle,
+    timedOut = false
+) {
     return {
         exitCode: result.exitCode ?? 0,
         stdout: result.stdout,
         stderr: result.stderr,
         signal: undefined,
-        timedOut: false
+        timedOut
     }
 }
 

--- a/packages/extension-agent/src/computer/backends/local/index.ts
+++ b/packages/extension-agent/src/computer/backends/local/index.ts
@@ -226,11 +226,24 @@ async function runChildProcess(
         })
 
         let done = false
-        let timedOut = false
+        const finish = (result: ExecuteResult) => {
+            if (done) {
+                return
+            }
+
+            done = true
+            clearTimeout(timer)
+            resolve(result)
+        }
         const timer =
             timeout > 0
                 ? setTimeout(() => {
-                      timedOut = true
+                      finish({
+                          exitCode: 1,
+                          stdout: decodeOutput(stdoutChunks),
+                          stderr: decodeOutput(stderrChunks),
+                          timedOut: true
+                      })
                       killLocalChild(child).catch(() => undefined)
                   }, timeout)
                 : undefined
@@ -254,32 +267,16 @@ async function runChildProcess(
 
             done = true
             clearTimeout(timer)
-            if (timedOut) {
-                resolve({
-                    exitCode: 1,
-                    stdout: decodeOutput(stdoutChunks),
-                    stderr: decodeOutput(stderrChunks),
-                    timedOut: true
-                })
-                return
-            }
-
             reject(err)
         })
 
         child.on('close', (code, signal) => {
-            if (done) {
-                return
-            }
-
-            done = true
-            clearTimeout(timer)
-            resolve({
-                exitCode: code ?? (timedOut ? 1 : 0),
+            finish({
+                exitCode: code ?? 0,
                 stdout: decodeOutput(stdoutChunks),
                 stderr: decodeOutput(stderrChunks),
                 signal: signal ?? undefined,
-                timedOut
+                timedOut: false
             })
         })
     })

--- a/packages/extension-agent/src/computer/backends/local/store.ts
+++ b/packages/extension-agent/src/computer/backends/local/store.ts
@@ -1,10 +1,14 @@
 /** @module computer/backends/local/store */
 
+import { spawn } from 'node:child_process'
 import fs from 'fs/promises'
 import path from 'path'
 import micromatch from 'micromatch'
+import which from 'which'
 import { LocalBackendConfig } from '../../../types'
 import type { FileContent } from '../../types'
+
+const rg = which.sync('rg', { nothrow: true })
 
 export interface BaseFileStore {
     readFile(filePath: string, offset?: number, limit?: number): Promise<string>
@@ -121,43 +125,81 @@ export class FileStore implements BaseFileStore {
         this.assertInScope(dir)
 
         const stat = await fs.stat(dir).catch(() => null)
-        const files = stat?.isDirectory()
-            ? await this._findFiles(dir, include)
-            : include == null || this._matchPattern(dir, include)
-              ? [dir]
-              : []
+        if (!stat) {
+            return []
+        }
 
-        const regex = new RegExp(pattern, 'gm')
-        const results: { file: string; mtime: number; lines: string[] }[] = []
+        if (stat.isDirectory() && rg) {
+            const args = [
+                '--json',
+                '-n',
+                '--hidden',
+                '--no-ignore',
+                '--follow',
+                '--color',
+                'never',
+                '--engine',
+                'auto'
+            ]
 
-        for (const file of files) {
-            if (this._shouldIgnore(file)) {
-                continue
+            if (include) {
+                args.push('-g', include)
             }
 
+            for (const item of this._cfg.ignores) {
+                args.push('-g', `!${item}`)
+            }
+
+            args.push('-e', pattern, '.')
+
             try {
-                const fileStat = await fs.stat(file)
-                if (!fileStat.isFile()) {
-                    continue
+                const result = await runProcess(rg, args, dir)
+                if (result.exitCode === 1) {
+                    return []
                 }
 
-                const content = await fs.readFile(file, 'utf-8')
-                const lines = content.split('\n')
-                const matched: string[] = []
-                for (let idx = 0; idx < lines.length; idx++) {
-                    if (regex.test(lines[idx])) {
-                        matched.push(`${file}:${idx + 1}:${lines[idx]}`)
+                if (result.exitCode !== 0) {
+                    throw new Error(
+                        result.stderr ||
+                            `ripgrep exited with ${result.exitCode}`
+                    )
+                }
+
+                const matched = new Map<string, string[]>()
+                for (const line of result.stdout.split('\n')) {
+                    if (!line) {
+                        continue
                     }
-                    regex.lastIndex = 0
+
+                    const item = JSON.parse(line)
+                    if (item.type !== 'match') {
+                        continue
+                    }
+
+                    const raw = item.data.path.text as string | undefined
+                    if (!raw) {
+                        continue
+                    }
+
+                    const file = path.resolve(dir, raw)
+                    if (this._shouldIgnore(file)) {
+                        continue
+                    }
+
+                    if (include && !this._matchPattern(file, include)) {
+                        continue
+                    }
+
+                    const text = (
+                        (item.data.lines.text as string | undefined) || ''
+                    ).replace(/\r?\n$/, '')
+                    const list = matched.get(file) || []
+                    list.push(`${file}:${item.data.line_number}:${text}`)
+                    matched.set(file, list)
                 }
 
-                if (matched.length > 0) {
-                    results.push({
-                        file,
-                        mtime: fileStat.mtimeMs,
-                        lines: matched
-                    })
-                }
+                const files = await sortByMtime([...matched.keys()])
+                return files.flatMap((file) => matched.get(file) || [])
             } catch (err) {
                 if (process.env['CHATLUNA_AGENT_DEBUG']) {
                     console.debug(err)
@@ -165,8 +207,41 @@ export class FileStore implements BaseFileStore {
             }
         }
 
-        results.sort((a, b) => b.mtime - a.mtime)
-        return results.flatMap((item) => item.lines)
+        const files = stat.isDirectory()
+            ? await this._findFiles(dir, include)
+            : include == null || this._matchPattern(dir, include)
+              ? [dir]
+              : []
+
+        const regex = new RegExp(pattern, 'gm')
+        const matched = new Map<string, string[]>()
+
+        for (const file of files) {
+            if (this._shouldIgnore(file)) {
+                continue
+            }
+
+            const content = await fs.readFile(file, 'utf-8').catch(() => null)
+            if (content == null) {
+                continue
+            }
+
+            const lines = content.split('\n')
+            const list: string[] = []
+            for (let idx = 0; idx < lines.length; idx++) {
+                if (regex.test(lines[idx])) {
+                    list.push(`${file}:${idx + 1}:${lines[idx]}`)
+                }
+                regex.lastIndex = 0
+            }
+
+            if (list.length > 0) {
+                matched.set(file, list)
+            }
+        }
+
+        const sorted = await sortByMtime([...matched.keys()])
+        return sorted.flatMap((file) => matched.get(file) || [])
     }
 
     async glob(pattern: string, searchPath?: string) {
@@ -174,20 +249,58 @@ export class FileStore implements BaseFileStore {
         this.assertInScope(dir)
 
         const stat = await fs.stat(dir).catch(() => null)
+        if (!stat) {
+            return []
+        }
+
         if (!stat?.isDirectory()) {
             return this._matchPattern(dir, pattern) ? [dir] : []
         }
 
-        const files = await this._findFiles(dir, pattern)
-        const list = await Promise.all(
-            files.map(async (file) => ({
-                path: file,
-                mtime: (await fs.stat(file).catch(() => null))?.mtimeMs ?? 0
-            }))
-        )
+        if (rg) {
+            const args = [
+                '--files',
+                '--hidden',
+                '--no-ignore',
+                '--follow',
+                '-0'
+            ]
 
-        list.sort((a, b) => b.mtime - a.mtime)
-        return list.map((item) => item.path)
+            args.push('-g', pattern)
+            for (const item of this._cfg.ignores) {
+                args.push('-g', `!${item}`)
+            }
+
+            args.push('.')
+
+            try {
+                const result = await runProcess(rg, args, dir)
+                if (result.exitCode !== 0) {
+                    throw new Error(
+                        result.stderr ||
+                            `ripgrep exited with ${result.exitCode}`
+                    )
+                }
+
+                const files = result.stdout
+                    .split('\0')
+                    .filter(Boolean)
+                    .map((file) => path.resolve(dir, file))
+                    .filter(
+                        (file) =>
+                            !this._shouldIgnore(file) &&
+                            this._matchPattern(file, pattern)
+                    )
+
+                return sortByMtime(files)
+            } catch (err) {
+                if (process.env['CHATLUNA_AGENT_DEBUG']) {
+                    console.debug(err)
+                }
+            }
+        }
+
+        return sortByMtime(await this._findFiles(dir, pattern))
     }
 
     private async _findFiles(
@@ -197,7 +310,6 @@ export class FileStore implements BaseFileStore {
         try {
             const entries = await fs.readdir(dirPath, { withFileTypes: true })
             const results: string[] = []
-            const sub: Promise<string[]>[] = []
 
             for (const entry of entries) {
                 const fullPath = path.join(dirPath, entry.name)
@@ -206,7 +318,7 @@ export class FileStore implements BaseFileStore {
                 }
 
                 if (entry.isDirectory()) {
-                    sub.push(this._findFiles(fullPath, pattern))
+                    results.push(...(await this._findFiles(fullPath, pattern)))
                     continue
                 }
 
@@ -223,15 +335,17 @@ export class FileStore implements BaseFileStore {
 
                 try {
                     const stat = await fs.stat(fullPath)
+                    if (stat.isDirectory()) {
+                        results.push(
+                            ...(await this._findFiles(fullPath, pattern))
+                        )
+                        continue
+                    }
+
                     if (stat.isFile()) {
                         if (!pattern || this._matchPattern(fullPath, pattern)) {
                             results.push(fullPath)
                         }
-                        continue
-                    }
-
-                    if (stat.isDirectory()) {
-                        sub.push(this._findFiles(fullPath, pattern))
                     }
                 } catch (err) {
                     if (process.env['CHATLUNA_AGENT_DEBUG']) {
@@ -240,7 +354,7 @@ export class FileStore implements BaseFileStore {
                 }
             }
 
-            return results.concat(...(await Promise.all(sub)))
+            return results
         } catch (err) {
             if (process.env['CHATLUNA_AGENT_DEBUG']) {
                 console.debug(err)
@@ -284,6 +398,51 @@ export class FileStore implements BaseFileStore {
             `path "${filePath}" is not in scope "${this._cfg.scopePath}"`
         )
     }
+}
+
+async function runProcess(file: string, args: string[], cwd: string) {
+    return await new Promise<{
+        exitCode: number
+        stdout: string
+        stderr: string
+    }>((resolve, reject) => {
+        const stdout: Buffer[] = []
+        const stderr: Buffer[] = []
+        const child = spawn(file, args, {
+            cwd,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            windowsHide: true
+        })
+
+        child.stdout.on('data', (chunk: Buffer | string) => {
+            stdout.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+        })
+
+        child.stderr.on('data', (chunk: Buffer | string) => {
+            stderr.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk))
+        })
+
+        child.on('error', reject)
+        child.on('close', (code) => {
+            resolve({
+                exitCode: code ?? 0,
+                stdout: Buffer.concat(stdout).toString('utf8'),
+                stderr: Buffer.concat(stderr).toString('utf8').trim()
+            })
+        })
+    })
+}
+
+async function sortByMtime(files: string[]) {
+    const list = await Promise.all(
+        files.map(async (file) => ({
+            path: file,
+            mtime: (await fs.stat(file).catch(() => null))?.mtimeMs ?? 0
+        }))
+    )
+
+    list.sort((a, b) => b.mtime - a.mtime)
+    return list.map((item) => item.path)
 }
 
 function replaceSubstring(

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -64,7 +64,10 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 }
             }
         )
-        const output = formatOpenTerminalOutput(current.data?.output)
+        const currentData = (current as any).data ?? current
+        const output = formatOpenTerminalOutput(
+            currentData?.output ?? currentData
+        )
         const root = output.stdout.trim() || '/'
         this._home = root
 
@@ -382,10 +385,10 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         )
 
         this._cwd = cwd
-        const data = result.data
+        const data = (result as any).data ?? result
 
         if (data?.status !== 'running') {
-            const output = formatOpenTerminalOutput(data?.output)
+            const output = formatOpenTerminalOutput(data?.output ?? data)
             return {
                 exitCode: data?.exitCode ?? data?.code ?? data?.exit_code ?? 0,
                 stdout: output.stdout,
@@ -478,8 +481,10 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
             }
         )
 
-        if (typeof result.data?.id !== 'string') {
-            const output = formatOpenTerminalOutput(result.data?.output)
+        const data = (result as any).data ?? result
+
+        if (typeof data?.id !== 'string') {
+            const output = formatOpenTerminalOutput(data?.output ?? data)
             throw new Error(
                 output.stderr || output.stdout || 'Failed to create terminal.'
             )
@@ -489,7 +494,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
             this.ctx,
             (pathname) => this.url(pathname),
             this.headers(),
-            result.data
+            data
         )
         const callbacks = new Set<(data: string) => void>()
         const url = this.url(`/execute/${run.id}`)
@@ -497,7 +502,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         let buffer = ''
         this._cwd = cwd
 
-        const output = formatOpenTerminalOutput(result.data?.output)
+        const output = formatOpenTerminalOutput(data?.output ?? data)
         buffer = `${output.stdout}${output.stderr}`
 
         const emit = (data: string) => {
@@ -674,7 +679,7 @@ function createOpenTerminalPoller(
             }
         })
 
-        data = status.data
+        data = (status as any).data ?? status
         if (typeof data.next_offset === 'number') {
             nextOffset = data.next_offset
         }
@@ -702,7 +707,7 @@ function createOpenTerminalPoller(
 
                 try {
                     const data = await read()
-                    const output = formatOpenTerminalOutput(data.output)
+                    const output = formatOpenTerminalOutput(data.output ?? data)
                     onData(`${output.stdout}${output.stderr}`)
                 } catch {
                     closed = true
@@ -726,7 +731,7 @@ function createOpenTerminalPoller(
             const stderr: string[] = []
 
             const append = (data: OpenTerminalData) => {
-                const output = formatOpenTerminalOutput(data.output)
+                const output = formatOpenTerminalOutput(data.output ?? data)
                 if (output.stdout) {
                     stdout.push(output.stdout)
                 }
@@ -783,7 +788,33 @@ function joinPath(dir: string, path: string) {
     return `${dir.replace(/\/$/, '')}/${path}`
 }
 
-function formatOpenTerminalOutput(output: unknown) {
+function formatOpenTerminalOutput(output: unknown): {
+    stdout: string
+    stderr: string
+} {
+    if (typeof output === 'string') {
+        return { stdout: output, stderr: '' }
+    }
+
+    if (output && typeof output === 'object' && !Array.isArray(output)) {
+        const row = output as Record<string, unknown>
+        const direct =
+            typeof row.data === 'string'
+                ? row.data
+                : typeof row.text === 'string'
+                  ? row.text
+                  : typeof row.message === 'string'
+                    ? row.message
+                    : typeof row.output === 'string'
+                      ? row.output
+                      : typeof row.content === 'string'
+                        ? row.content
+                        : ''
+        const stdout = typeof row.stdout === 'string' ? row.stdout : direct
+        const stderr = typeof row.stderr === 'string' ? row.stderr : ''
+        return { stdout, stderr }
+    }
+
     const stdout: string[] = []
     const stderr: string[] = []
 
@@ -792,12 +823,30 @@ function formatOpenTerminalOutput(output: unknown) {
     }
 
     for (const item of output) {
-        const data = typeof item?.data === 'string' ? item.data : ''
+        if (typeof item === 'string') {
+            stdout.push(item)
+            continue
+        }
+
+        const row = item as Record<string, unknown>
+        const data =
+            typeof row.data === 'string'
+                ? row.data
+                : typeof row.text === 'string'
+                  ? row.text
+                  : typeof row.message === 'string'
+                    ? row.message
+                    : typeof row.output === 'string'
+                      ? row.output
+                      : typeof row.content === 'string'
+                        ? row.content
+                        : ''
         if (!data) {
             continue
         }
 
-        if (item?.type === 'stderr') {
+        const type = typeof row.type === 'string' ? row.type.toLowerCase() : ''
+        if (type.includes('stderr') || type.includes('error')) {
             stderr.push(data)
             continue
         }

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -467,92 +467,123 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
 
     async createTerminal(options: TerminalOptions = {}) {
         const cwd = options.cwd || this._cwd
-        const headers = {
-            ...this.headers(),
-            'content-type': 'application/json'
-        }
         const result = await this.ctx.http.post(
-            this.url('/execute'),
+            this.url('/api/terminals'),
+            undefined,
             {
-                command: 'bash',
-                cwd
-            },
-            {
-                params: {
-                    wait: 1
-                },
-                headers
+                headers: this.headers()
             }
         )
-
         const data =
-            (result as unknown as OpenTerminalResponse).data ??
-            (result as unknown as OpenTerminalData)
-
-        if (typeof data?.id !== 'string') {
-            const output = formatOpenTerminalOutput(data?.output ?? data)
-            throw new Error(
-                output.stderr || output.stdout || 'Failed to create terminal.'
-            )
+            (result as unknown as OpenTerminalTerminalResponse).data ??
+            (result as unknown as OpenTerminalTerminalData)
+        if (typeof data.id !== 'string') {
+            throw new Error('Failed to create terminal.')
         }
 
-        const run = createOpenTerminalPoller(
-            this.ctx,
-            (pathname) => this.url(pathname),
-            this.headers(),
-            data
-        )
         const callbacks = new Set<(data: string) => void>()
-        const url = this.url(`/execute/${run.id}`)
+        const ws = this.ctx.http.ws(
+            toWebSocketUrl(this.url(`/api/terminals/${data.id}`)),
+            {
+                headers: this.headers()
+            }
+        )
         const ctx = this.ctx
-        let buffer = ''
+        const deleteUrl = this.url(`/api/terminals/${data.id}`)
+        const requestHeaders = this.headers()
+        let closed = false
+        const queue: Buffer[] = []
         this._cwd = cwd
 
-        const output = formatOpenTerminalOutput(data?.output ?? data)
-        buffer = `${output.stdout}${output.stderr}`
+        const open = new Promise<void>((resolve, reject) => {
+            ws.addEventListener('open', () => {
+                const token = this.resolveSecret(this.cfg.apiKey)
+                if (token) {
+                    ws.send(
+                        JSON.stringify({
+                            type: 'auth',
+                            token
+                        })
+                    )
+                }
+                ws.send(Buffer.from(`cd ${quoteShell(cwd)}\n`, 'utf8'))
+                for (const item of queue) {
+                    ws.send(item)
+                }
+                queue.length = 0
+                resolve()
+            })
+            ws.addEventListener('error', reject)
+        })
 
-        const emit = (data: string) => {
-            if (!data) {
+        ws.addEventListener('message', (event) => {
+            const chunk = event.data
+            if (typeof chunk === 'string') {
                 return
             }
 
-            if (callbacks.size < 1) {
-                buffer += data
+            const text =
+                chunk instanceof Blob
+                    ? ''
+                    : Array.isArray(chunk)
+                      ? Buffer.concat(chunk).toString('utf8')
+                      : Buffer.from(chunk).toString('utf8')
+            if (!text) {
                 return
             }
-
             for (const callback of callbacks) {
-                callback(data)
+                callback(text)
             }
-        }
-        run.start(emit)
+        })
+
+        ws.addEventListener('close', () => {
+            closed = true
+            callbacks.clear()
+        })
+
+        await open
 
         return {
-            id: run.id,
+            id: data.id,
             async onData(callback) {
                 callbacks.add(callback)
-                if (buffer) {
-                    callback(buffer)
-                    buffer = ''
-                }
                 return () => {
                     callbacks.delete(callback)
                 }
             },
             async sendInput(data) {
-                await ctx.http.post(
-                    `${url}/input`,
-                    {
-                        input: data
-                    },
-                    {
-                        headers
-                    }
+                if (closed) {
+                    return
+                }
+                const text = Buffer.from(data, 'utf8')
+                if (ws.readyState === 1) {
+                    ws.send(text)
+                    return
+                }
+                queue.push(text)
+            },
+            async resize(cols, rows) {
+                if (closed || ws.readyState !== 1) {
+                    return
+                }
+                ws.send(
+                    JSON.stringify({
+                        type: 'resize',
+                        cols,
+                        rows
+                    })
                 )
             },
-            async resize(_cols, _rows) {},
             async kill() {
-                await run.kill()
+                if (!closed) {
+                    ws.close()
+                    closed = true
+                }
+                await ctx.http
+                    .delete(deleteUrl, {
+                        headers: requestHeaders
+                    })
+                    .catch(() => undefined)
             }
         } satisfies TerminalHandle
     }
@@ -652,6 +683,16 @@ type OpenTerminalData = {
 
 type OpenTerminalResponse = {
     data?: OpenTerminalData
+}
+
+type OpenTerminalTerminalData = {
+    id?: string
+    created_at?: string
+    pid?: number
+}
+
+type OpenTerminalTerminalResponse = {
+    data?: OpenTerminalTerminalData
 }
 
 function createOpenTerminalPoller(
@@ -786,6 +827,16 @@ function createOpenTerminalPoller(
 
 function ensureTrailingSlash(url: string) {
     return url.endsWith('/') ? url : `${url}/`
+}
+
+function toWebSocketUrl(url: string) {
+    if (url.startsWith('https://')) {
+        return `wss://${url.slice('https://'.length)}`
+    }
+    if (url.startsWith('http://')) {
+        return `ws://${url.slice('http://'.length)}`
+    }
+    return url
 }
 
 function joinPath(dir: string, path: string) {

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -810,18 +810,7 @@ function formatOpenTerminalOutput(output: unknown): {
 
     if (output && typeof output === 'object' && !Array.isArray(output)) {
         const row = output as Record<string, unknown>
-        const direct =
-            typeof row.data === 'string'
-                ? row.data
-                : typeof row.text === 'string'
-                  ? row.text
-                  : typeof row.message === 'string'
-                    ? row.message
-                    : typeof row.output === 'string'
-                      ? row.output
-                      : typeof row.content === 'string'
-                        ? row.content
-                        : ''
+        const direct = readOpenTerminalRow(row)
         const stdout = typeof row.stdout === 'string' ? row.stdout : direct
         const stderr = typeof row.stderr === 'string' ? row.stderr : ''
         return { stdout, stderr }
@@ -841,18 +830,7 @@ function formatOpenTerminalOutput(output: unknown): {
         }
 
         const row = item as Record<string, unknown>
-        const data =
-            typeof row.data === 'string'
-                ? row.data
-                : typeof row.text === 'string'
-                  ? row.text
-                  : typeof row.message === 'string'
-                    ? row.message
-                    : typeof row.output === 'string'
-                      ? row.output
-                      : typeof row.content === 'string'
-                        ? row.content
-                        : ''
+        const data = readOpenTerminalRow(row)
         if (!data) {
             continue
         }
@@ -870,6 +848,20 @@ function formatOpenTerminalOutput(output: unknown): {
         stdout: stdout.join(''),
         stderr: stderr.join('')
     }
+}
+
+function readOpenTerminalRow(row: Record<string, unknown>) {
+    return typeof row.data === 'string'
+        ? row.data
+        : typeof row.text === 'string'
+          ? row.text
+          : typeof row.message === 'string'
+            ? row.message
+            : typeof row.output === 'string'
+              ? row.output
+              : typeof row.content === 'string'
+                ? row.content
+                : ''
 }
 
 async function readOpenTerminalAsset(stream: Readable) {

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -851,17 +851,22 @@ function formatOpenTerminalOutput(output: unknown): {
 }
 
 function readOpenTerminalRow(row: Record<string, unknown>) {
-    return typeof row.data === 'string'
-        ? row.data
-        : typeof row.text === 'string'
-          ? row.text
-          : typeof row.message === 'string'
-            ? row.message
-            : typeof row.output === 'string'
-              ? row.output
-              : typeof row.content === 'string'
-                ? row.content
-                : ''
+    if (typeof row.data === 'string') {
+        return row.data
+    }
+    if (typeof row.text === 'string') {
+        return row.text
+    }
+    if (typeof row.message === 'string') {
+        return row.message
+    }
+    if (typeof row.output === 'string') {
+        return row.output
+    }
+    if (typeof row.content === 'string') {
+        return row.content
+    }
+    return ''
 }
 
 async function readOpenTerminalAsset(stream: Readable) {

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -535,14 +535,16 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
 
         ws.addEventListener('message', (event) => {
             const chunk = event.data
-            const text =
-                typeof chunk === 'string'
-                    ? chunk
-                    : chunk instanceof Blob
-                      ? ''
-                    : Array.isArray(chunk)
-                      ? Buffer.concat(chunk).toString('utf8')
-                      : Buffer.from(chunk).toString('utf8')
+            let text = ''
+            if (typeof chunk === 'string') {
+                text = chunk
+            } else if (chunk instanceof Blob) {
+                text = ''
+            } else if (Array.isArray(chunk)) {
+                text = Buffer.concat(chunk).toString('utf8')
+            } else {
+                text = Buffer.from(chunk).toString('utf8')
+            }
             if (!text) {
                 return
             }

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -64,7 +64,9 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 }
             }
         )
-        const currentData = (current as any).data ?? current
+        const currentData =
+            (current as unknown as OpenTerminalResponse).data ??
+            (current as unknown as OpenTerminalData)
         const output = formatOpenTerminalOutput(
             currentData?.output ?? currentData
         )
@@ -385,7 +387,9 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         )
 
         this._cwd = cwd
-        const data = (result as any).data ?? result
+        const data =
+            (result as unknown as OpenTerminalResponse).data ??
+            (result as unknown as OpenTerminalData)
 
         if (data?.status !== 'running') {
             const output = formatOpenTerminalOutput(data?.output ?? data)
@@ -481,7 +485,9 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
             }
         )
 
-        const data = (result as any).data ?? result
+        const data =
+            (result as unknown as OpenTerminalResponse).data ??
+            (result as unknown as OpenTerminalData)
 
         if (typeof data?.id !== 'string') {
             const output = formatOpenTerminalOutput(data?.output ?? data)
@@ -644,6 +650,10 @@ type OpenTerminalData = {
     signal?: string
 }
 
+type OpenTerminalResponse = {
+    data?: OpenTerminalData
+}
+
 function createOpenTerminalPoller(
     ctx: Context,
     url: (pathname: string) => string,
@@ -679,7 +689,9 @@ function createOpenTerminalPoller(
             }
         })
 
-        data = (status as any).data ?? status
+        data =
+            (status as unknown as OpenTerminalResponse).data ??
+            (status as unknown as OpenTerminalData)
         if (typeof data.next_offset === 'number') {
             nextOffset = data.next_offset
         }

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -492,8 +492,6 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         const deleteUrl = this.url(`/api/terminals/${data.id}`)
         const requestHeaders = this.headers()
         let closed = false
-        const queue: Buffer[] = []
-        this._cwd = cwd
 
         const open = new Promise<void>((resolve, reject) => {
             let settled = false
@@ -519,10 +517,6 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                     )
                 }
                 ws.send(Buffer.from(`cd ${quoteShell(cwd)}\n`, 'utf8'))
-                for (const item of queue) {
-                    ws.send(item)
-                }
-                queue.length = 0
                 resolve()
             })
             ws.addEventListener('error', () => {
@@ -559,6 +553,7 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         })
 
         await open
+        this._cwd = cwd
 
         return {
             id: data.id,
@@ -569,15 +564,11 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 }
             },
             async sendInput(data) {
-                if (closed) {
+                if (closed || ws.readyState !== 1) {
                     return
                 }
                 const text = Buffer.from(data, 'utf8')
-                if (ws.readyState === 1) {
-                    ws.send(text)
-                    return
-                }
-                queue.push(text)
+                ws.send(text)
             },
             async resize(cols, rows) {
                 if (closed || ws.readyState !== 1) {
@@ -879,8 +870,20 @@ function formatOpenTerminalOutput(output: unknown): {
     if (output && typeof output === 'object' && !Array.isArray(output)) {
         const row = output as Record<string, unknown>
         const direct = readOpenTerminalRow(row)
-        const stdout = typeof row.stdout === 'string' ? row.stdout : direct
-        const stderr = typeof row.stderr === 'string' ? row.stderr : ''
+        const type = typeof row.type === 'string' ? row.type.toLowerCase() : ''
+        const isErr = type.includes('stderr') || type.includes('error')
+        let stdout = direct
+        let stderr = ''
+        if (typeof row.stdout === 'string') {
+            stdout = row.stdout
+        } else if (isErr) {
+            stdout = ''
+        }
+        if (typeof row.stderr === 'string') {
+            stderr = row.stderr
+        } else if (isErr) {
+            stderr = direct
+        }
         return { stdout, stderr }
     }
 

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -496,7 +496,19 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         this._cwd = cwd
 
         const open = new Promise<void>((resolve, reject) => {
+            let settled = false
+            const fail = (reason: string) => {
+                if (settled) {
+                    return
+                }
+                settled = true
+                reject(new Error(reason))
+            }
             ws.addEventListener('open', () => {
+                if (settled) {
+                    return
+                }
+                settled = true
                 const token = this.resolveSecret(this.cfg.apiKey)
                 if (token) {
                     ws.send(
@@ -513,18 +525,21 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 queue.length = 0
                 resolve()
             })
-            ws.addEventListener('error', reject)
+            ws.addEventListener('error', () => {
+                fail('Failed to open terminal websocket.')
+            })
+            ws.addEventListener('close', () => {
+                fail('Terminal websocket closed before ready.')
+            })
         })
 
         ws.addEventListener('message', (event) => {
             const chunk = event.data
-            if (typeof chunk === 'string') {
-                return
-            }
-
             const text =
-                chunk instanceof Blob
-                    ? ''
+                typeof chunk === 'string'
+                    ? chunk
+                    : chunk instanceof Blob
+                      ? ''
                     : Array.isArray(chunk)
                       ? Buffer.concat(chunk).toString('utf8')
                       : Buffer.from(chunk).toString('utf8')

--- a/packages/extension-agent/src/computer/backends/open_terminal.ts
+++ b/packages/extension-agent/src/computer/backends/open_terminal.ts
@@ -6,7 +6,7 @@ import { posix } from 'path'
 import { Readable } from 'node:stream'
 import { Context } from 'koishi'
 import mimeTypes from 'mime-types'
-import { buildPosixBackgroundCommand, quoteShell } from './types'
+import { quoteShell } from './types'
 import { OpenTerminalBackendConfig } from '../../types'
 import {
     ComputerSessionApi,
@@ -49,43 +49,27 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
             throw new Error('open-terminal baseUrl is empty.')
         }
 
-        const current = await this.ctx.http.post(
-            this.url('/execute'),
-            {
-                command: 'pwd'
-            },
-            {
-                params: {
-                    wait: 5
-                },
-                headers: {
-                    ...this.headers(),
-                    'content-type': 'application/json'
-                }
-            }
+        const current = readOpenTerminalData<OpenTerminalCwdData>(
+            await this.ctx.http(this.url('/files/cwd'), {
+                method: 'GET',
+                headers: this.headers()
+            })
         )
-        const currentData =
-            (current as unknown as OpenTerminalResponse).data ??
-            (current as unknown as OpenTerminalData)
-        const output = formatOpenTerminalOutput(
-            currentData?.output ?? currentData
-        )
-        const root = output.stdout.trim() || '/'
+        const root = current.cwd || '/'
         this._home = root
 
         if (this.options.cwd) {
             try {
-                const result = await this.ctx.http(this.url('/files/list'), {
-                    method: 'GET',
-                    headers: this.headers(),
-                    params: {
-                        directory: this.options.cwd
-                    }
-                })
-                this._root =
-                    typeof result.data?.dir === 'string'
-                        ? result.data.dir
-                        : this.options.cwd
+                const result = readOpenTerminalData<OpenTerminalListData>(
+                    await this.ctx.http(this.url('/files/list'), {
+                        method: 'GET',
+                        headers: this.headers(),
+                        params: {
+                            directory: this.options.cwd
+                        }
+                    })
+                )
+                this._root = result.dir || this.options.cwd
                 this._cwd = this._root
             } catch {
                 this._root = root
@@ -198,7 +182,9 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 )
                 if (result.exitCode !== 0) {
                     throw new Error(
-                        result.stderr || `Failed to write ${filePath}`
+                        result.stderr ||
+                            result.stdout ||
+                            `Failed to write ${filePath}`
                     )
                 }
             } finally {
@@ -366,60 +352,148 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
     }
 
     async execute(command: string, options: ExecuteOptions = {}) {
-        const cwd = options.workdir || this._cwd
-        const headers = {
-            ...this.headers(),
-            'content-type': 'application/json'
+        const cwd = this.resolvePath(options.workdir || this._cwd)
+        const term = await openOpenTerminal(this.ctx, {
+            url: (pathname) => this.url(pathname),
+            headers: this.headers(),
+            apiKey: this.resolveSecret(this.cfg.apiKey),
+            cwd,
+            cols: 120,
+            rows: 30
+        })
+        const id = randomUUID().replaceAll('-', '')
+        const start = `__CHATLUNA_OPEN_TERMINAL_START__${id}`
+        const end = `__CHATLUNA_OPEN_TERMINAL_END__${id}`
+        const stdoutPath = `/tmp/chatluna-${id}.stdout`
+        const stderrPath = `/tmp/chatluna-${id}.stderr`
+        const env = options.env
+            ? Object.entries(options.env)
+                  .map(([key, value]) => `export ${key}=${quoteShell(value)}`)
+                  .join('\n')
+            : ''
+        const wrapped = `${env ? `${env}\n` : ''}stty -echo 2>/dev/null
+export PS1=''
+__chatluna_stdout=${quoteShell(stdoutPath)}
+__chatluna_stderr=${quoteShell(stderrPath)}
+rm -f "$__chatluna_stdout" "$__chatluna_stderr"
+: > "$__chatluna_stdout"
+: > "$__chatluna_stderr"
+printf '%s\n' ${quoteShell(start)}
+__chatluna_shell=$(command -v bash || command -v sh)
+"$__chatluna_shell" -lc ${quoteShell(command)} >"$__chatluna_stdout" 2>"$__chatluna_stderr"
+__chatluna_code=$?
+printf '\n${end}:%s\n' "$__chatluna_code"
+exit
+`
+
+        let pending = ''
+        let started = false
+        let exitCode = 1
+        let timedOut = false
+        const timeout = options.timeout ?? 30000
+        let result = { exitCode: 1 }
+
+        try {
+            result = await new Promise<{ exitCode: number }>((resolve) => {
+                let done = false
+                let timer: NodeJS.Timeout | undefined
+                let queue = Promise.resolve()
+
+                const finish = (code: number) => {
+                    if (done) {
+                        return
+                    }
+
+                    done = true
+                    clearTimeout(timer)
+                    resolve({ exitCode: code })
+                }
+
+                const trim = () => {
+                    if (!started) {
+                        const match = pending.match(
+                            new RegExp(
+                                `(?:^|\\r\\n|\\n|\\r)${escapeRegExp(start)}(?:\\r\\n|\\n|\\r)`
+                            )
+                        )
+                        if (!match || match.index == null) {
+                            const size = start.length + 8
+                            if (pending.length > size) {
+                                pending = pending.slice(-size)
+                            }
+                            return
+                        }
+
+                        pending = pending.slice(match.index + match[0].length)
+                        started = true
+                    }
+
+                    const match = pending.match(
+                        new RegExp(
+                            `(?:[\\s\\S]*?)${escapeRegExp(end)}:(-?\\d+)(?:\\r\\n|\\n|\\r)?`
+                        )
+                    )
+                    if (!match) {
+                        const size = end.length + 64
+                        if (pending.length > size) {
+                            pending = pending.slice(-size)
+                        }
+                        return
+                    }
+
+                    exitCode = Number(match[1]) || 0
+                    finish(exitCode)
+                }
+
+                term.ws.addEventListener('message', (event) => {
+                    queue = queue
+                        .then(async () => {
+                            if (done) {
+                                return
+                            }
+
+                            pending += await readOpenTerminalMessage(event.data)
+                            trim()
+                        })
+                        .catch(() => undefined)
+                })
+
+                term.closed.then(async () => {
+                    await queue.catch(() => undefined)
+                    if (!done) {
+                        finish(exitCode)
+                    }
+                })
+
+                if (timeout > 0) {
+                    timer = setTimeout(() => {
+                        trim()
+                        if (done) {
+                            return
+                        }
+
+                        timedOut = true
+                        finish(exitCode)
+                    }, timeout)
+                }
+
+                term.ws.send(Buffer.from(wrapped, 'utf8'))
+            })
+        } finally {
+            await term.kill().catch(() => undefined)
         }
-        const result = await this.ctx.http.post(
-            this.url('/execute'),
-            {
-                command,
-                cwd,
-                env: options.env
-            },
-            {
-                params: {
-                    wait: 1
-                },
-                headers
-            }
-        )
 
         this._cwd = cwd
-        const data =
-            (result as unknown as OpenTerminalResponse).data ??
-            (result as unknown as OpenTerminalData)
-
-        if (data?.status !== 'running') {
-            const output = formatOpenTerminalOutput(data?.output ?? data)
-            return {
-                exitCode: data?.exitCode ?? data?.code ?? data?.exit_code ?? 0,
-                stdout: output.stdout,
-                stderr: output.stderr,
-                signal: data?.signal,
-                timedOut: false
-            }
-        }
-
-        const run = createOpenTerminalPoller(
-            this.ctx,
-            (pathname) => this.url(pathname),
-            this.headers(),
-            data
-        )
-        const waited = await run.wait(options.timeout ?? 30000)
+        const [stdout, stderr] = await Promise.all([
+            this.readFile(stdoutPath).catch(() => ''),
+            this.readFile(stderrPath).catch(() => '')
+        ])
 
         return {
-            exitCode:
-                waited.data?.exitCode ??
-                waited.data?.code ??
-                waited.data?.exit_code ??
-                0,
-            stdout: waited.stdout,
-            stderr: waited.stderr,
-            signal: waited.data?.signal,
-            timedOut: waited.timedOut
+            exitCode: result.exitCode,
+            stdout,
+            stderr,
+            timedOut
         }
     }
 
@@ -466,97 +540,41 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
     }
 
     async createTerminal(options: TerminalOptions = {}) {
-        const cwd = options.cwd || this._cwd
-        const result = await this.ctx.http.post(
-            this.url('/api/terminals'),
-            undefined,
-            {
-                headers: this.headers()
-            }
-        )
-        const data =
-            (result as unknown as OpenTerminalTerminalResponse).data ??
-            (result as unknown as OpenTerminalTerminalData)
-        if (typeof data.id !== 'string') {
-            throw new Error('Failed to create terminal.')
-        }
-
+        const cwd = this.resolvePath(options.cwd || this._cwd)
+        const term = await openOpenTerminal(this.ctx, {
+            url: (pathname) => this.url(pathname),
+            headers: this.headers(),
+            apiKey: this.resolveSecret(this.cfg.apiKey),
+            cwd,
+            cols: options.cols,
+            rows: options.rows
+        })
         const callbacks = new Set<(data: string) => void>()
-        const ws = this.ctx.http.ws(
-            toWebSocketUrl(this.url(`/api/terminals/${data.id}`)),
-            {
-                headers: this.headers()
-            }
-        )
-        const ctx = this.ctx
-        const deleteUrl = this.url(`/api/terminals/${data.id}`)
-        const requestHeaders = this.headers()
         let closed = false
-
-        const open = new Promise<void>((resolve, reject) => {
-            let settled = false
-            const fail = (reason: string) => {
-                if (settled) {
-                    return
-                }
-                settled = true
-                reject(new Error(reason))
-            }
-            ws.addEventListener('open', () => {
-                if (settled) {
-                    return
-                }
-                settled = true
-                const token = this.resolveSecret(this.cfg.apiKey)
-                if (token) {
-                    ws.send(
-                        JSON.stringify({
-                            type: 'auth',
-                            token
-                        })
-                    )
-                }
-                ws.send(Buffer.from(`cd ${quoteShell(cwd)}\n`, 'utf8'))
-                resolve()
-            })
-            ws.addEventListener('error', () => {
-                fail('Failed to open terminal websocket.')
-            })
-            ws.addEventListener('close', () => {
-                fail('Terminal websocket closed before ready.')
-            })
+        let queue = Promise.resolve()
+        term.ws.addEventListener('message', (event) => {
+            queue = queue
+                .then(async () => {
+                    const text = await readOpenTerminalMessage(event.data)
+                    if (!text) {
+                        return
+                    }
+                    for (const callback of callbacks) {
+                        callback(text)
+                    }
+                })
+                .catch(() => undefined)
         })
 
-        ws.addEventListener('message', (event) => {
-            const chunk = event.data
-            let text = ''
-            if (typeof chunk === 'string') {
-                text = chunk
-            } else if (chunk instanceof Blob) {
-                text = ''
-            } else if (Array.isArray(chunk)) {
-                text = Buffer.concat(chunk).toString('utf8')
-            } else {
-                text = Buffer.from(chunk).toString('utf8')
-            }
-            if (!text) {
-                return
-            }
-            for (const callback of callbacks) {
-                callback(text)
-            }
-        })
-
-        ws.addEventListener('close', () => {
+        term.ws.addEventListener('close', () => {
             closed = true
             callbacks.clear()
         })
 
-        await open
         this._cwd = cwd
 
         return {
-            id: data.id,
+            id: term.id,
             async onData(callback) {
                 callbacks.add(callback)
                 return () => {
@@ -564,17 +582,16 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 }
             },
             async sendInput(data) {
-                if (closed || ws.readyState !== 1) {
+                if (closed || term.ws.readyState !== 1) {
                     return
                 }
-                const text = Buffer.from(data, 'utf8')
-                ws.send(text)
+                term.ws.send(Buffer.from(data, 'utf8'))
             },
             async resize(cols, rows) {
-                if (closed || ws.readyState !== 1) {
+                if (closed || term.ws.readyState !== 1) {
                     return
                 }
-                ws.send(
+                term.ws.send(
                     JSON.stringify({
                         type: 'resize',
                         cols,
@@ -583,15 +600,9 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
                 )
             },
             async kill() {
-                if (!closed) {
-                    ws.close()
-                    closed = true
-                }
-                await ctx.http
-                    .delete(deleteUrl, {
-                        headers: requestHeaders
-                    })
-                    .catch(() => undefined)
+                closed = true
+                callbacks.clear()
+                await term.kill()
             }
         } satisfies TerminalHandle
     }
@@ -601,7 +612,11 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
         marker: string,
         _options: ExecuteOptions = {}
     ) {
-        return buildPosixBackgroundCommand(command, marker)
+        return `${command}
+__chatluna_code=$?
+printf '\n${marker}:%s\n' "$__chatluna_code"
+exit
+`
     }
 
     async getDesktopInfo() {
@@ -678,19 +693,16 @@ export class OpenTerminalComputerSession implements ComputerSessionApi {
     }
 }
 
-type OpenTerminalData = {
-    id?: string
-    next_offset?: number
-    output?: unknown
-    status?: string
-    exitCode?: number
-    code?: number
-    exit_code?: number
-    signal?: string
+type OpenTerminalCwdData = {
+    cwd?: string
 }
 
-type OpenTerminalResponse = {
-    data?: OpenTerminalData
+type OpenTerminalListData = {
+    dir?: string
+}
+
+type OpenTerminalEnvelope<T> = {
+    data?: T
 }
 
 type OpenTerminalTerminalData = {
@@ -699,138 +711,123 @@ type OpenTerminalTerminalData = {
     pid?: number
 }
 
-type OpenTerminalTerminalResponse = {
-    data?: OpenTerminalTerminalData
+type OpenTerminalSocket = {
+    id: string
+    ws: ReturnType<Context['http']['ws']>
+    closed: Promise<void>
+    kill(): Promise<void>
 }
 
-function createOpenTerminalPoller(
+async function openOpenTerminal(
     ctx: Context,
-    url: (pathname: string) => string,
-    headers: Record<string, string>,
-    init: OpenTerminalData
+    options: {
+        url: (pathname: string) => string
+        headers: Record<string, string>
+        apiKey: string
+        cwd: string
+        cols?: number
+        rows?: number
+    }
 ) {
-    if (typeof init.id !== 'string') {
-        throw new Error('Failed to start open-terminal command.')
-    }
-
-    const id = init.id
-    let data = init
-    let nextOffset =
-        typeof init.next_offset === 'number'
-            ? init.next_offset
-            : Array.isArray(init.output)
-              ? init.output.length
-              : 0
-    let closed = init.status !== 'running'
-    let timer: NodeJS.Timeout | undefined
-
-    const read = async () => {
-        if (closed) {
-            return data
-        }
-
-        const status = await ctx.http(url(`/execute/${id}/status`), {
-            method: 'GET',
-            headers,
-            params: {
-                wait: 1,
-                offset: nextOffset
-            }
+    const result = readOpenTerminalData<OpenTerminalTerminalData>(
+        await ctx.http.post(options.url('/api/terminals'), undefined, {
+            headers: options.headers
         })
+    )
+    if (typeof result.id !== 'string') {
+        throw new Error('Failed to create terminal.')
+    }
 
-        data =
-            (status as unknown as OpenTerminalResponse).data ??
-            (status as unknown as OpenTerminalData)
-        if (typeof data.next_offset === 'number') {
-            nextOffset = data.next_offset
+    const ws = ctx.http.ws(
+        toWebSocketUrl(options.url(`/api/terminals/${result.id}`)),
+        {
+            headers: options.headers
         }
-        closed = data.status !== 'running'
-        return data
-    }
+    )
+    let resolveClosed: (() => void) | undefined
+    const closed = new Promise<void>((resolve) => {
+        resolveClosed = resolve
+    })
+    ws.addEventListener('close', () => {
+        resolveClosed?.()
+    })
 
-    const kill = async () => {
-        closed = true
-        clearTimeout(timer)
-        await ctx.http
-            .delete(url(`/execute/${id}`), {
-                headers
-            })
-            .catch(() => undefined)
-    }
+    try {
+        await new Promise<void>((resolve, reject) => {
+            let done = false
 
-    return {
-        id,
-        start(onData: (text: string) => void) {
-            const poll = async () => {
-                if (closed) {
+            const fail = (message: string) => {
+                if (done) {
                     return
                 }
 
-                try {
-                    const data = await read()
-                    const output = formatOpenTerminalOutput(data.output ?? data)
-                    onData(`${output.stdout}${output.stderr}`)
-                } catch {
-                    closed = true
-                }
-
-                if (!closed) {
-                    timer = setTimeout(() => {
-                        poll().catch(() => undefined)
-                    }, 0)
-                }
+                done = true
+                reject(new Error(message))
             }
 
-            if (!closed) {
-                timer = setTimeout(() => {
-                    poll().catch(() => undefined)
-                }, 0)
-            }
-        },
-        async wait(timeout: number) {
-            const stdout: string[] = []
-            const stderr: string[] = []
-
-            const append = (data: OpenTerminalData) => {
-                const output = formatOpenTerminalOutput(data.output ?? data)
-                if (output.stdout) {
-                    stdout.push(output.stdout)
-                }
-                if (output.stderr) {
-                    stderr.push(output.stderr)
-                }
-            }
-
-            append(data)
-            const end = Date.now() + Math.max(timeout, 0)
-
-            while (Date.now() < end) {
-                if (closed) {
-                    break
+            ws.addEventListener('open', () => {
+                if (done) {
+                    return
                 }
 
-                append(await read())
-            }
-
-            if (!closed) {
-                await kill()
-                return {
-                    data,
-                    stdout: stdout.join(''),
-                    stderr: stderr.join(''),
-                    timedOut: true
+                done = true
+                if (options.apiKey) {
+                    ws.send(
+                        JSON.stringify({
+                            type: 'auth',
+                            token: options.apiKey
+                        })
+                    )
                 }
-            }
+                if (options.cols != null && options.rows != null) {
+                    ws.send(
+                        JSON.stringify({
+                            type: 'resize',
+                            cols: options.cols,
+                            rows: options.rows
+                        })
+                    )
+                }
+                ws.send(Buffer.from(`cd ${quoteShell(options.cwd)}\n`, 'utf8'))
+                resolve()
+            })
 
-            return {
-                data,
-                stdout: stdout.join(''),
-                stderr: stderr.join(''),
-                timedOut: false
-            }
-        },
-        kill
+            ws.addEventListener('error', () => {
+                fail('Failed to open terminal websocket.')
+            })
+
+            ws.addEventListener('close', () => {
+                fail('Terminal websocket closed before ready.')
+            })
+        })
+    } catch (err) {
+        if (ws.readyState === 0 || ws.readyState === 1) {
+            ws.close()
+        }
+        await ctx.http
+            .delete(options.url(`/api/terminals/${result.id}`), {
+                headers: options.headers
+            })
+            .catch(() => undefined)
+        throw err
     }
+
+    return {
+        id: result.id,
+        ws,
+        closed,
+        async kill() {
+            if (ws.readyState === 0 || ws.readyState === 1) {
+                ws.close()
+            }
+            await ctx.http
+                .delete(options.url(`/api/terminals/${result.id}`), {
+                    headers: options.headers
+                })
+                .catch(() => undefined)
+            await closed.catch(() => undefined)
+        }
+    } satisfies OpenTerminalSocket
 }
 
 function ensureTrailingSlash(url: string) {
@@ -859,85 +856,44 @@ function joinPath(dir: string, path: string) {
     return `${dir.replace(/\/$/, '')}/${path}`
 }
 
-function formatOpenTerminalOutput(output: unknown): {
-    stdout: string
-    stderr: string
-} {
-    if (typeof output === 'string') {
-        return { stdout: output, stderr: '' }
-    }
-
-    if (output && typeof output === 'object' && !Array.isArray(output)) {
-        const row = output as Record<string, unknown>
-        const direct = readOpenTerminalRow(row)
-        const type = typeof row.type === 'string' ? row.type.toLowerCase() : ''
-        const isErr = type.includes('stderr') || type.includes('error')
-        let stdout = direct
-        let stderr = ''
-        if (typeof row.stdout === 'string') {
-            stdout = row.stdout
-        } else if (isErr) {
-            stdout = ''
-        }
-        if (typeof row.stderr === 'string') {
-            stderr = row.stderr
-        } else if (isErr) {
-            stderr = direct
-        }
-        return { stdout, stderr }
-    }
-
-    const stdout: string[] = []
-    const stderr: string[] = []
-
-    if (!Array.isArray(output)) {
-        return { stdout: '', stderr: '' }
-    }
-
-    for (const item of output) {
-        if (typeof item === 'string') {
-            stdout.push(item)
-            continue
-        }
-
-        const row = item as Record<string, unknown>
-        const data = readOpenTerminalRow(row)
-        if (!data) {
-            continue
-        }
-
-        const type = typeof row.type === 'string' ? row.type.toLowerCase() : ''
-        if (type.includes('stderr') || type.includes('error')) {
-            stderr.push(data)
-            continue
-        }
-
-        stdout.push(data)
-    }
-
-    return {
-        stdout: stdout.join(''),
-        stderr: stderr.join('')
-    }
+function readOpenTerminalData<T>(value: unknown) {
+    return ((value as OpenTerminalEnvelope<T>).data ?? value) as T
 }
 
-function readOpenTerminalRow(row: Record<string, unknown>) {
-    if (typeof row.data === 'string') {
-        return row.data
+async function readOpenTerminalMessage(value: unknown) {
+    if (typeof value === 'string') {
+        return value
     }
-    if (typeof row.text === 'string') {
-        return row.text
+
+    if (value instanceof Blob) {
+        return Buffer.from(await value.arrayBuffer()).toString('utf8')
     }
-    if (typeof row.message === 'string') {
-        return row.message
+
+    if (Array.isArray(value)) {
+        return Buffer.concat(
+            value.map((item) =>
+                Buffer.isBuffer(item) ? item : Buffer.from(item)
+            )
+        ).toString('utf8')
     }
-    if (typeof row.output === 'string') {
-        return row.output
+
+    if (ArrayBuffer.isView(value)) {
+        return Buffer.from(
+            value.buffer,
+            value.byteOffset,
+            value.byteLength
+        ).toString('utf8')
     }
-    if (typeof row.content === 'string') {
-        return row.content
+
+    if (value instanceof ArrayBuffer) {
+        return Buffer.from(value).toString('utf8')
     }
+
     return ''
+}
+
+function escapeRegExp(value: string) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }
 
 async function readOpenTerminalAsset(stream: Readable) {

--- a/packages/extension-agent/src/computer/tools/bash.ts
+++ b/packages/extension-agent/src/computer/tools/bash.ts
@@ -19,7 +19,9 @@ Rules:
 - Absolute paths outside the scope path are blocked
 - Certain high-risk commands require explicit user confirmation
 - Commands in the blocked list are always rejected
-- If a command may take a while, keep running, or exceed the normal timeout, prefer background=true and query it later yourself
+- Default to foreground execution. In 99% of cases you should NOT use background=true.
+- Use background=true only when it is truly necessary for a long-lived process that must keep running after the tool returns, such as starting a server.
+- Builds, tests, scripts, package installs, one-off migrations, and most long commands should still run in the foreground, even if they take a while.
 - Do not use this tool for agentcli commands; there is a dedicated agentcli tool
 
 When to use:
@@ -51,7 +53,7 @@ When to use:
                 .boolean()
                 .optional()
                 .describe(
-                    'Run the command as a managed background job. Commands ending with & are also treated as background jobs automatically.'
+                    'Run the command as a managed background job only when strictly necessary for a long-lived process such as a server. Do not use this in normal cases. Commands ending with & are also treated as background jobs automatically.'
                 ),
             action: z
                 .enum(['run', 'status', 'list', 'kill'])
@@ -185,9 +187,14 @@ When to use:
             })
 
             if (result.timedOut) {
+                const output = await this.formatLargeResult(
+                    computer,
+                    'bash',
+                    formatExecuteResult(result)
+                )
                 return this.withBackend(
                     computer,
-                    `Command timed out after ${timeout}ms.`
+                    `Command timed out after ${timeout}ms.\n${output}`
                 )
             }
 

--- a/packages/extension-agent/src/service/computer.ts
+++ b/packages/extension-agent/src/service/computer.ts
@@ -840,7 +840,11 @@ export class ChatLunaAgentComputerService {
         )
 
         if (result.exitCode !== 0) {
-            throw new Error(result.stderr.trim() || `Failed to remove ${path}`)
+            throw new Error(
+                result.stderr.trim() ||
+                    result.stdout.trim() ||
+                    `Failed to remove ${path}`
+            )
         }
     }
 

--- a/packages/extension-agent/src/sub-agent/run.ts
+++ b/packages/extension-agent/src/sub-agent/run.ts
@@ -105,6 +105,7 @@ export async function runSubAgentTurn(input: RunSubAgentTurnOptions) {
         tools: toolRef.tools,
         prompt: chatPrompt.value,
         agentMode: 'tool-calling',
+        maxIterations: input.info.maxTurns,
         returnIntermediateSteps: false,
         handleParsingErrors: true,
         instructions: computed(() => undefined)

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -63,7 +63,8 @@
     "devDependencies": {
         "@types/micromatch": "^4.0.9",
         "atsc": "^2.1.0",
-        "koishi": "^4.18.9"
+        "koishi": "^4.18.9",
+        "koishi-plugin-adapter-onebot": "^6.8.0"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",

--- a/packages/extension-tools/src/config.ts
+++ b/packages/extension-tools/src/config.ts
@@ -14,6 +14,9 @@ export interface Config extends ChatLunaPlugin.Config {
     group: boolean
     groupScopeSelector: string[]
     groupWhitelist: string[]
+    fileSender: boolean
+    fileSenderToolName: string
+    fileSenderTimeout: number
     command: boolean
     commandWithSend: boolean
     commandAutoExecute: boolean
@@ -54,7 +57,8 @@ export const Config: Schema<Config> = Schema.intersect([
         cron: Schema.boolean().default(true)
     }),
     Schema.object({
-        group: Schema.boolean().default(false)
+        group: Schema.boolean().default(false),
+        fileSender: Schema.boolean().default(false)
     }),
 
     Schema.union([
@@ -118,6 +122,14 @@ export const Config: Schema<Config> = Schema.intersect([
             group: Schema.const(true).required(),
             groupScopeSelector: Schema.array(Schema.string()),
             groupWhitelist: Schema.array(Schema.string()).default([])
+        }),
+        Schema.object({})
+    ]),
+    Schema.union([
+        Schema.object({
+            fileSender: Schema.const(true).required(),
+            fileSenderToolName: Schema.string().default('send_file'),
+            fileSenderTimeout: Schema.number().min(1).max(300).default(30)
         }),
         Schema.object({})
     ]),

--- a/packages/extension-tools/src/locales/en-US.schema.yml
+++ b/packages/extension-tools/src/locales/en-US.schema.yml
@@ -16,6 +16,7 @@ $inner:
       cron: 'Enable scheduled reminders. '
     - $desc: 'Extended Services Features'
       group: 'Enable group management plugin'
+      fileSender: 'Enable file sender plugin and inject send_file tool for main plugin'
       knowledge: 'Enable knowledge base plugin calls'
 
     - - $desc: 'Request Plugin Configuration'
@@ -44,6 +45,10 @@ $inner:
             $desc: 'Member IDs allowed to use group management functions'
         groupWhitelist:
             $desc: 'Group ID whitelist for using group management functions. Available in all groups when empty.'
+
+    - - $desc: 'File Sender Plugin Configuration'
+        fileSenderToolName: 'Native file tool name (default: send_file).'
+        fileSenderTimeout: 'File upload request timeout in seconds.'
 
     - - $desc: 'Cron Task Plugin Configuration'
         cronScopeSelector:

--- a/packages/extension-tools/src/locales/zh-CN.schema.yml
+++ b/packages/extension-tools/src/locales/zh-CN.schema.yml
@@ -14,6 +14,7 @@ $inner:
       codeSandbox: 启用 Python 代码执行功能。(需要申请 API)
     - $desc: 扩展服务功能
       group: 启用群管插件，提供群管理能力。
+      fileSender: 启用文件发送插件，向主插件注入 send_file 工具。
       knowledge: 启用知识库插件调用功能。(需要安装知识库插件)
 
     - - $desc: request 插件配置
@@ -42,6 +43,10 @@ $inner:
             $desc: 允许使用群管功能的成员 ID 列表。
         groupWhitelist:
             $desc: 允许使用群管功能的群 ID 白名单。为空时在所有群可用。
+
+    - - $desc: 文件发送插件配置
+        fileSenderToolName: 原生文件发送工具名（默认 send_file）。
+        fileSenderTimeout: 文件上传请求超时（秒）。
 
     - - $desc: 定时任务插件配置
         cronScopeSelector:

--- a/packages/extension-tools/src/plugin.ts
+++ b/packages/extension-tools/src/plugin.ts
@@ -4,6 +4,7 @@ import { Config } from '.'
 // import start
 import { apply as command } from './plugins/command'
 import { apply as cron } from './plugins/cron'
+import { apply as file_sender } from './plugins/file_sender'
 import { apply as group } from './plugins/group'
 import { apply as music } from './plugins/music'
 import { apply as request } from './plugins/request'
@@ -23,7 +24,7 @@ export async function plugin(
 
     const middlewares: Plugin[] =
         // middleware start
-        [command, cron, group, music, request, think, todos] // middleware end
+        [command, cron, file_sender, group, music, request, think, todos] // middleware end
 
     for (const middleware of middlewares) {
         await middleware(ctx, config, plugin)

--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -273,7 +273,7 @@ class SendFileTool extends StructuredTool {
     description = `发送 OneBot 文件消息，自动按当前会话上下文决定群聊或私聊。
 
 参数：
-- file: 单文件地址（URL、file://、base64://）
+- file: 单文件地址（http/https URL、base64://）
 - name: 单文件名称（可选）
 - files: 多文件列表，支持字符串或 { file, name }
 

--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -14,10 +14,8 @@ export async function apply(
         return
     }
 
-    const tool = new SendFileTool(config)
-
     plugin.registerTool(config.fileSenderToolName, {
-        description: tool.description,
+        description: new SendFileTool(config).description,
         selector() {
             return true
         },
@@ -65,21 +63,40 @@ type OneBotInternal = {
 class SendFileTool extends StructuredTool {
     name = 'send_file'
 
-    schema = z.object({
-        file: z.string().min(1).optional(),
-        name: z.string().optional(),
-        files: z
-            .array(
-                z.union([
-                    z.string(),
-                    z.object({
-                        file: z.string().min(1),
-                        name: z.string().optional()
-                    })
-                ])
-            )
-            .optional()
-    })
+    schema = z
+        .object({
+            file: z.string().min(1).optional(),
+            name: z.string().optional(),
+            files: z
+                .array(
+                    z.union([
+                        z.string(),
+                        z.object({
+                            file: z.string().min(1),
+                            name: z.string().optional()
+                        })
+                    ])
+                )
+                .optional()
+        })
+        .superRefine((input, ctx) => {
+            const hasFile = Boolean(input.file?.trim())
+            const hasFiles =
+                Array.isArray(input.files) && input.files.length > 0
+            if (!hasFile && !hasFiles) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: "'file' 或 'files' 至少提供一个。"
+                })
+                return
+            }
+            if (hasFile && hasFiles) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: "'file' 与 'files' 不能同时提供。"
+                })
+            }
+        })
 
     constructor(private config: Config) {
         super({})

--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -27,6 +27,32 @@ export async function apply(
     })
 }
 
+type OneBotResponse = {
+    file_id?: string
+    data?: {
+        file_id?: string
+    }
+}
+
+type OneBotInternal = {
+    _get?: (
+        action: string,
+        params: Record<string, unknown>
+    ) => Promise<OneBotResponse>
+    request?: (
+        action: string,
+        params: Record<string, unknown>
+    ) => Promise<OneBotResponse>
+    callAction?: (
+        action: string,
+        params: Record<string, unknown>
+    ) => Promise<OneBotResponse>
+    sendAction?: (
+        action: string,
+        params: Record<string, unknown>
+    ) => Promise<OneBotResponse>
+}
+
 class SendFileTool extends StructuredTool {
     name = 'send_file'
 
@@ -69,7 +95,7 @@ class SendFileTool extends StructuredTool {
             return '当前仅支持 OneBot 会话。'
         }
 
-        const internal = (session.bot as any).internal
+        const internal = (session.bot as { internal?: OneBotInternal }).internal
         if (!internal) {
             return '缺少 OneBot internal API 实例。'
         }
@@ -119,7 +145,7 @@ class SendFileTool extends StructuredTool {
         }[] = []
 
         for (const item of queue) {
-            let file = item.file
+            const file = item.file
 
             if (session.isDirect) {
                 const data = await requestOnebot(
@@ -215,9 +241,9 @@ function getName(file: string, name?: string) {
 }
 
 async function requestOnebot(
-    internal: any,
+    internal: OneBotInternal,
     action: string,
-    params: Record<string, any>,
+    params: Record<string, unknown>,
     timeoutSeconds: number
 ) {
     const timeoutMs = timeoutSeconds * 1000
@@ -241,9 +267,9 @@ async function requestOnebot(
         )
     }
 
-    return await Promise.race([
+    return await Promise.race<OneBotResponse>([
         run(),
-        new Promise((_, reject) => {
+        new Promise<OneBotResponse>((_resolve, reject) => {
             setTimeout(() => {
                 reject(new Error(`${action} 请求超时，已超过 ${timeoutMs}ms。`))
             }, timeoutMs)

--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -184,7 +184,7 @@ class SendFileTool extends StructuredTool {
                     targetId: String(
                         session.isDirect
                             ? session.userId
-                            : session.guildId ?? session.channelId
+                            : (session.guildId ?? session.channelId)
                     ),
                     error: validateError
                 })

--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -34,6 +34,15 @@ type OneBotResponse = {
     }
 }
 
+type SendFileResult = {
+    file: string
+    name: string
+    fileId: string
+    targetType: 'group' | 'private'
+    targetId: string
+    error?: string
+}
+
 type OneBotInternal = {
     _get?: (
         action: string,
@@ -136,23 +145,50 @@ class SendFileTool extends StructuredTool {
             return '没有可上传的文件。'
         }
 
-        const result: {
-            file: string
-            name: string
-            fileId: string
-            targetType: 'group' | 'private'
-            targetId: string
-        }[] = []
+        const result: SendFileResult[] = []
 
         for (const item of queue) {
             const file = item.file
 
             if (session.isDirect) {
+                try {
+                    const data = await requestOnebot(
+                        internal,
+                        'upload_private_file',
+                        {
+                            user_id: Number(session.userId),
+                            file,
+                            name: item.name
+                        },
+                        this.config.fileSenderTimeout
+                    )
+
+                    result.push({
+                        file: item.file,
+                        name: item.name,
+                        fileId: getFileId(data, item.file),
+                        targetType: 'private',
+                        targetId: String(session.userId)
+                    })
+                } catch (err) {
+                    result.push({
+                        file: item.file,
+                        name: item.name,
+                        fileId: '',
+                        targetType: 'private',
+                        targetId: String(session.userId),
+                        error: String(err)
+                    })
+                }
+                continue
+            }
+
+            try {
                 const data = await requestOnebot(
                     internal,
-                    'upload_private_file',
+                    'upload_group_file',
                     {
-                        user_id: Number(session.userId),
+                        group_id: Number(session.guildId ?? session.channelId),
                         file,
                         name: item.name
                     },
@@ -162,36 +198,20 @@ class SendFileTool extends StructuredTool {
                 result.push({
                     file: item.file,
                     name: item.name,
-                    fileId:
-                        String(
-                            data?.file_id ?? data?.data?.file_id ?? ''
-                        ).trim() || item.file,
-                    targetType: 'private',
-                    targetId: String(session.userId)
+                    fileId: getFileId(data, item.file),
+                    targetType: 'group',
+                    targetId: String(session.guildId ?? session.channelId)
                 })
-                continue
+            } catch (err) {
+                result.push({
+                    file: item.file,
+                    name: item.name,
+                    fileId: '',
+                    targetType: 'group',
+                    targetId: String(session.guildId ?? session.channelId),
+                    error: String(err)
+                })
             }
-
-            const data = await requestOnebot(
-                internal,
-                'upload_group_file',
-                {
-                    group_id: Number(session.guildId ?? session.channelId),
-                    file,
-                    name: item.name
-                },
-                this.config.fileSenderTimeout
-            )
-
-            result.push({
-                file: item.file,
-                name: item.name,
-                fileId:
-                    String(data?.file_id ?? data?.data?.file_id ?? '').trim() ||
-                    item.file,
-                targetType: 'group',
-                targetId: String(session.guildId ?? session.channelId)
-            })
         }
 
         return JSON.stringify(
@@ -240,6 +260,10 @@ function getName(file: string, name?: string) {
     return 'file'
 }
 
+function getFileId(data: OneBotResponse, fallback: string) {
+    return String(data?.file_id ?? data?.data?.file_id ?? '').trim() || fallback
+}
+
 async function requestOnebot(
     internal: OneBotInternal,
     action: string,
@@ -267,8 +291,9 @@ async function requestOnebot(
         )
     }
 
+    const task = run()
     return await Promise.race<OneBotResponse>([
-        run(),
+        task,
         new Promise<OneBotResponse>((_resolve, reject) => {
             setTimeout(() => {
                 reject(new Error(`${action} 请求超时，已超过 ${timeoutMs}ms。`))

--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -26,10 +26,15 @@ export async function apply(
 }
 
 type OneBotResponse = {
+    status?: 'ok' | 'failed'
+    retcode?: number
     file_id?: string
     data?: {
         file_id?: string
     }
+    message?: string
+    wording?: string
+    stream?: string
 }
 
 type SendFileResult = {
@@ -183,7 +188,9 @@ class SendFileTool extends StructuredTool {
                     result.push({
                         file: item.file,
                         name: item.name,
-                        fileId: getFileId(data, item.file),
+                        fileId: String(
+                            data.data?.file_id || data.file_id || ''
+                        ).trim(),
                         targetType: 'private',
                         targetId: String(session.userId)
                     })
@@ -215,7 +222,9 @@ class SendFileTool extends StructuredTool {
                 result.push({
                     file: item.file,
                     name: item.name,
-                    fileId: getFileId(data, item.file),
+                    fileId: String(
+                        data.data?.file_id || data.file_id || ''
+                    ).trim(),
                     targetType: 'group',
                     targetId: String(session.guildId ?? session.channelId)
                 })
@@ -277,10 +286,6 @@ function getName(file: string, name?: string) {
     return 'file'
 }
 
-function getFileId(data: OneBotResponse, fallback: string) {
-    return String(data?.file_id ?? data?.data?.file_id ?? '').trim() || fallback
-}
-
 async function requestOnebot(
     internal: OneBotInternal,
     action: string,
@@ -308,13 +313,25 @@ async function requestOnebot(
         )
     }
 
-    const task = run()
-    return await Promise.race<OneBotResponse>([
-        task,
-        new Promise<OneBotResponse>((_resolve, reject) => {
-            setTimeout(() => {
-                reject(new Error(`${action} 请求超时，已超过 ${timeoutMs}ms。`))
-            }, timeoutMs)
-        })
-    ])
+    return await new Promise<OneBotResponse>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            reject(new Error(`${action} 请求超时，已超过 ${timeoutMs}ms。`))
+        }, timeoutMs)
+
+        run()
+            .then((data) => {
+                if (data.status && data.status !== 'ok') {
+                    const msg = data.wording || data.message || 'unknown error'
+                    reject(new Error(`${action} 请求失败：${msg}`))
+                    return
+                }
+                resolve(data)
+            })
+            .catch((err) => {
+                reject(err)
+            })
+            .finally(() => {
+                clearTimeout(timer)
+            })
+    })
 }

--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -1,9 +1,10 @@
 import { StructuredTool } from '@langchain/core/tools'
 import { z } from 'zod'
-import { Context } from 'koishi'
+import { Context, h } from 'koishi'
 import { ChatLunaToolRunnable } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Config } from '..'
+import type { OneBotBot } from 'koishi-plugin-adapter-onebot'
 
 export async function apply(
     _ctx: Context,
@@ -27,47 +28,6 @@ export async function apply(
         }
     })
 }
-
-type OneBotResponse = {
-    status?: 'ok' | 'failed'
-    retcode?: number
-    file_id?: string
-    data?: {
-        file_id?: string
-    }
-    message?: string
-    wording?: string
-    stream?: string
-}
-
-type SendFileResult = {
-    file: string
-    name: string
-    fileId: string
-    targetType: 'group' | 'private'
-    targetId: string
-    error?: string
-}
-
-type OneBotInternal = {
-    _get?: (
-        action: string,
-        params: Record<string, unknown>
-    ) => Promise<OneBotResponse>
-    request?: (
-        action: string,
-        params: Record<string, unknown>
-    ) => Promise<OneBotResponse>
-    callAction?: (
-        action: string,
-        params: Record<string, unknown>
-    ) => Promise<OneBotResponse>
-    sendAction?: (
-        action: string,
-        params: Record<string, unknown>
-    ) => Promise<OneBotResponse>
-}
-
 class SendFileTool extends StructuredTool {
     name = 'send_file'
 
@@ -125,15 +85,6 @@ class SendFileTool extends StructuredTool {
             return 'QQ 官方 Bot 已禁用 send_file。'
         }
 
-        if (session.platform !== 'onebot') {
-            return '当前仅支持 OneBot 会话。'
-        }
-
-        const internal = (session.bot as { internal?: OneBotInternal }).internal
-        if (!internal) {
-            return '缺少 OneBot internal API 实例。'
-        }
-
         const queue: { file: string; name: string }[] = []
 
         if (Array.isArray(input.files) && input.files.length > 0) {
@@ -170,90 +121,77 @@ class SendFileTool extends StructuredTool {
             return '没有可上传的文件。'
         }
 
+        if (session.platform !== 'onebot') {
+            return '当前仅支持 OneBot 会话。'
+        }
+
         const result: SendFileResult[] = []
+
+        const type = session.isDirect ? 'private' : 'group'
+        const target = session.isDirect
+            ? session.userId
+            : (session.guildId ?? session.channelId)
+        const onebotAction = session.isDirect
+            ? 'upload_private_file'
+            : 'upload_group_file'
 
         for (const item of queue) {
             const file = item.file
-            const validateError = validateFile(file)
-            if (validateError) {
+            const error = validateFile(file)
+            if (error) {
                 result.push({
-                    file: item.file,
+                    file,
                     name: item.name,
                     fileId: '',
-                    targetType: session.isDirect ? 'private' : 'group',
-                    targetId: String(
-                        session.isDirect
-                            ? session.userId
-                            : (session.guildId ?? session.channelId)
-                    ),
-                    error: validateError
+                    targetType: type,
+                    targetId: String(target),
+                    error
                 })
-                continue
-            }
-
-            if (session.isDirect) {
-                try {
-                    const data = await requestOnebot(
-                        internal,
-                        'upload_private_file',
-                        {
-                            user_id: Number(session.userId),
-                            file,
-                            name: item.name
-                        },
-                        this.config.fileSenderTimeout
-                    )
-
-                    result.push({
-                        file: item.file,
-                        name: item.name,
-                        fileId: String(
-                            data.data?.file_id || data.file_id || ''
-                        ).trim(),
-                        targetType: 'private',
-                        targetId: String(session.userId)
-                    })
-                } catch (err) {
-                    result.push({
-                        file: item.file,
-                        name: item.name,
-                        fileId: '',
-                        targetType: 'private',
-                        targetId: String(session.userId),
-                        error: String(err)
-                    })
-                }
                 continue
             }
 
             try {
-                const data = await requestOnebot(
-                    internal,
-                    'upload_group_file',
-                    {
-                        group_id: Number(session.guildId ?? session.channelId),
-                        file,
-                        name: item.name
-                    },
-                    this.config.fileSenderTimeout
-                )
+                let data: { file_id?: string; data?: { file_id?: string } }
+
+                if (session.platform === 'onebot') {
+                    data = await requestOnebot(
+                        (session.bot as OneBotBot<Context>).internal,
+                        onebotAction,
+                        session.isDirect
+                            ? {
+                                  user_id: Number(target),
+                                  file,
+                                  name: item.name
+                              }
+                            : {
+                                  group_id: Number(target),
+                                  file,
+                                  name: item.name
+                              },
+                        this.config.fileSenderTimeout
+                    )
+                } else {
+                    data = {
+                        file_id: (await session.send(h.file(file)))[0]
+                    }
+                }
 
                 result.push({
-                    file: item.file,
+                    file,
                     name: item.name,
                     fileId: String(
                         data.data?.file_id || data.file_id || ''
                     ).trim(),
-                    targetType: 'group',
-                    targetId: String(session.guildId ?? session.channelId)
+                    targetType: type,
+                    targetId: String(target)
                 })
             } catch (err) {
                 result.push({
-                    file: item.file,
+                    file,
                     name: item.name,
                     fileId: '',
-                    targetType: 'group',
-                    targetId: String(session.guildId ?? session.channelId),
+                    targetType: type,
+                    targetId: String(target),
                     error: String(err)
                 })
             }
@@ -339,8 +277,17 @@ function validateFile(file: string) {
     }
 }
 
+function withTimeout<T>(promise: Promise<T>, timeout: number): Promise<T> {
+    return Promise.race([
+        promise,
+        new Promise<T>((_, reject) =>
+            setTimeout(() => reject(new Error('Timeout')), timeout)
+        )
+    ])
+}
+
 async function requestOnebot(
-    internal: OneBotInternal,
+    internal: OneBotBot<Context>['internal'],
     action: string,
     params: Record<string, unknown>,
     timeoutSeconds: number
@@ -348,43 +295,29 @@ async function requestOnebot(
     const timeoutMs = timeoutSeconds * 1000
 
     const run = async () => {
-        if (typeof internal._get === 'function') {
-            return await internal._get(action, params)
-        }
-        if (typeof internal.request === 'function') {
-            return await internal.request(action, params)
-        }
-        if (typeof internal.callAction === 'function') {
-            return await internal.callAction(action, params)
-        }
-        if (typeof internal.sendAction === 'function') {
-            return await internal.sendAction(action, params)
-        }
-
-        throw new Error(
-            `OneBot internal API does not support action: ${action}`
-        )
+        return (await internal._request(action, params)).data as OneBotResponse
     }
 
-    return await new Promise<OneBotResponse>((resolve, reject) => {
-        const timer = setTimeout(() => {
-            reject(new Error(`${action} 请求超时，已超过 ${timeoutMs}ms。`))
-        }, timeoutMs)
+    return withTimeout(run(), timeoutMs)
+}
 
-        run()
-            .then((data) => {
-                if (data.status && data.status !== 'ok') {
-                    const msg = data.wording || data.message || 'unknown error'
-                    reject(new Error(`${action} 请求失败：${msg}`))
-                    return
-                }
-                resolve(data)
-            })
-            .catch((err) => {
-                reject(err)
-            })
-            .finally(() => {
-                clearTimeout(timer)
-            })
-    })
+type OneBotResponse = {
+    status?: 'ok' | 'failed'
+    retcode?: number
+    file_id?: string
+    data?: {
+        file_id?: string
+    }
+    message?: string
+    wording?: string
+    stream?: string
+}
+
+type SendFileResult = {
+    file: string
+    name: string
+    fileId: string
+    targetType: 'group' | 'private'
+    targetId: string
+    error?: string
 }

--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -19,6 +19,9 @@ export async function apply(
         selector() {
             return true
         },
+        authorization(session) {
+            return session.platform === 'onebot'
+        },
         createTool() {
             return new SendFileTool(config)
         }
@@ -171,6 +174,22 @@ class SendFileTool extends StructuredTool {
 
         for (const item of queue) {
             const file = item.file
+            const validateError = validateFile(file)
+            if (validateError) {
+                result.push({
+                    file: item.file,
+                    name: item.name,
+                    fileId: '',
+                    targetType: session.isDirect ? 'private' : 'group',
+                    targetId: String(
+                        session.isDirect
+                            ? session.userId
+                            : session.guildId ?? session.channelId
+                    ),
+                    error: validateError
+                })
+                continue
+            }
 
             if (session.isDirect) {
                 try {
@@ -242,7 +261,7 @@ class SendFileTool extends StructuredTool {
 
         return JSON.stringify(
             {
-                ok: true,
+                ok: result.every((item) => item.error === undefined),
                 count: result.length,
                 files: result
             },
@@ -270,6 +289,10 @@ function getName(file: string, name?: string) {
         return input
     }
 
+    if (file.startsWith('base64://')) {
+        return 'file'
+    }
+
     try {
         const url = new URL(file)
         const part = decodeURIComponent(url.pathname.split('/').pop() ?? '')
@@ -284,6 +307,36 @@ function getName(file: string, name?: string) {
     }
 
     return 'file'
+}
+
+function validateFile(file: string) {
+    if (file.startsWith('base64://')) {
+        return ''
+    }
+
+    try {
+        const url = new URL(file)
+        if (url.protocol === 'file:') {
+            return '不允许 file:// 来源。'
+        }
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+            return '仅支持 http/https/base64 来源。'
+        }
+        const host = url.hostname.toLowerCase()
+        if (
+            host === 'localhost' ||
+            host === '127.0.0.1' ||
+            host === '::1' ||
+            host.startsWith('10.') ||
+            host.startsWith('192.168.') ||
+            /^172\.(1[6-9]|2\d|3[0-1])\./.test(host)
+        ) {
+            return '不允许访问内网或本地地址。'
+        }
+        return ''
+    } catch {
+        return '仅支持 http/https/base64 来源。'
+    }
 }
 
 async function requestOnebot(

--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -1,0 +1,252 @@
+import { StructuredTool } from '@langchain/core/tools'
+import { z } from 'zod'
+import { Context } from 'koishi'
+import { ChatLunaToolRunnable } from 'koishi-plugin-chatluna/llm-core/platform/types'
+import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
+import { Config } from '..'
+
+export async function apply(
+    _ctx: Context,
+    config: Config,
+    plugin: ChatLunaPlugin
+) {
+    if (config.fileSender !== true) {
+        return
+    }
+
+    const tool = new SendFileTool(config)
+
+    plugin.registerTool(config.fileSenderToolName, {
+        description: tool.description,
+        selector() {
+            return true
+        },
+        createTool() {
+            return new SendFileTool(config)
+        }
+    })
+}
+
+class SendFileTool extends StructuredTool {
+    name = 'send_file'
+
+    schema = z.object({
+        file: z.string().min(1).optional(),
+        name: z.string().optional(),
+        files: z
+            .array(
+                z.union([
+                    z.string(),
+                    z.object({
+                        file: z.string().min(1),
+                        name: z.string().optional()
+                    })
+                ])
+            )
+            .optional()
+    })
+
+    constructor(private config: Config) {
+        super({})
+        this.name = config.fileSenderToolName
+    }
+
+    async _call(
+        input: z.infer<typeof this.schema>,
+        _,
+        runtime: ChatLunaToolRunnable
+    ) {
+        const session = runtime.configurable.session
+        if (!session) {
+            return '缺少会话上下文。'
+        }
+
+        if (session.platform === 'qq') {
+            return 'QQ 官方 Bot 已禁用 send_file。'
+        }
+
+        if (session.platform !== 'onebot') {
+            return '当前仅支持 OneBot 会话。'
+        }
+
+        const internal = (session.bot as any).internal
+        if (!internal) {
+            return '缺少 OneBot internal API 实例。'
+        }
+
+        const queue: { file: string; name: string }[] = []
+
+        if (Array.isArray(input.files) && input.files.length > 0) {
+            for (const item of input.files) {
+                if (typeof item === 'string') {
+                    const file = item.trim()
+                    if (!file) continue
+                    queue.push({
+                        file,
+                        name: getName(file, '')
+                    })
+                    continue
+                }
+
+                const file = item.file.trim()
+                if (!file) continue
+                queue.push({
+                    file,
+                    name: getName(file, item.name)
+                })
+            }
+        } else {
+            const file = input.file?.trim()
+            if (!file) {
+                return 'file 不能为空。'
+            }
+            queue.push({
+                file,
+                name: getName(file, input.name)
+            })
+        }
+
+        if (queue.length < 1) {
+            return '没有可上传的文件。'
+        }
+
+        const result: {
+            file: string
+            name: string
+            fileId: string
+            targetType: 'group' | 'private'
+            targetId: string
+        }[] = []
+
+        for (const item of queue) {
+            let file = item.file
+
+            if (session.isDirect) {
+                const data = await requestOnebot(
+                    internal,
+                    'upload_private_file',
+                    {
+                        user_id: Number(session.userId),
+                        file,
+                        name: item.name
+                    },
+                    this.config.fileSenderTimeout
+                )
+
+                result.push({
+                    file: item.file,
+                    name: item.name,
+                    fileId:
+                        String(
+                            data?.file_id ?? data?.data?.file_id ?? ''
+                        ).trim() || item.file,
+                    targetType: 'private',
+                    targetId: String(session.userId)
+                })
+                continue
+            }
+
+            const data = await requestOnebot(
+                internal,
+                'upload_group_file',
+                {
+                    group_id: Number(session.guildId ?? session.channelId),
+                    file,
+                    name: item.name
+                },
+                this.config.fileSenderTimeout
+            )
+
+            result.push({
+                file: item.file,
+                name: item.name,
+                fileId:
+                    String(data?.file_id ?? data?.data?.file_id ?? '').trim() ||
+                    item.file,
+                targetType: 'group',
+                targetId: String(session.guildId ?? session.channelId)
+            })
+        }
+
+        return JSON.stringify(
+            {
+                ok: true,
+                count: result.length,
+                files: result
+            },
+            null,
+            2
+        )
+    }
+
+    description = `发送 OneBot 文件消息，自动按当前会话上下文决定群聊或私聊。
+
+参数：
+- file: 单文件地址（URL、file://、base64://）
+- name: 单文件名称（可选）
+- files: 多文件列表，支持字符串或 { file, name }
+
+说明：
+- 支持一次提交多个文件，按顺序排队上传
+- 群文件固定上传根目录
+`
+}
+
+function getName(file: string, name?: string) {
+    const input = (name ?? '').trim()
+    if (input) {
+        return input
+    }
+
+    try {
+        const url = new URL(file)
+        const part = decodeURIComponent(url.pathname.split('/').pop() ?? '')
+        if (part) {
+            return part
+        }
+    } catch {}
+
+    const part = file.split(/[\\/]/).pop()?.trim()
+    if (part) {
+        return part
+    }
+
+    return 'file'
+}
+
+async function requestOnebot(
+    internal: any,
+    action: string,
+    params: Record<string, any>,
+    timeoutSeconds: number
+) {
+    const timeoutMs = timeoutSeconds * 1000
+
+    const run = async () => {
+        if (typeof internal._get === 'function') {
+            return await internal._get(action, params)
+        }
+        if (typeof internal.request === 'function') {
+            return await internal.request(action, params)
+        }
+        if (typeof internal.callAction === 'function') {
+            return await internal.callAction(action, params)
+        }
+        if (typeof internal.sendAction === 'function') {
+            return await internal.sendAction(action, params)
+        }
+
+        throw new Error(
+            `OneBot internal API does not support action: ${action}`
+        )
+    }
+
+    return await Promise.race([
+        run(),
+        new Promise((_, reject) => {
+            setTimeout(() => {
+                reject(new Error(`${action} 请求超时，已超过 ${timeoutMs}ms。`))
+            }, timeoutMs)
+        })
+    ])
+}


### PR DESCRIPTION
## Summary
- Add optional `fileSender` extension plugin and register `send_file` tool for OneBot sessions, with configurable tool name and upload timeout.
- Improve OpenTerminal backend compatibility by accepting both wrapped (`data`) and direct response shapes, and make output parsing more tolerant across payload formats.
- Respect sub-agent max turn limits by wiring `maxIterations` through agent executor creation.

## Changes
- `core`: add optional `maxIterations` in `CreateAgentExecutorOptions` and pass to `AgentExecutor`.
- `extension-agent`:
  - set `maxIterations` from `input.info.maxTurns` in sub-agent runs.
  - harden OpenTerminal response/output handling.
  - update OpenTerminal docker env example for binary mime prefixes.
- `extension-tools`:
  - add `file_sender` plugin (`send_file`) for OneBot private/group file uploads.
  - add config schema fields: `fileSender`, `fileSenderToolName`, `fileSenderTimeout`.
  - add i18n schema descriptions in `en-US` and `zh-CN`.
  - wire plugin into middleware chain.

## Notes
- QQ official bot path remains explicitly disabled for `send_file`.
