### PR TITLE
fix(extension-agent): fallback when bwrap is unusable

### DIFF
--- a/packages/extension-agent/src/computer/backends/local/sandbox.ts
+++ b/packages/extension-agent/src/computer/backends/local/sandbox.ts
@@ -1,10 +1,13 @@
 /** @module computer/backends/local/sandbox */
 
+import { spawnSync } from 'node:child_process'
+import fs from 'node:fs'
 import path from 'path'
 import which from 'which'
 import { LocalBackendConfig } from '../../../types'
 
 const PROTECTED_NAMES = ['.git', '.chatluna', '.agents', '.codex', '.claude']
+const BWRAP_PROBE_CACHE = new Map<string, boolean>()
 
 const WRITE_COMMAND_PATTERNS = [
     />/,
@@ -109,6 +112,10 @@ export function wrapCommandWithSandbox(
         return command
     }
 
+    if (!canUseBubblewrap(bwrap, tmp)) {
+        return command
+    }
+
     const scope = cfg.scopePath || workdir || process.cwd()
     const binds =
         cfg.sandboxMode === 'read-only'
@@ -152,4 +159,40 @@ function containsProtectedName(value: string) {
 
 function quote(value: string) {
     return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function canUseBubblewrap(bwrap: string, tmp: string) {
+    const cached = BWRAP_PROBE_CACHE.get(bwrap)
+    if (cached != null) {
+        return cached
+    }
+
+    const probeTmp = path.join(tmp, 'bwrap-probe')
+    fs.mkdirSync(probeTmp, { recursive: true })
+
+    const result = spawnSync(
+        bwrap,
+        [
+            '--ro-bind',
+            '/',
+            '/',
+            '--bind',
+            probeTmp,
+            '/tmp',
+            '--dev',
+            '/dev',
+            '--proc',
+            '/proc',
+            'sh',
+            '-lc',
+            'true'
+        ],
+        {
+            stdio: 'ignore'
+        }
+    )
+
+    const ok = result.status === 0
+    BWRAP_PROBE_CACHE.set(bwrap, ok)
+    return ok
 }

--- a/packages/extension-agent/src/computer/backends/local/sandbox.ts
+++ b/packages/extension-agent/src/computer/backends/local/sandbox.ts
@@ -1,13 +1,12 @@
 /** @module computer/backends/local/sandbox */
 
 import { spawnSync } from 'node:child_process'
-import fs from 'node:fs'
 import path from 'path'
 import which from 'which'
 import { LocalBackendConfig } from '../../../types'
 
 const PROTECTED_NAMES = ['.git', '.chatluna', '.agents', '.codex', '.claude']
-const BWRAP_PROBE_CACHE = new Map<string, boolean>()
+const BWRAP_PROBE_CACHE = new Set<string>()
 
 const WRITE_COMMAND_PATTERNS = [
     />/,
@@ -109,11 +108,16 @@ export function wrapCommandWithSandbox(
 
     const bwrap = which.sync('bwrap', { nothrow: true })
     if (!bwrap) {
-        return command
+        throw new Error(
+            'Local backend sandbox requires bubblewrap (`bwrap`), but it is not installed.'
+        )
     }
 
-    if (!canUseBubblewrap(bwrap, tmp)) {
-        return command
+    const bwrapError = getBubblewrapError(bwrap, tmp)
+    if (bwrapError) {
+        throw new Error(
+            `Local backend sandbox requires bubblewrap, but the startup probe failed: ${bwrapError}`
+        )
     }
 
     const scope = cfg.scopePath || workdir || process.cwd()
@@ -161,14 +165,10 @@ function quote(value: string) {
     return `'${value.replaceAll("'", `'\\''`)}'`
 }
 
-function canUseBubblewrap(bwrap: string, tmp: string) {
-    const cached = BWRAP_PROBE_CACHE.get(bwrap)
-    if (cached != null) {
-        return cached
+function getBubblewrapError(bwrap: string, tmp: string) {
+    if (BWRAP_PROBE_CACHE.has(bwrap)) {
+        return ''
     }
-
-    const probeTmp = path.join(tmp, 'bwrap-probe')
-    fs.mkdirSync(probeTmp, { recursive: true })
 
     const result = spawnSync(
         bwrap,
@@ -177,7 +177,7 @@ function canUseBubblewrap(bwrap: string, tmp: string) {
             '/',
             '/',
             '--bind',
-            probeTmp,
+            tmp,
             '/tmp',
             '--dev',
             '/dev',
@@ -188,11 +188,18 @@ function canUseBubblewrap(bwrap: string, tmp: string) {
             'true'
         ],
         {
-            stdio: 'ignore'
+            encoding: 'utf8'
         }
     )
 
-    const ok = result.status === 0
-    BWRAP_PROBE_CACHE.set(bwrap, ok)
-    return ok
+    if (result.status === 0) {
+        BWRAP_PROBE_CACHE.add(bwrap)
+        return ''
+    }
+
+    return (
+        result.stderr?.trim() ||
+        result.error?.message ||
+        'bubblewrap startup probe failed.'
+    )
 }


### PR DESCRIPTION
Fixes #799

## 问题

在 Linux 环境下，`chatluna-agent` 的 local backend 只要检测到 `bwrap` 存在，就会无条件为命令套上 bubblewrap sandbox。

这在 Ubuntu 24.04 的 AppArmor / unprivileged user namespace 限制环境里会导致 local 命令整体失败，典型报错包括：

- `bwrap: Can't mount proc on /newroot/proc: Operation not permitted`
- `bwrap: setting up uid map: Permission denied`

## 根因

问题不在于 `bwrap` 是否安装，而在于 **`bwrap` 在当前宿主环境中是否真的可用**。

Ubuntu 24.04 默认启用了对 unprivileged user namespace 的限制。此时即使系统里已经安装了 `bwrap`，它也可能因为 AppArmor / userns 限制而无法初始化 sandbox，最终把 local backend 的命令执行一并打死。

## 修改方式

本 PR 只修改了一个文件：

- `packages/extension-agent/src/computer/backends/local/sandbox.ts`

修改内容：

1. 保留现有行为：
   - Windows 不使用 `bwrap`
   - `bwrap` 不存在时直接返回原命令
2. 新增一层最小 runtime probe：
   - 当检测到 `bwrap` 存在时，先执行一次最小 `bwrap` 探测
   - 探测成功才继续返回包装后的 sandbox 命令
   - 探测失败则回退到原命令
3. 增加进程内缓存，避免每次执行都重复探测

也就是说，这个改动把原来的：

- `bwrap` 不存在 => 裸跑

扩展为：

- `bwrap` 不存在 => 裸跑
- `bwrap` 存在但当前环境不可用 => 裸跑
- `bwrap` 存在且可用 => 继续使用 sandbox

## 设计取舍

这是一个 **runtime mitigation**，不是系统级根治。

它不试图让 ChatLuna 管理宿主机的 AppArmor profile 或 sysctl，也不改变 `bwrap` 正常可用环境下的既有行为。目标只是避免 local backend 因为“检测到 `bwrap` 已安装，但实际上无法初始化”而直接失效。

## 验证方式

仓库当前没有自动化测试框架，因此本次验证为定向手工验证。

### 1. 本地函数级验证

- 真实可用 `bwrap`：
  - `wrapCommandWithSandbox()` 继续返回带 `bwrap` 的包装命令
- 假失败 `bwrap`：
  - 模拟返回 mount/proc 权限错误
  - `wrapCommandWithSandbox()` 返回原始命令

### 2. `LocalComputerSession.execute()` 验证

- 假失败 `bwrap` 环境：
  - `execute('printf ok')` 成功，`stdout=ok`
- 真实 `bwrap` 环境：
  - `execute('printf ok')` 仍成功，`stdout=ok`

### 3. 真实 Ubuntu 24.04 + AppArmor VM 对照验证

在本地完整 Ubuntu 24.04 VM 中进行了原始版本与补丁版本对照验证：

- `kernel.apparmor_restrict_unprivileged_userns=1` 时
  - 原始版本：仍返回 `bwrap` 包装命令并失败
  - 补丁版本：回退为原命令并成功执行
- `kernel.apparmor_restrict_unprivileged_userns=0` 时
  - 原始版本：`bwrap` 正常执行
  - 补丁版本：同样继续走 `bwrap`，不破坏正常路径

对照结果说明：

- 补丁确实只在 `bwrap` 不可用时回退
- 不会破坏 `bwrap` 正常可用路径

## 风险边界

- 该补丁属于 fail-open 缓解，不是 fail-closed 设计
- 这与当前已有语义一致：原实现本来就在“系统没有 `bwrap`”时直接返回原命令
- 如果未来项目希望 sandbox 不可用时直接拒绝执行，应单独讨论为新的策略变更，而不是混入这次 bugfix
