### PR TITLE
fix(extension-variable): migrate lunar variables to before-chat and renderer providers

### DIFF
--- a/packages/extension-variable/src/plugins/group.ts
+++ b/packages/extension-variable/src/plugins/group.ts
@@ -17,17 +17,19 @@ export async function apply(
         await collector.collect(session)
     })
 
-    ctx.chatluna.promptRenderer.registerFunctionProvider(
-        'latest_message',
-        async (args, _, configurable) => {
-            const session = configurable.session as Session
-            const messageCount = parseInt(args[0]) || 4
-            const messages = collector.getMessages(
-                session.guildId || session.userId,
-                session.userId
-            )
-            return messages.slice(-messageCount).join('\n\n')
-        }
+    ctx.effect(() =>
+        ctx.chatluna.promptRenderer.registerFunctionProvider(
+            'latest_message',
+            async (args, _, configurable) => {
+                const session = configurable.session as Session
+                const messageCount = parseInt(args[0]) || 4
+                const messages = collector.getMessages(
+                    session.guildId || session.userId,
+                    session.userId
+                )
+                return messages.slice(-messageCount).join('\n\n')
+            }
+        )
     )
 }
 

--- a/packages/extension-variable/src/plugins/lunar.ts
+++ b/packages/extension-variable/src/plugins/lunar.ts
@@ -5,6 +5,8 @@ import { Lunar } from 'lunar-javascript'
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import Holidays from 'date-holidays'
 
+const DEFAULT_HOLIDAY_REGIONS = ['CN', 'US']
+
 export async function apply(
     ctx: Context,
     config: Config,
@@ -14,23 +16,33 @@ export async function apply(
         return
     }
 
-    ctx.before('chatluna/chat', async (_session, _message, promptVariables) => {
-        // Get lunar calendar information
-        const lunarDate = getChineseLunarDate()
+    ctx.on(
+        'chatluna/before-chat',
+        async (_conversationId, _message, promptVariables) => {
+            Object.assign(promptVariables, buildLunarVariables())
+        }
+    )
 
-        // Get holiday information for China and US (can be customized)
-        const holidayInfo = getCurrentHoliday(['CN', 'US'])
+    ctx.effect(() =>
+        ctx.chatluna.promptRenderer.registerVariableProvider(() =>
+            buildLunarVariables()
+        )
+    )
+}
 
-        promptVariables.lunar_date = lunarDate.fullLunarDate
-        promptVariables.lunar_year = lunarDate.year
-        promptVariables.lunar_month = lunarDate.month
-        promptVariables.lunar_day = lunarDate.day
-        promptVariables.lunar_zodiac = lunarDate.zodiac
-        promptVariables.lunar_year_ganzhi = lunarDate.yearGanZhi
+export function buildLunarVariables(): Record<string, string> {
+    const lunarDate = getChineseLunarDate()
+    const holidayInfo = getCurrentHoliday(DEFAULT_HOLIDAY_REGIONS)
 
-        // Holiday information
-        promptVariables.current_holiday = holidayInfo
-    })
+    return {
+        lunar_date: lunarDate.fullLunarDate,
+        lunar_year: lunarDate.year,
+        lunar_month: lunarDate.month,
+        lunar_day: lunarDate.day,
+        lunar_zodiac: lunarDate.zodiac,
+        lunar_year_ganzhi: lunarDate.yearGanZhi,
+        current_holiday: holidayInfo
+    }
 }
 
 /**
@@ -58,7 +70,7 @@ export function getChineseLunarDate() {
  * @param regions Array of region codes. Defaults to ['CN', 'US']
  * @returns Current holiday information or empty string if no holiday
  */
-export function getCurrentHoliday(regions: string[] = ['CN', 'US']) {
+export function getCurrentHoliday(regions: string[] = DEFAULT_HOLIDAY_REGIONS) {
     const date = new Date()
     const currentHolidays = []
 


### PR DESCRIPTION
## Summary

This PR fixes variable injection in koishi-plugin-chatluna-variable-extension so lunar/holiday variables work in both the main ChatLuna
flow and chatluna-character preset rendering.

## Changes

- migrate lunar variable injection from the obsolete chatluna/chat hook to chatluna/before-chat
- extract shared lunar/holiday variable generation into a single helper
- register the same lunar/holiday variables through ctx.chatluna.promptRenderer.registerVariableProvider(...)
    - this makes the variables available to chatluna-character without changing its rendering flow
- wrap latest_message function registration with ctx.effect(...)
    - ensures provider lifecycle is tied to the plugin scope and avoids stale registrations on reload

## Behavior

After this change:

- ChatLuna main chat requests still receive:
    - lunar_date
    - lunar_year
    - lunar_month
    - lunar_day
    - lunar_zodiac
    - lunar_year_ganzhi
    - current_holiday
- chatluna-character templates can also resolve the same global lunar/holiday variables via the shared prompt renderer
- latest_message() behavior is unchanged

## Verification

- built koishi-plugin-chatluna-variable-extension successfully:
    - yarn workspace koishi-plugin-chatluna-variable-extension build
