### PR TITLE
fix(extension-agent): keep sub-agent tool permissions independent

### DIFF
--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -187,12 +187,7 @@ export class ChatLunaAgentSubAgentService {
                     return undefined
                 }
 
-                const next = this.permission.createSubAgentToolMask(info)
-                const base =
-                    ctx.parent?.toolMask ??
-                    ctx.runConfig?.configurable?.toolMask
-                const names = this.ctx.chatluna.platform.getFilteredTools(next)
-                const mask = buildSubAgentToolMask(base, names)
+                const mask = this.permission.createSubAgentToolMask(info)
 
                 return {
                     agent: await createSubAgent({
@@ -330,32 +325,4 @@ function isRunnable(info: SubAgentInfo) {
         !info.hidden &&
         !info.shadowedBy
     )
-}
-
-function buildSubAgentToolMask(base: ToolMask | undefined, names: string[]) {
-    if (!base) {
-        return buildToolMask(names)
-    }
-
-    const allow = names.filter((name) => {
-        if (base.mode === 'all') {
-            return true
-        }
-
-        if (base.mode === 'allow') {
-            return base.allow.includes(name)
-        }
-
-        return !base.deny.includes(name)
-    })
-
-    return buildToolMask(allow)
-}
-
-function buildToolMask(allow: string[]): ToolMask {
-    return {
-        mode: 'allow',
-        allow,
-        deny: []
-    }
 }


### PR DESCRIPTION
## Summary
- 修复主 Agent 调用 Sub Agent 时，Sub Agent 意外继承父级工具掩码的问题。
- 让 Sub Agent 仅按自身权限配置与工具级 subAgents 规则决定可用工具，避免黑名单模式被父级白名单再次收窄。

## Verification
- yarn fast-build extension-agent
- ./node_modules/.bin/tsc --noEmit -p packages/extension-agent/tsconfig.json
