### PR TITLE
fix(extension-tools): 为 send_file 增加 plugin-common 来源元信息

### DIFF
--- a/packages/extension-tools/src/plugins/file_sender.ts
+++ b/packages/extension-tools/src/plugins/file_sender.ts
@@ -20,6 +20,11 @@ export async function apply(
         selector() {
             return true
         },
+        meta: {
+            source: 'extension',
+            group: 'plugin-common',
+            tags: ['plugin-common', 'file', 'onebot']
+        },
         authorization(session) {
             return session.platform === 'onebot'
         },


### PR DESCRIPTION
## 变更说明
- 为 `chatluna-plugin-common` 注册的 `send_file` 工具补充 `meta` 元信息（`source/group/tags`）。
- 让上层插件可以基于“工具来源”做精确过滤，而不是仅按工具名过滤，避免同名工具误伤。

## 背景
- `chatluna-character` 需要跳过 `plugin-common` 的文件发送工具。
- 仅靠工具名过滤会存在同名冲突风险，因此先在工具注册处补充来源标识。

## 影响范围
- 仅影响 `extension-tools` 中 `file_sender` 工具注册元信息。
- 不改变工具执行逻辑与权限判定。
