### PR TITLE
[Refactor] bump package versions for 1.4.0-alpha.0

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-dify-adapter",
     "description": "dify adapter for chatluna",
-    "version": "1.3.8",
+    "version": "1.3.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.3.31",
+    "version": "1.3.32",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80"
     },
     "devDependencies": {
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.3.13",
+    "version": "1.3.14",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "1.0.31",
+        "@chatluna/v1-shared-adapter": "1.0.32",
         "@langchain/core": "^0.3.80",
         "zod-to-json-schema": "3.23.5"
     },
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.31",
+        "@chatluna/v1-shared-adapter": "^1.0.32",
         "@langchain/core": "^0.3.80",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.3.36",
+    "version": "1.4.0-alpha.0",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.15",
+    "version": "1.0.16",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -87,7 +87,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-long-memory",
     "description": "long memory for chatluna",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-plugin-common",
     "description": "plugin service for agent mode of chatluna",
-    "version": "1.3.10",
+    "version": "1.3.11",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -68,8 +68,8 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36",
-        "koishi-plugin-chatluna-agent": "^1.0.14",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0",
+        "koishi-plugin-chatluna-agent": "^1.0.16",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-variable-extension",
     "description": "variable extension for ChatLuna",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -61,7 +61,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.31",
+    "version": "1.0.32",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.3.36"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.0"
     }
 }


### PR DESCRIPTION
description: |-

This pr updates the ChatLuna core package to 1.4.0-alpha.0 and aligns dependent package versions and peer dependency ranges across the monorepo for the alpha release.

## New Features

List new features here

## Bug fixes

See the list of fixed issues below

## Other Changes

- Bump `koishi-plugin-chatluna` to `1.4.0-alpha.0`
- Update dependent package versions including shared adapter, agent, tools, variable, long-memory, gemini, dify, and openai-like packages
- Align peer dependency ranges across adapters, extensions, renderers, and services to the new alpha version