### PR TITLE
fix(extension-agent): 修复 Skill 导入与管理页刷新

### DIFF
--- a/packages/extension-agent/client/components/layout/agent-shell.vue
+++ b/packages/extension-agent/client/components/layout/agent-shell.vue
@@ -3,80 +3,77 @@
         <div class="main-content">
             <el-scrollbar>
                 <div class="content-wrapper">
-                    <Transition name="fade-slide" mode="out-in">
-                        <div
-                            v-if="activeTab === 'mcp'"
-                            key="mcp"
-                            class="view-container"
-                        >
-                            <mcp-page
-                                :config="mcpCfg"
-                                :status="mcpStatus"
-                                :loading="loading"
-                                @refresh="refreshData"
-                                @save="saveMcp"
-                            />
-                        </div>
+                    <div
+                        v-if="activeTab === 'mcp'"
+                        key="mcp"
+                        class="view-container"
+                    >
+                        <mcp-page
+                            :config="mcpCfg"
+                            :status="mcpStatus"
+                            :loading="loading"
+                            @refresh="refreshData"
+                            @save="saveMcp"
+                        />
+                    </div>
 
-                        <div
-                            v-else-if="activeTab === 'skills'"
+                    <KeepAlive>
+                        <skills-page
+                            v-if="activeTab === 'skills'"
                             key="skills"
                             class="view-container"
-                        >
-                            <skills-page
-                                :config="skillsCfg"
-                                :status="skillsStatus"
-                                :agents="subAgentStatus?.catalog"
-                                :computer="computerStatus"
-                                :loading="loading"
-                                @refresh="refreshData"
-                                @save="(value) => saveSection('skills', value)"
-                            />
-                        </div>
+                            :config="skillsCfg"
+                            :status="skillsStatus"
+                            :agents="subAgentStatus?.catalog"
+                            :computer="computerStatus"
+                            :loading="loading"
+                            @refresh="refreshData"
+                            @save="(value) => saveSection('skills', value)"
+                        />
+                    </KeepAlive>
 
-                        <div
-                            v-else-if="activeTab === 'computer'"
-                            key="computer"
-                            class="view-container"
-                        >
-                            <computer-page
-                                :config="computerCfg"
-                                :status="computerStatus"
-                                :loading="loading"
-                            />
-                        </div>
+                    <div
+                        v-if="activeTab === 'computer'"
+                        key="computer"
+                        class="view-container"
+                    >
+                        <computer-page
+                            :config="computerCfg"
+                            :status="computerStatus"
+                            :loading="loading"
+                        />
+                    </div>
 
-                        <div
-                            v-else-if="activeTab === 'subAgent'"
+                    <KeepAlive>
+                        <sub-agent-page
+                            v-if="activeTab === 'subAgent'"
                             key="sub-agent"
                             class="view-container"
-                        >
-                            <sub-agent-page
-                                :config="subAgentCfg"
-                                :status="subAgentStatus"
-                                :skills="skillsStatus?.catalog"
-                                :mcp="mcpStatus?.servers"
-                                :computer="computerStatus"
-                                :tools="toolStatus?.catalog"
-                                :loading="loading"
-                                @refresh="refreshData"
-                                @save="
-                                    (value) => saveSection('subAgent', value)
-                                "
-                            />
-                        </div>
+                            :config="subAgentCfg"
+                            :status="subAgentStatus"
+                            :skills="skillsStatus?.catalog"
+                            :mcp="mcpStatus?.servers"
+                            :computer="computerStatus"
+                            :tools="toolStatus?.catalog"
+                            :loading="loading"
+                            @refresh="refreshData"
+                            @save="(value) => saveSection('subAgent', value)"
+                        />
+                    </KeepAlive>
 
-                        <div v-else key="tool" class="view-container">
-                            <tool-page
-                                :config="toolCfg"
-                                :status="toolStatus"
-                                :agents="subAgentStatus?.catalog"
-                                :loading="loading"
-                                @refresh="refreshData"
-                                @save="(value) => saveSection('tool', value)"
-                            />
-                        </div>
-                    </Transition>
+                    <KeepAlive>
+                        <tool-page
+                            v-if="activeTab === 'tool'"
+                            key="tool"
+                            class="view-container"
+                            :config="toolCfg"
+                            :status="toolStatus"
+                            :agents="subAgentStatus?.catalog"
+                            :loading="loading"
+                            @refresh="refreshData"
+                            @save="(value) => saveSection('tool', value)"
+                        />
+                    </KeepAlive>
                 </div>
             </el-scrollbar>
         </div>
@@ -99,10 +96,9 @@ import type { AgentConfig } from '../../../src/types'
 
 const activeTab = ref('mcp')
 const pending = ref(false)
-let refreshId = 0
+let refreshTask: Promise<void> | undefined
 const data = computed(() => store.chatluna_agent_webui)
 const config = computed(() => data.value?.config)
-const status = computed(() => data.value?.status)
 const mcpCfg = computed(() => data.value?.config?.mcp)
 const skillsCfg = computed(() => data.value?.config?.skills)
 const computerCfg = computed(() => data.value?.config?.computer)
@@ -116,17 +112,24 @@ const toolStatus = computed(() => data.value?.status?.tool)
 const loading = computed(() => pending.value || !data.value)
 
 const refreshData = async () => {
-    const id = ++refreshId
-    try {
-        pending.value = true
-        await send('chatluna-agent/refreshConsoleData')
-    } catch {
-        ElMessage.error('刷新 Agent 数据失败')
-    } finally {
-        if (id === refreshId) {
-            pending.value = false
-        }
+    if (refreshTask) {
+        await refreshTask
+        return
     }
+
+    refreshTask = (async () => {
+        try {
+            pending.value = true
+            await send('chatluna-agent/refreshConsoleData')
+        } catch {
+            ElMessage.error('刷新 Agent 数据失败')
+        } finally {
+            pending.value = false
+            refreshTask = undefined
+        }
+    })()
+
+    await refreshTask
 }
 
 const handleTabChange = (tab: string) => {

--- a/packages/extension-agent/client/components/skills/skills-import-folder-dialog.vue
+++ b/packages/extension-agent/client/components/skills/skills-import-folder-dialog.vue
@@ -365,7 +365,7 @@ async function importSkills() {
         ElMessage.success(
             result.replaced.length > 0
                 ? `已导入 ${result.imported.length} 个 Skill，并覆盖 ${result.replaced.length} 个同名项。`
-                : `已导入 ${result.imported.length} 个 Skill，并默认启用。`
+                : `已导入 ${result.imported.length} 个 Skill。`
         )
     } catch {
         ElMessage.error('导入失败，请稍后重试。')

--- a/packages/extension-agent/client/components/skills/skills-import-github-dialog.vue
+++ b/packages/extension-agent/client/components/skills/skills-import-github-dialog.vue
@@ -405,7 +405,7 @@ async function importSkills() {
         ElMessage.success(
             result.replaced.length > 0
                 ? `已导入 ${result.imported.length} 个 Skill，并覆盖 ${result.replaced.length} 个同名项。`
-                : `已导入 ${result.imported.length} 个 Skill，并默认启用。`
+                : `已导入 ${result.imported.length} 个 Skill。`
         )
     } catch (error) {
         ElMessage.error(formatError(error))

--- a/packages/extension-agent/client/components/skills/skills-import-markdown-dialog.vue
+++ b/packages/extension-agent/client/components/skills/skills-import-markdown-dialog.vue
@@ -229,7 +229,7 @@ async function importSkills() {
         ElMessage.success(
             result.replaced.length > 0
                 ? `已导入 1 个 Skill，并覆盖同名项。`
-                : `已导入 1 个 Skill，并默认启用。`
+                : `已导入 1 个 Skill。`
         )
     } catch (error) {
         ElMessage.error(`导入失败: ${formatError(error)}`)

--- a/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
+++ b/packages/extension-agent/client/components/sub-agent/sub-agent-page.vue
@@ -193,7 +193,17 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, reactive, ref, toRaw, watch } from 'vue'
+import {
+    computed,
+    onActivated,
+    onBeforeUnmount,
+    onDeactivated,
+    onMounted,
+    reactive,
+    ref,
+    toRaw,
+    watch
+} from 'vue'
 import { send } from '@koishijs/client'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { useCompactMode, useHideDesc } from '../shared/use-hide-desc'
@@ -352,6 +362,7 @@ const compactMode = useCompactMode('subAgent')
 const hideDesc = useHideDesc('subAgent')
 const currentView = ref<'list' | 'detail'>('list')
 const listTab = ref<'catalog' | 'runs' | 'availability'>('catalog')
+const active = ref(false)
 const agents = ref<SubAgentInfo[]>([])
 const runs = ref<SubAgentRunInfo[]>([])
 const toolAvailability = ref<ToolAvailabilityInfo[]>([])
@@ -513,10 +524,21 @@ const computerOptions = computed(() => {
     ]
 })
 
-onMounted(async () => {
+onMounted(() => {
     mobile.value = window.innerWidth <= 768
     window.addEventListener('resize', onResize)
-    await loadExtraData()
+})
+
+onActivated(async () => {
+    active.value = true
+    await loadMeta()
+    if (listTab.value === 'availability') {
+        await loadAvailability()
+    }
+})
+
+onDeactivated(() => {
+    active.value = false
 })
 
 onBeforeUnmount(() => {
@@ -524,13 +546,24 @@ onBeforeUnmount(() => {
 })
 
 watch(
-    [
-        () => props.status.catalog,
-        () => props.tools,
-        () => props.skills
-    ],
+    () => listTab.value,
+    async (value) => {
+        if (value !== 'availability' || !active.value) {
+            return
+        }
+
+        await loadAvailability()
+    }
+)
+
+watch(
+    [() => props.status.catalog, () => props.tools, () => props.skills],
     async () => {
-        await loadDynamicData()
+        if (!active.value || listTab.value !== 'availability') {
+            return
+        }
+
+        await loadAvailability()
     },
     { deep: true }
 )
@@ -548,43 +581,28 @@ function onAgentCreated(id: string) {
     openDetail(id)
 }
 
-async function loadExtraData() {
+async function loadMeta() {
     try {
         busy.value = true
-        const [catalog, runList, availability, presets, models] =
-            await Promise.all([
-                send('chatluna-agent/getSubAgents'),
-                send('chatluna-agent/getSubAgentRuns'),
-                send('chatluna-agent/getToolAvailability'),
-                send('chatluna-agent/getPresetNames'),
-                send('chatluna-agent/getModelNames')
-            ])
+        const [presets, models] = await Promise.all([
+            send('chatluna-agent/getPresetNames'),
+            send('chatluna-agent/getModelNames')
+        ])
 
-        agents.value = [...catalog]
-        runs.value = [...runList]
-        toolAvailability.value = [...availability]
         presetNames.value = [...presets]
         modelNames.value = [...models]
     } catch {
-        ElMessage.error('读取 Sub Agent 数据失败，请稍后重试。')
+        ElMessage.error('读取 Sub Agent 扩展数据失败，请稍后重试。')
     } finally {
         busy.value = false
     }
 }
 
-async function loadDynamicData() {
+async function loadAvailability() {
     try {
-        const [catalog, runList, availability] = await Promise.all([
-            send('chatluna-agent/getSubAgents'),
-            send('chatluna-agent/getSubAgentRuns'),
-            send('chatluna-agent/getToolAvailability')
-        ])
-
-        agents.value = [...catalog]
-        runs.value = [...runList]
-        toolAvailability.value = [...availability]
+        toolAvailability.value = await send('chatluna-agent/getToolAvailability')
     } catch {
-        ElMessage.error('同步 Sub Agent 动态数据失败，请稍后重试。')
+        ElMessage.error('读取工具可用性失败，请稍后重试。')
     }
 }
 
@@ -592,7 +610,10 @@ async function reloadSubAgents() {
     try {
         busy.value = true
         await send('chatluna-agent/reloadSubAgents')
-        await loadExtraData()
+        if (listTab.value === 'availability') {
+            await loadAvailability()
+        }
+        await loadMeta()
         ElMessage.success('已重新扫描 Sub Agent 目录。')
     } catch {
         ElMessage.error('重新扫描失败，请稍后重试。')
@@ -605,7 +626,9 @@ async function toggleAgent(item: SubAgentInfo, enabled: boolean) {
     try {
         await send('chatluna-agent/setSubAgentEnabled', item.id, enabled)
         item.enabled = enabled
-        await loadExtraData()
+        if (listTab.value === 'availability') {
+            await loadAvailability()
+        }
         ElMessage.success(enabled ? '已启用该 agent。' : '已停用该 agent。')
     } catch {
         ElMessage.error('更新 agent 状态失败，请稍后重试。')
@@ -662,7 +685,9 @@ async function saveSelected() {
         }
 
         await send('chatluna-agent/saveSubAgentConfig', next)
-        await loadExtraData()
+        if (listTab.value === 'availability') {
+            await loadAvailability()
+        }
         ElMessage.success('已保存 Sub Agent 配置。')
     } catch {
         ElMessage.error('保存失败，请稍后重试。')
@@ -696,7 +721,9 @@ async function removeAgent(item: SubAgentInfo) {
         if (selected) {
             currentView.value = 'list'
         }
-        await loadExtraData()
+        if (listTab.value === 'availability') {
+            await loadAvailability()
+        }
         ElMessage.success('已删除该 Sub Agent。')
     } catch (error) {
         if (error !== 'cancel' && error !== 'close') {
@@ -734,7 +761,10 @@ async function createPresetAgent(
         busy.value = true
         await send('chatluna-agent/createPresetAgent', name, preset, options)
         showPresetDialog.value = false
-        await loadExtraData()
+        if (listTab.value === 'availability') {
+            await loadAvailability()
+        }
+        await loadMeta()
         ElMessage.success('已创建 preset agent。')
     } catch {
         ElMessage.error('创建 preset agent 失败，请稍后重试。')
@@ -835,7 +865,9 @@ async function savePreview() {
         }
         ElMessage.success('保存内容成功。')
         showPreview.value = false
-        await loadExtraData()
+        if (listTab.value === 'availability') {
+            await loadAvailability()
+        }
     } catch (error) {
         ElMessage.error(
             `保存失败：${error instanceof Error ? error.message : String(error)}`

--- a/packages/extension-agent/src/skills/import.ts
+++ b/packages/extension-agent/src/skills/import.ts
@@ -478,8 +478,18 @@ async function importFromGithub(ctx: Context, url: string, tmp: string) {
 
     await unzipToDir(Buffer.from(response.data), root)
 
+    const files = await collectFilesRecursive(root, { relative: true })
+    const tops = Array.from(
+        new Set(files.map((file) => file.replaceAll('\\', '/').split('/')[0]))
+    ).filter(Boolean)
+    const base =
+        tops.length === 1 &&
+        (await stat(join(root, tops[0])).catch(() => undefined))?.isDirectory()
+            ? join(root, tops[0])
+            : root
+
     const searchRoot = info.subpath
-        ? await findSubpathRoot(root, info.subpath)
+        ? await findSubpathRoot(base, info.subpath)
         : undefined
 
     if (info.subpath && !searchRoot) {
@@ -489,7 +499,7 @@ async function importFromGithub(ctx: Context, url: string, tmp: string) {
     }
 
     return {
-        root: searchRoot ?? root,
+        root: searchRoot ?? base,
         diagnostics
     }
 }


### PR DESCRIPTION
## Summary
- 修复从 GitHub 导入 Skill 时，预览目录与正式导入目录不一致导致无法识别勾选项的问题。
- 调整 Skill 导入成功提示，去掉“默认启用”的误导性文案。
- 保留切回 Skills、Sub Agent、Tools 页时的刷新能力，同时用 KeepAlive、按需请求和刷新去重减少重复加载。

## Testing
- yarn fast-build extension-agent
