### PR TITLE
fix(core): 将空响应视为失败并交给模型重试

### DIFF
--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -239,23 +239,28 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
             const latestTokenUsage = this._createTokenUsageTracker()
             let stream: AsyncGenerator<ChatGenerationChunk> | null = null
             let hasChunk = false
+            let hasResponse = false
             let hasToolCallChunk = false
 
             try {
                 stream = await this._createStream(streamParams)
 
                 for await (const chunk of stream) {
-                    hasToolCallChunk =
-                        this._handleStreamChunk(
-                            chunk,
-                            runManager,
-                            latestTokenUsage
-                        ) || hasToolCallChunk
+                    const hasTool = this._handleStreamChunk(
+                        chunk,
+                        runManager,
+                        latestTokenUsage
+                    )
+                    hasToolCallChunk = hasTool || hasToolCallChunk
                     hasChunk = true
+                    hasResponse =
+                        hasResponse ||
+                        hasTool ||
+                        getMessageContent(chunk.message.content).trim().length > 0
                     yield chunk
                 }
 
-                this._ensureChunksReceived(hasChunk)
+                this._ensureChunksReceived(hasChunk, hasResponse)
                 this._finalizeStream(
                     hasToolCallChunk,
                     latestTokenUsage,
@@ -268,12 +273,12 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 if (
                     this._shouldRethrowStreamError(
                         error,
-                        hasChunk,
+                        hasResponse,
                         attempt,
                         maxRetries
                     )
                 ) {
-                    if (hasChunk) {
+                    if (hasResponse) {
                         logger.debug(
                             'Stream failed after yielding chunks, cannot retry'
                         )
@@ -322,10 +327,11 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         return hasToolCallChunk
     }
 
-    private _hasToolCallChunk(message?: AIMessageChunk): boolean {
+    private _hasToolCallChunk(message?: AIMessage | AIMessageChunk): boolean {
         return (
             (message?.tool_calls?.length ?? 0) > 0 ||
-            (message?.tool_call_chunks?.length ?? 0) > 0 ||
+            ((message as AIMessageChunk | undefined)?.tool_call_chunks?.length ??
+                0) > 0 ||
             (message?.invalid_tool_calls?.length ?? 0) > 0
         )
     }
@@ -347,8 +353,8 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         latestTokenUsage.output_token_details = usage.output_token_details
     }
 
-    private _ensureChunksReceived(hasChunk: boolean) {
-        if (hasChunk) {
+    private _ensureChunksReceived(hasChunk: boolean, hasResponse: boolean) {
+        if (hasChunk && hasResponse) {
             return
         }
 
@@ -391,12 +397,12 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
 
     private _shouldRethrowStreamError(
         error: unknown,
-        hasChunk: boolean,
+        hasResponse: boolean,
         attempt: number,
         maxRetries: number
     ): boolean {
         return (
-            this._isAbortError(error) || hasChunk || attempt === maxRetries - 1
+            this._isAbortError(error) || hasResponse || attempt === maxRetries - 1
         )
     }
 
@@ -493,6 +499,18 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                             ...this.invocationParams(options),
                             input: messages
                         })
+                    }
+
+                    if (
+                        getMessageContent(response.message.content).trim()
+                            .length < 1 &&
+                        this._hasToolCallChunk(
+                            response.message as AIMessage | AIMessageChunk
+                        ) !== true
+                    ) {
+                        throw new ChatLunaError(
+                            ChatLunaErrorCode.API_REQUEST_FAILED
+                        )
                     }
 
                     return response

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -295,7 +295,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 logger.debug(
                     `Stream failed before first chunk (attempt ${attempt + 1}/${maxRetries}), retrying...`
                 )
-                await sleep(2000)
+                await sleep(2000 * 2 ** attempt)
             }
         }
     }
@@ -533,7 +533,7 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                         throw error
                     }
 
-                    await sleep(2000)
+                    await sleep(2000 * 2 ** attempt)
                 }
             }
 

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -256,7 +256,8 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                     hasResponse =
                         hasResponse ||
                         hasTool ||
-                        getMessageContent(chunk.message.content).trim().length > 0
+                        getMessageContent(chunk.message.content).trim()
+                            .length > 0
                     yield chunk
                 }
 
@@ -330,8 +331,8 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
     private _hasToolCallChunk(message?: AIMessage | AIMessageChunk): boolean {
         return (
             (message?.tool_calls?.length ?? 0) > 0 ||
-            ((message as AIMessageChunk | undefined)?.tool_call_chunks?.length ??
-                0) > 0 ||
+            ((message as AIMessageChunk | undefined)?.tool_call_chunks
+                ?.length ?? 0) > 0 ||
             (message?.invalid_tool_calls?.length ?? 0) > 0
         )
     }

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -255,13 +255,18 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                     hasChunk = true
                     hasResponse =
                         hasResponse ||
-                        hasTool ||
-                        getMessageContent(chunk.message.content).trim()
-                            .length > 0
+                        this._hasResponse(
+                            chunk.message as AIMessage | AIMessageChunk
+                        )
                     yield chunk
                 }
 
-                this._ensureChunksReceived(hasChunk, hasResponse)
+                if (!hasResponse) {
+                    throw new ChatLunaError(
+                        ChatLunaErrorCode.API_REQUEST_FAILED
+                    )
+                }
+
                 this._finalizeStream(
                     hasToolCallChunk,
                     latestTokenUsage,
@@ -274,12 +279,12 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                 if (
                     this._shouldRethrowStreamError(
                         error,
-                        hasResponse,
+                        hasChunk,
                         attempt,
                         maxRetries
                     )
                 ) {
-                    if (hasResponse) {
+                    if (hasChunk) {
                         logger.debug(
                             'Stream failed after yielding chunks, cannot retry'
                         )
@@ -337,6 +342,20 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         )
     }
 
+    private _hasResponse(message?: AIMessage | AIMessageChunk): boolean {
+        const content = message?.content
+
+        return (
+            (typeof content === 'string'
+                ? content.trim().length > 0
+                : Array.isArray(content) && content.length > 0) ||
+            this._hasToolCallChunk(message) ||
+            ((message?.additional_kwargs?.tool_calls as unknown[] | undefined)
+                ?.length ?? 0) > 0 ||
+            message?.additional_kwargs?.function_call != null
+        )
+    }
+
     private _updateTokenUsageFromChunk(
         chunk: ChatGenerationChunk,
         latestTokenUsage: TokenUsageTracker
@@ -352,14 +371,6 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         latestTokenUsage.total_tokens = usage.total_tokens
         latestTokenUsage.input_token_details = usage.input_token_details
         latestTokenUsage.output_token_details = usage.output_token_details
-    }
-
-    private _ensureChunksReceived(hasChunk: boolean, hasResponse: boolean) {
-        if (hasChunk && hasResponse) {
-            return
-        }
-
-        throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED)
     }
 
     private _finalizeStream(
@@ -398,12 +409,12 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
 
     private _shouldRethrowStreamError(
         error: unknown,
-        hasResponse: boolean,
+        hasChunk: boolean,
         attempt: number,
         maxRetries: number
     ): boolean {
         return (
-            this._isAbortError(error) || hasResponse || attempt === maxRetries - 1
+            this._isAbortError(error) || hasChunk || attempt === maxRetries - 1
         )
     }
 
@@ -503,11 +514,9 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
                     }
 
                     if (
-                        getMessageContent(response.message.content).trim()
-                            .length < 1 &&
-                        this._hasToolCallChunk(
+                        !this._hasResponse(
                             response.message as AIMessage | AIMessageChunk
-                        ) !== true
+                        )
                     ) {
                         throw new ChatLunaError(
                             ChatLunaErrorCode.API_REQUEST_FAILED


### PR DESCRIPTION
## 变更说明

- 将非流式空响应视为 `API_REQUEST_FAILED`，交给模型层现有 `maxRetries` 处理。
- 流式响应改为检查是否收到有效文本或 tool call，避免空流被当作成功返回。
- 保留纯 tool call 响应的成功路径，不把这类响应误判为空响应失败。

## 验证

- `yarn fast-build core`
