### PR TITLE
fix(extension-agent): add background option to e2b command execution

### DIFF
--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/src/computer/backends/e2b.ts
+++ b/packages/extension-agent/src/computer/backends/e2b.ts
@@ -653,8 +653,9 @@ export class E2BComputerSession implements ComputerSessionApi {
 
         try {
             handle = (await current.commands.run(command, {
-                ...options
-            } as CommandStartOpts & { background: true })) as CommandHandle
+                ...options,
+                background: true
+            })) as CommandHandle
             result = await handle.wait()
         } catch (err) {
             if (err instanceof CommandExitError) {


### PR DESCRIPTION
## Summary
- Explicitly pass `background: true` to E2B command `run` options instead of relying on spread options
- Bump extension-agent version to 1.0.15

## Why
The previous code spread `options` which didn't guarantee `background: true` was included, potentially causing commands to not run in the background as intended.