### PR TITLE
fix(core): 正式支持 direct tool observation

### DIFF
--- a/packages/core/src/llm-core/agent/executor.ts
+++ b/packages/core/src/llm-core/agent/executor.ts
@@ -11,6 +11,7 @@ import type { AgentExecutorInput, AgentExecutorOutput } from './legacy-executor'
 export {
     coerceToAgentObservation,
     LegacyAgentExecutor,
+    observationToMessageContent,
     runAgent,
     toToolInputErrorObservation,
     type AgentExecutorInput,

--- a/packages/core/src/llm-core/agent/legacy-executor.ts
+++ b/packages/core/src/llm-core/agent/legacy-executor.ts
@@ -479,6 +479,10 @@ function isAgentObservation(value: unknown): value is AgentObservation {
         return true
     }
 
+    if (isDirectToolOutput(value)) {
+        return true
+    }
+
     if (!Array.isArray(value)) {
         return false
     }
@@ -490,6 +494,10 @@ export function coerceToAgentObservation(
     observation: unknown,
     toolName?: string
 ): AgentObservation {
+    if (isDirectToolOutput(observation)) {
+        return observation
+    }
+
     if (isAgentObservation(observation)) {
         if (
             Array.isArray(observation) &&

--- a/packages/core/src/llm-core/agent/legacy-executor.ts
+++ b/packages/core/src/llm-core/agent/legacy-executor.ts
@@ -599,3 +599,7 @@ function toParsingErrorAction(
         log: text
     }
 }
+
+export function observationToMessageContent(observation: AgentObservation) {
+    return isDirectToolOutput(observation) ? '' : observation
+}

--- a/packages/core/src/llm-core/agent/openai/index.ts
+++ b/packages/core/src/llm-core/agent/openai/index.ts
@@ -7,6 +7,7 @@ import {
     MessageContentComplex,
     ToolMessage
 } from '@langchain/core/messages'
+import { isDirectToolOutput } from '@langchain/core/messages/tool'
 import { BaseOutputParser } from '@langchain/core/output_parsers'
 import {
     RunnableLambda,
@@ -55,16 +56,22 @@ function _convertAgentStepToMessages(
 ) {
     if (isToolsAgentAction(action) && action.toolCallId !== undefined) {
         const log = action.messageLog as BaseMessage[]
+        const content = isDirectToolOutput(observation) ? '' : observation
         if (
-            observation.length < 1 ||
-            observation == null ||
-            observation === 'null'
+            !isDirectToolOutput(observation) &&
+            (content.length < 1 || content === 'null')
         ) {
-            observation = `The tool ${action.tool} returned no output. Try again or stop the tool call, tell the user failed to execute the tool.`
+            return log.concat(
+                new ToolMessage({
+                    content: `The tool ${action.tool} returned no output. Try again or stop the tool call, tell the user failed to execute the tool.`,
+                    name: action.tool,
+                    tool_call_id: action.toolCallId
+                })
+            )
         }
         return log.concat(
             new ToolMessage({
-                content: observation,
+                content,
                 name: action.tool,
                 tool_call_id: action.toolCallId
             })

--- a/packages/core/src/llm-core/agent/openai/index.ts
+++ b/packages/core/src/llm-core/agent/openai/index.ts
@@ -7,7 +7,6 @@ import {
     MessageContentComplex,
     ToolMessage
 } from '@langchain/core/messages'
-import { isDirectToolOutput } from '@langchain/core/messages/tool'
 import { BaseOutputParser } from '@langchain/core/output_parsers'
 import {
     RunnableLambda,
@@ -31,6 +30,7 @@ import {
 } from './output_parser'
 import { BaseChatPromptTemplate } from '@langchain/core/prompts'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
+import { observationToMessageContent } from '../legacy-executor'
 
 /**
  * Checks if the given action is a FunctionsAgentAction.
@@ -56,9 +56,9 @@ function _convertAgentStepToMessages(
 ) {
     if (isToolsAgentAction(action) && action.toolCallId !== undefined) {
         const log = action.messageLog as BaseMessage[]
-        const content = isDirectToolOutput(observation) ? '' : observation
+        const content = observationToMessageContent(observation)
         if (
-            !isDirectToolOutput(observation) &&
+            content === observation &&
             (content.length < 1 || content === 'null')
         ) {
             return log.concat(

--- a/packages/core/src/llm-core/agent/sub-agent.ts
+++ b/packages/core/src/llm-core/agent/sub-agent.ts
@@ -5,6 +5,7 @@ import {
     SystemMessage,
     ToolMessage
 } from '@langchain/core/messages'
+import { isDirectToolOutput } from '@langchain/core/messages/tool'
 import { StructuredTool } from '@langchain/core/tools'
 import { randomUUID } from 'crypto'
 import type { Awaitable, Session } from 'koishi'
@@ -868,7 +869,9 @@ function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
         ...steps.map(
             (step) =>
                 new ToolMessage({
-                    content: step.observation,
+                    content: isDirectToolOutput(step.observation)
+                        ? ''
+                        : step.observation,
                     tool_call_id: step.action.toolCallId,
                     name: step.action.tool
                 })

--- a/packages/core/src/llm-core/agent/sub-agent.ts
+++ b/packages/core/src/llm-core/agent/sub-agent.ts
@@ -5,7 +5,6 @@ import {
     SystemMessage,
     ToolMessage
 } from '@langchain/core/messages'
-import { isDirectToolOutput } from '@langchain/core/messages/tool'
 import { StructuredTool } from '@langchain/core/tools'
 import { randomUUID } from 'crypto'
 import type { Awaitable, Session } from 'koishi'
@@ -13,6 +12,7 @@ import { z } from 'zod'
 import type { ChatLunaToolRunnable } from '../platform/types'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import type { ChatLunaAgent } from './agent'
+import { observationToMessageContent } from './legacy-executor'
 import { MessageQueue } from './types'
 import type { AgentEvent, AgentStep, SubagentContext, ToolMask } from './types'
 
@@ -869,9 +869,7 @@ function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
         ...steps.map(
             (step) =>
                 new ToolMessage({
-                    content: isDirectToolOutput(step.observation)
-                        ? ''
-                        : step.observation,
+                    content: observationToMessageContent(step.observation),
                     tool_call_id: step.action.toolCallId,
                     name: step.action.tool
                 })

--- a/packages/core/src/llm-core/agent/types.ts
+++ b/packages/core/src/llm-core/agent/types.ts
@@ -10,6 +10,7 @@ import type {
     MessageContentFileUrl,
     MessageContentVideo
 } from 'koishi-plugin-chatluna/utils/langchain'
+import type { DirectToolOutput } from '@langchain/core/messages/tool'
 
 export interface ChatCompletionMessageToolCall {
     /**
@@ -193,7 +194,14 @@ export type AgentObservationComplexContent =
     | MessageContentAudio
     | MessageContentVideo
 
-export type AgentObservation = AgentObservationComplexContent[] | string
+export type AgentDirectToolObservation = DirectToolOutput & {
+    replyEmitted?: boolean
+}
+
+export type AgentObservation =
+    | AgentObservationComplexContent[]
+    | AgentDirectToolObservation
+    | string
 
 export interface ToolMask {
     mode: 'all' | 'allow' | 'deny'

--- a/packages/core/src/llm-core/memory/message/database_history.ts
+++ b/packages/core/src/llm-core/memory/message/database_history.ts
@@ -8,6 +8,7 @@ import {
     SystemMessage,
     ToolMessage
 } from '@langchain/core/messages'
+import { isDirectToolOutput } from '@langchain/core/messages/tool'
 import { BaseChatMessageHistory } from '@langchain/core/chat_history'
 import {
     bufferToArrayBuffer,
@@ -71,7 +72,9 @@ function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
         ...steps.map(
             (step) =>
                 new ToolMessage({
-                    content: step.observation,
+                    content: isDirectToolOutput(step.observation)
+                        ? ''
+                        : step.observation,
                     tool_call_id: step.action.toolCallId,
                     name: step.action.tool
                 })

--- a/packages/core/src/llm-core/memory/message/database_history.ts
+++ b/packages/core/src/llm-core/memory/message/database_history.ts
@@ -8,7 +8,6 @@ import {
     SystemMessage,
     ToolMessage
 } from '@langchain/core/messages'
-import { isDirectToolOutput } from '@langchain/core/messages/tool'
 import { BaseChatMessageHistory } from '@langchain/core/chat_history'
 import {
     bufferToArrayBuffer,
@@ -16,6 +15,7 @@ import {
     gzipEncode
 } from 'koishi-plugin-chatluna/utils/string'
 import { randomUUID } from 'crypto'
+import { observationToMessageContent } from '../../agent/legacy-executor'
 import type { AgentStep } from '../../agent/types'
 import type { MessageRecord } from '../../../services/conversation_types'
 
@@ -72,9 +72,7 @@ function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
         ...steps.map(
             (step) =>
                 new ToolMessage({
-                    content: isDirectToolOutput(step.observation)
-                        ? ''
-                        : step.observation,
+                    content: observationToMessageContent(step.observation),
                     tool_call_id: step.action.toolCallId,
                     name: step.action.tool
                 })

--- a/packages/extension-agent/src/sub-agent/session.ts
+++ b/packages/extension-agent/src/sub-agent/session.ts
@@ -6,7 +6,10 @@ import {
     HumanMessage,
     ToolMessage
 } from '@langchain/core/messages'
-import type { AgentStep } from 'koishi-plugin-chatluna/llm-core/agent'
+import {
+    observationToMessageContent,
+    type AgentStep
+} from 'koishi-plugin-chatluna/llm-core/agent'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import type { SubAgentInfo, SubAgentRunInfo } from '../types'
 
@@ -219,7 +222,7 @@ function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
         ...steps.map(
             (step) =>
                 new ToolMessage({
-                    content: step.observation,
+                    content: observationToMessageContent(step.observation),
                     tool_call_id: step.action.toolCallId,
                     name: step.action.tool
                 })

--- a/packages/extension-agent/src/sub-agent/session.ts
+++ b/packages/extension-agent/src/sub-agent/session.ts
@@ -7,8 +7,8 @@ import {
     ToolMessage
 } from '@langchain/core/messages'
 import {
-    observationToMessageContent,
-    type AgentStep
+    type AgentStep,
+    observationToMessageContent
 } from 'koishi-plugin-chatluna/llm-core/agent'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import type { SubAgentInfo, SubAgentRunInfo } from '../types'


### PR DESCRIPTION
## Summary
- 正式将 direct tool output 纳入 `AgentObservation`，避免最终回复对象在 agent 流程中被提前当成非法 observation 转成字符串。
- 在 OpenAI agent、sub-agent 和消息历史落库链路中显式处理 direct tool output，统一将这类控制结果写成空的 tool message 内容。
- 这样 `character_reply` 一类最终回复工具可以通过 LangChain 原生的 `lc_direct_tool_output` 正常结束，而不是依赖额外兜底。
