### PR TITLE
fix(adapter-openai-like): 支持按关键词隐藏模型

### DIFF
--- a/packages/adapter-openai-like/src/client.ts
+++ b/packages/adapter-openai-like/src/client.ts
@@ -68,13 +68,13 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
                 (model) => !isNonLLMModel(model)
             )
 
-            const blacklistModels = this._config.blacklistModels
+            const blacklist = this._config.blacklistModels
                 .map((keyword) => keyword.trim().toLowerCase())
                 .filter((keyword) => keyword.length > 0)
 
-            const blacklistFilteredModels = filteredModels.filter((model) => {
+            const models = filteredModels.filter((model) => {
                 const id = model.toLowerCase()
-                return !blacklistModels.some((keyword) => id.includes(keyword))
+                return !blacklist.some((keyword) => id.includes(keyword))
             })
 
             const supportToolCalling = (model: string) => {
@@ -90,7 +90,7 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
                 }
             }
 
-            const formattedModels = blacklistFilteredModels.map(
+            const formattedModels = models.map(
                 (model) =>
                     ({
                         name: model,

--- a/packages/adapter-openai-like/src/client.ts
+++ b/packages/adapter-openai-like/src/client.ts
@@ -72,11 +72,6 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
                 .map((keyword) => keyword.trim().toLowerCase())
                 .filter((keyword) => keyword.length > 0)
 
-            const models = filteredModels.filter((model) => {
-                const id = model.toLowerCase()
-                return !blacklist.some((keyword) => id.includes(keyword))
-            })
-
             const supportToolCalling = (model: string) => {
                 // const lower = model.toLowerCase()
 
@@ -90,16 +85,21 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
                 }
             }
 
-            const formattedModels = models.map(
-                (model) =>
-                    ({
-                        name: model,
-                        type: isEmbeddingModel(model)
-                            ? ModelType.embeddings
-                            : ModelType.llm,
-                        ...supportToolCalling(model)
-                    }) as ModelInfo
-            )
+            const formattedModels = filteredModels
+                .filter((model) => {
+                    const id = model.toLowerCase()
+                    return !blacklist.some((keyword) => id.includes(keyword))
+                })
+                .map(
+                    (model) =>
+                        ({
+                            name: model,
+                            type: isEmbeddingModel(model)
+                                ? ModelType.embeddings
+                                : ModelType.llm,
+                            ...supportToolCalling(model)
+                        }) as ModelInfo
+                )
 
             return additionalModels.concat(
                 formattedModels.filter(

--- a/packages/adapter-openai-like/src/client.ts
+++ b/packages/adapter-openai-like/src/client.ts
@@ -68,6 +68,15 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
                 (model) => !isNonLLMModel(model)
             )
 
+            const blacklistModels = this._config.blacklistModels
+                .map((keyword) => keyword.trim().toLowerCase())
+                .filter((keyword) => keyword.length > 0)
+
+            const blacklistFilteredModels = filteredModels.filter((model) => {
+                const id = model.toLowerCase()
+                return !blacklistModels.some((keyword) => id.includes(keyword))
+            })
+
             const supportToolCalling = (model: string) => {
                 // const lower = model.toLowerCase()
 
@@ -81,7 +90,7 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
                 }
             }
 
-            const formattedModels = filteredModels.map(
+            const formattedModels = blacklistFilteredModels.map(
                 (model) =>
                     ({
                         name: model,

--- a/packages/adapter-openai-like/src/index.ts
+++ b/packages/adapter-openai-like/src/index.ts
@@ -59,6 +59,7 @@ export interface Config extends ChatLunaPlugin.Config {
         modelCapabilities: ModelCapabilities[]
         contextSize: number
     }[]
+    blacklistModels: string[]
     additionCookies: [string, string][]
     maxContextRatio: number
     temperature: number
@@ -94,7 +95,8 @@ export const Config: Schema<Config> = Schema.intersect([
             })
         )
             .default([])
-            .role('table')
+            .role('table'),
+        blacklistModels: Schema.array(Schema.string()).default([])
     }),
     Schema.object({
         apiKeys: Schema.array(

--- a/packages/adapter-openai-like/src/locales/en-US.schema.yml
+++ b/packages/adapter-openai-like/src/locales/en-US.schema.yml
@@ -14,6 +14,10 @@ $inner:
                 $inner:
                     - Tool calling
                     - Visual image input
+      blacklistModels:
+          $desc: 'Keyword blacklist models. Hide models whose IDs contain these keywords.'
+          $inner:
+              - Keyword
 
     - $desc: 'API Configuration'
       apiKeys:

--- a/packages/adapter-openai-like/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-openai-like/src/locales/zh-CN.schema.yml
@@ -14,6 +14,10 @@ $inner:
                 $inner:
                     - 工具调用
                     - 图片视觉输入
+      blacklistModels:
+          $desc: 关键词黑名单模型列表。将隐藏 ID 中含有以下关键词的模型。
+          $inner:
+              - 关键词
 
     - $desc: 请求设置
       apiKeys:


### PR DESCRIPTION
## 变更说明
- 在 `chatluna-openai-like-adapter` 中新增“关键词黑名单模型列表”配置项，支持按关键词过滤模型 ID。
- 在模型刷新流程中加入黑名单过滤逻辑（大小写不敏感，按包含关系匹配）。
- 补充中英文 schema 文案，确保控制台配置项可见且语义清晰。

## 验证
- `yarn fast-build adapter-openai-like`
