### PR TITLE
[Fix] preserve compacted history metadata

### DIFF
--- a/packages/core/src/llm-core/agent/legacy-executor.ts
+++ b/packages/core/src/llm-core/agent/legacy-executor.ts
@@ -75,7 +75,7 @@ async function executeTools(
 
                 return {
                     action,
-                    observation: `Tool '${action.tool}' is not allowed for the current sub-agent. Available tools: ${allowed.join(', ')}`
+                    observation: `Tool '${action.tool}' is not allowed for the current agent. Available tools: ${allowed.join(', ')}`
                 } as AgentStep
             }
 

--- a/packages/core/src/llm-core/chain/base.ts
+++ b/packages/core/src/llm-core/chain/base.ts
@@ -393,7 +393,7 @@ export async function callChatLunaChain(
         ]
     })
 
-    await events?.['llm-used-token-count'](usedToken)
+    await events?.['llm-used-token-count']?.(usedToken)
 
     return response
 }

--- a/packages/core/src/llm-core/chain/infinite_context_chain.ts
+++ b/packages/core/src/llm-core/chain/infinite_context_chain.ts
@@ -62,6 +62,9 @@ Focus on information that would be helpful for continuing the conversation, incl
 - Key user requests, constraints, or preferences that should persist
 - Important technical decisions and why they were made
 
+Some old tool result messages may say that the original tool output expired and was removed.
+Treat those as intentional retention placeholders, not as meaningful tool output.
+
 Your summary should be comprehensive enough to provide context but concise enough to be quickly understood.
 
 Do not respond to any questions in the conversation, only output the summary.

--- a/packages/core/src/llm-core/chain/plugin_chat_chain.ts
+++ b/packages/core/src/llm-core/chain/plugin_chat_chain.ts
@@ -192,12 +192,12 @@ export class ChatLunaPluginChain
             .chatHistory as KoishiChatMessageHistory
 
         const messages = await chatHistory.getMessages()
+        const history =
+            this.agentMode === 'react'
+                ? await chatHistory.removeAllToolAndFunctionMessages()
+                : messages
 
-        if (this.agentMode === 'react') {
-            await chatHistory.removeAllToolAndFunctionMessages()
-        }
-
-        requests['chat_history'] = [...messages]
+        requests['chat_history'] = [...history]
         requests['id'] = conversationId
         requests['variables'] = Object.assign(nextVars, {
             prompt: getMessageContent(message.content)

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -157,6 +157,9 @@ export class ChatInterface {
             if (this.ctx.chatluna.currentConfig.infiniteContext) {
                 const manager = this._ensureInfiniteContextManager()
                 const result = await manager?.compressIfNeeded(wrapper)
+                if (result?.messages) {
+                    await this._chatHistory.replaceMessages(result.messages)
+                }
                 if (result?.compressed) {
                     await this.ctx.chatluna.conversation.recordCompression(
                         this._input.conversationId,
@@ -390,6 +393,9 @@ export class ChatInterface {
         }
 
         const result = await manager.compressIfNeeded(wrapper, force)
+        if (result.messages) {
+            await this._chatHistory.replaceMessages(result.messages)
+        }
         if (result.compressed) {
             await this.ctx.chatluna.conversation.recordCompression(
                 this._input.conversationId,

--- a/packages/core/src/llm-core/chat/helper.ts
+++ b/packages/core/src/llm-core/chat/helper.ts
@@ -23,10 +23,18 @@ import {
 
 export function createDisplayResponse(responseMessage: AIMessage) {
     const msg = new AIMessage({
-        content: responseMessage.content
+        content: responseMessage.content,
+        id: responseMessage.id,
+        name: responseMessage.name,
+        tool_calls: responseMessage.tool_calls,
+        usage_metadata: responseMessage.usage_metadata,
+        additional_kwargs: {
+            ...responseMessage.additional_kwargs
+        },
+        response_metadata: {
+            ...responseMessage.response_metadata
+        }
     })
-
-    msg.additional_kwargs = responseMessage.additional_kwargs
     return msg
 }
 

--- a/packages/core/src/llm-core/chat/infinite_context.ts
+++ b/packages/core/src/llm-core/chat/infinite_context.ts
@@ -1,5 +1,9 @@
 /* eslint-disable max-len */
-import { BaseMessage, HumanMessage } from '@langchain/core/messages'
+import {
+    BaseMessage,
+    HumanMessage,
+    mapStoredMessageToChatMessage
+} from '@langchain/core/messages'
 import { ComputedRef } from '@vue/reactivity'
 import { logger } from 'koishi-plugin-chatluna'
 import { ChatLunaLLMChainWrapper } from 'koishi-plugin-chatluna/llm-core/chain/base'
@@ -80,9 +84,13 @@ export class InfiniteContextManager {
         const expiredToolResultText =
             'This tool result expired after 1 hour, so the original output was removed.'
         let compactedCount = 0
-        const compactedMessages = messages.map((message) => {
+        const compactedIndexes = new Set<number>()
+
+        for (let idx = 0; idx < messages.length; idx++) {
+            const message = messages[idx]
+
             if (message.getType() !== 'tool') {
-                return message
+                continue
             }
 
             const meta = message.response_metadata?.chatluna as
@@ -90,24 +98,38 @@ export class InfiniteContextManager {
                 | undefined
 
             if (meta?.createdAt == null) {
-                return message
+                continue
             }
 
             if (Date.now() - new Date(meta.createdAt).getTime() < 3600000) {
-                return message
+                continue
             }
 
             if (
                 getMessageContent(message.content).trim() ===
                 expiredToolResultText
             ) {
-                return message
+                continue
             }
 
-            message.content = expiredToolResultText
             compactedCount++
-            return message
-        })
+            compactedIndexes.add(idx)
+        }
+
+        const compactedMessages =
+            compactedCount > 0
+                ? messages.map((message, idx) => {
+                      const cloned = mapStoredMessageToChatMessage(
+                          message.toDict()
+                      )
+
+                      if (compactedIndexes.has(idx)) {
+                          cloned.content = expiredToolResultText
+                      }
+
+                      return cloned
+                  })
+                : messages
         const nextMessages = compactedCount > 0 ? compactedMessages : messages
         const compactedTokens =
             compactedCount > 0

--- a/packages/core/src/llm-core/chat/infinite_context.ts
+++ b/packages/core/src/llm-core/chat/infinite_context.ts
@@ -8,6 +8,7 @@ import { ChatLunaChatModel } from 'koishi-plugin-chatluna/llm-core/platform/mode
 import { PresetTemplate } from 'koishi-plugin-chatluna/llm-core/prompt'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
 import { ChatLunaInfiniteContextChain } from '../chain/infinite_context_chain'
+import type { ChatLunaMessageMeta } from '../../services/conversation_types'
 
 export interface CompressContextResult {
     inputTokens: number
@@ -17,6 +18,7 @@ export interface CompressContextResult {
     compressed: boolean
     originalMessageCount: number
     remainingMessageCount: number
+    messages?: BaseMessage[]
 }
 
 function formatTranscript(messages: BaseMessage[]) {
@@ -75,8 +77,51 @@ export class InfiniteContextManager {
         }
 
         const inputTokens = await this._countMessagesTokens(model, messages)
+        const expiredToolResultText =
+            'This tool result expired after 1 hour, so the original output was removed.'
+        let compactedCount = 0
+        const compactedMessages = messages.map((message) => {
+            if (message.getType() !== 'tool') {
+                return message
+            }
+
+            const meta = message.response_metadata?.chatluna as
+                | ChatLunaMessageMeta
+                | undefined
+
+            if (meta?.createdAt == null) {
+                return message
+            }
+
+            if (Date.now() - new Date(meta.createdAt).getTime() < 3600000) {
+                return message
+            }
+
+            if (
+                getMessageContent(message.content).trim() ===
+                expiredToolResultText
+            ) {
+                return message
+            }
+
+            message.content = expiredToolResultText
+            compactedCount++
+            return message
+        })
+        const nextMessages = compactedCount > 0 ? compactedMessages : messages
+        const compactedTokens =
+            compactedCount > 0
+                ? await this._countMessagesTokens(model, nextMessages)
+                : inputTokens
         let presetTokens = 0
         let threshold: number | undefined
+
+        if (compactedCount > 0) {
+            logger.info(
+                '[InfiniteContext] Replaced %d expired tool results before compression',
+                compactedCount
+            )
+        }
 
         if (!force) {
             const invocation = model.invocationParams()
@@ -88,12 +133,17 @@ export class InfiniteContextManager {
             if (!maxTokenLimit || maxTokenLimit <= 0) {
                 return {
                     inputTokens,
-                    outputTokens: inputTokens,
-                    reducedTokens: 0,
-                    reducedPercent: 0,
+                    outputTokens: compactedTokens,
+                    reducedTokens: inputTokens - compactedTokens,
+                    reducedPercent:
+                        inputTokens > 0
+                            ? ((inputTokens - compactedTokens) / inputTokens) *
+                              100
+                            : 0,
                     compressed: false,
                     originalMessageCount: messages.length,
-                    remainingMessageCount: messages.length
+                    remainingMessageCount: nextMessages.length,
+                    messages: compactedCount > 0 ? nextMessages : undefined
                 }
             }
 
@@ -111,42 +161,51 @@ export class InfiniteContextManager {
                 maxTokenLimit * (this.options.threshold ?? 0.85)
             )
 
-            if (inputTokens + presetTokens <= threshold) {
+            if (compactedTokens + presetTokens <= threshold) {
                 return {
                     inputTokens,
-                    outputTokens: inputTokens,
-                    reducedTokens: 0,
-                    reducedPercent: 0,
+                    outputTokens: compactedTokens,
+                    reducedTokens: inputTokens - compactedTokens,
+                    reducedPercent:
+                        inputTokens > 0
+                            ? ((inputTokens - compactedTokens) / inputTokens) *
+                              100
+                            : 0,
                     compressed: false,
                     originalMessageCount: messages.length,
-                    remainingMessageCount: messages.length
+                    remainingMessageCount: nextMessages.length,
+                    messages: compactedCount > 0 ? nextMessages : undefined
                 }
             }
 
             logger.info(
                 '[InfiniteContext] Start compression with history tokens: %d, total tokens: %d, threshold: %d',
-                inputTokens,
-                inputTokens + presetTokens,
+                compactedTokens,
+                compactedTokens + presetTokens,
                 threshold
             )
         } else {
             logger.info(
                 '[InfiniteContext] Start manual compression with history tokens: %d',
-                inputTokens
+                compactedTokens
             )
         }
 
-        const transcript = formatTranscript(messages)
+        const transcript = formatTranscript(nextMessages)
 
         if (!transcript.trim()) {
             return {
                 inputTokens,
-                outputTokens: inputTokens,
-                reducedTokens: 0,
-                reducedPercent: 0,
+                outputTokens: compactedTokens,
+                reducedTokens: inputTokens - compactedTokens,
+                reducedPercent:
+                    inputTokens > 0
+                        ? ((inputTokens - compactedTokens) / inputTokens) * 100
+                        : 0,
                 compressed: false,
                 originalMessageCount: messages.length,
-                remainingMessageCount: messages.length
+                remainingMessageCount: nextMessages.length,
+                messages: compactedCount > 0 ? nextMessages : undefined
             }
         }
 
@@ -160,12 +219,16 @@ export class InfiniteContextManager {
         if (!summary?.text.trim()) {
             return {
                 inputTokens,
-                outputTokens: inputTokens,
-                reducedTokens: 0,
-                reducedPercent: 0,
+                outputTokens: compactedTokens,
+                reducedTokens: inputTokens - compactedTokens,
+                reducedPercent:
+                    inputTokens > 0
+                        ? ((inputTokens - compactedTokens) / inputTokens) * 100
+                        : 0,
                 compressed: false,
                 originalMessageCount: messages.length,
-                remainingMessageCount: messages.length
+                remainingMessageCount: nextMessages.length,
+                messages: compactedCount > 0 ? nextMessages : undefined
             }
         }
 
@@ -176,8 +239,6 @@ export class InfiniteContextManager {
                 source: 'infinite-context'
             }
         })
-
-        await this._rewriteChatHistory([message])
 
         const outputTokens = summary.usageMetadata?.output_tokens ?? 0
         const reducedTokens = inputTokens - outputTokens
@@ -207,28 +268,9 @@ export class InfiniteContextManager {
             reducedPercent,
             compressed: true,
             originalMessageCount: messages.length,
-            remainingMessageCount: 1
+            remainingMessageCount: 1,
+            messages: [message]
         }
-    }
-
-    private async _rewriteChatHistory(messages: BaseMessage[]): Promise<void> {
-        const additionalArgs = {
-            ...(await this.options.chatHistory.getAdditionalArgs())
-        }
-
-        await this.options.chatHistory.clear()
-
-        for (const message of messages) {
-            await this.options.chatHistory.addMessage(message)
-        }
-
-        if (Object.keys(additionalArgs).length > 0) {
-            await this.options.chatHistory.overrideAdditionalArgs(
-                additionalArgs
-            )
-        }
-
-        await this.options.chatHistory.loadConversation()
     }
 
     private async _countMessagesTokens(

--- a/packages/core/src/llm-core/memory/message/database_history.ts
+++ b/packages/core/src/llm-core/memory/message/database_history.ts
@@ -208,7 +208,7 @@ export class KoishiChatMessageHistory extends BaseChatMessageHistory {
         await this._saveConversation()
     }
 
-    async removeAllToolAndFunctionMessages() {
+    async removeAllToolAndFunctionMessages(): Promise<BaseMessage[]> {
         const messages = await this.getMessages()
         const filtered = messages.filter((message) => {
             const type = message.getType()
@@ -216,10 +216,12 @@ export class KoishiChatMessageHistory extends BaseChatMessageHistory {
         })
 
         if (filtered.length === messages.length) {
-            return
+            return messages
         }
 
         await this.replaceMessages(filtered)
+
+        return filtered
     }
 
     async overrideAdditionalArgs(kwargs: {

--- a/packages/core/src/llm-core/memory/message/database_history.ts
+++ b/packages/core/src/llm-core/memory/message/database_history.ts
@@ -17,68 +17,10 @@ import {
 import { randomUUID } from 'crypto'
 import { observationToMessageContent } from '../../agent/legacy-executor'
 import type { AgentStep } from '../../agent/types'
-import type { MessageRecord } from '../../../services/conversation_types'
-
-async function serializeMessage(
-    message: BaseMessage,
-    conversationId: string,
-    parentId?: string | null
-): Promise<MessageRecord> {
-    let additionalArgs = Object.assign({}, message.additional_kwargs)
-
-    delete additionalArgs['preset']
-    delete additionalArgs['raw_content']
-    delete additionalArgs['type']
-
-    if (Object.keys(additionalArgs).length === 0) {
-        additionalArgs = null
-    }
-
-    return {
-        id: randomUUID(),
-        content: await gzipEncode(JSON.stringify(message.content)).then((buf) =>
-            bufferToArrayBuffer(buf)
-        ),
-        parentId: parentId ?? null,
-        role: message.getType(),
-        name: message.name,
-        tool_calls: message['tool_calls'],
-        tool_call_id: message['tool_call_id'],
-        additional_kwargs_binary:
-            additionalArgs && Object.keys(additionalArgs).length > 0
-                ? await gzipEncode(JSON.stringify(additionalArgs)).then((buf) =>
-                      bufferToArrayBuffer(buf)
-                  )
-                : null,
-        rawId: message.id ?? null,
-        conversationId,
-        createdAt: new Date()
-    }
-}
-
-function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
-    return [
-        new AIMessage({
-            content: '',
-            tool_calls: steps.map((step) => ({
-                id: step.action.toolCallId,
-                name: step.action.tool,
-                args:
-                    typeof step.action.toolInput !== 'string'
-                        ? step.action.toolInput
-                        : { input: step.action.toolInput }
-            }))
-        }),
-        ...steps.map(
-            (step) =>
-                new ToolMessage({
-                    content: observationToMessageContent(step.observation),
-                    tool_call_id: step.action.toolCallId,
-                    name: step.action.tool
-                })
-        )
-    ]
-}
+import type {
+    ChatLunaMessageMeta,
+    MessageRecord
+} from '../../../services/conversation_types'
 
 export class KoishiChatMessageHistory extends BaseChatMessageHistory {
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -182,6 +124,43 @@ export class KoishiChatMessageHistory extends BaseChatMessageHistory {
         await this.addMessages(createAgentToolMessages(steps))
     }
 
+    async replaceMessages(messages: BaseMessage[]): Promise<void> {
+        await this.loadConversation()
+
+        const serializedMessages: MessageRecord[] = []
+        let parentId: string | null = null
+
+        for (const message of messages) {
+            const serializedMessage = await serializeMessage(
+                message,
+                this.conversationId,
+                parentId
+            )
+            serializedMessages.push(serializedMessage)
+            parentId = serializedMessage.id
+        }
+
+        await this._ctx.database.remove('chatluna_message', {
+            conversationId: this.conversationId
+        })
+
+        if (serializedMessages.length > 0) {
+            await this._ctx.database.upsert(
+                'chatluna_message',
+                serializedMessages
+            )
+        }
+
+        this._serializedChatHistory = serializedMessages
+        this._chatHistory = [...messages]
+        this._latestId =
+            serializedMessages[serializedMessages.length - 1]?.id ?? null
+        const updatedAt = new Date()
+        this._updatedAt = updatedAt
+
+        await this._saveConversation(updatedAt)
+    }
+
     async clear(): Promise<void> {
         await this._ctx.database.remove('chatluna_message', {
             conversationId: this.conversationId
@@ -230,59 +209,17 @@ export class KoishiChatMessageHistory extends BaseChatMessageHistory {
     }
 
     async removeAllToolAndFunctionMessages() {
-        await this.loadConversation()
+        const messages = await this.getMessages()
+        const filtered = messages.filter((message) => {
+            const type = message.getType()
+            return type !== 'tool' && type !== 'function'
+        })
 
-        const toolAndFunctionMessages = this._serializedChatHistory.filter(
-            (msg) => msg.role === 'tool' || msg.role === 'function'
-        )
-
-        if (toolAndFunctionMessages.length === 0) {
+        if (filtered.length === messages.length) {
             return
         }
 
-        const messageIds = toolAndFunctionMessages.map((msg) => msg.id)
-
-        await this._ctx.database.remove('chatluna_message', {
-            id: messageIds
-        })
-
-        this._serializedChatHistory = this._serializedChatHistory.filter(
-            (msg) => msg.role !== 'tool' && msg.role !== 'function'
-        )
-
-        for (let i = 0; i < this._serializedChatHistory.length; i++) {
-            const currentMsg = this._serializedChatHistory[i]
-            const prevMsg = this._serializedChatHistory[i - 1]
-
-            currentMsg.parentId = prevMsg?.id ?? null
-        }
-
-        if (this._serializedChatHistory.length > 0) {
-            const updatedMessages = this._serializedChatHistory.map((msg) => ({
-                id: msg.id,
-                parentId: msg.parentId,
-                content: msg.content,
-                role: msg.role,
-                conversationId: msg.conversationId,
-                name: msg.name,
-                tool_call_id: msg.tool_call_id,
-                tool_calls: msg.tool_calls,
-                additional_kwargs_binary: msg.additional_kwargs_binary,
-                rawId: msg.rawId
-            }))
-
-            await this._ctx.database.upsert('chatluna_message', updatedMessages)
-
-            this._latestId =
-                this._serializedChatHistory[
-                    this._serializedChatHistory.length - 1
-                ].id
-        } else {
-            this._latestId = null
-        }
-
-        await this._saveConversation()
-        this._chatHistory = await this._loadMessages()
+        await this.replaceMessages(filtered)
     }
 
     async overrideAdditionalArgs(kwargs: {
@@ -363,8 +300,19 @@ export class KoishiChatMessageHistory extends BaseChatMessageHistory {
             const args = JSON.parse(
                 item.additional_kwargs_binary
                     ? await gzipDecode(item.additional_kwargs_binary)
-                    : (item.additional_kwargs ?? '{}')
+                    : '{}'
             )
+            const responseMetadata = JSON.parse(
+                item.response_metadata_binary
+                    ? await gzipDecode(item.response_metadata_binary)
+                    : '{}'
+            )
+
+            responseMetadata.chatluna = {
+                ...(responseMetadata.chatluna ?? {}),
+                recordId: item.id,
+                createdAt: item.createdAt?.toISOString()
+            }
 
             let content: MessageContent
             try {
@@ -392,6 +340,7 @@ export class KoishiChatMessageHistory extends BaseChatMessageHistory {
                 tool_calls:
                     (item.tool_calls as AIMessage['tool_calls']) ?? undefined,
                 tool_call_id: item.tool_call_id ?? undefined,
+                response_metadata: responseMetadata,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 additional_kwargs: args as any
             }
@@ -519,5 +468,115 @@ export class KoishiChatMessageHistory extends BaseChatMessageHistory {
                 updatedAt: time
             }
         ])
+    }
+}
+
+async function serializeMessage(
+    message: BaseMessage,
+    conversationId: string,
+    parentId?: string | null
+): Promise<MessageRecord> {
+    const meta = readMessageMeta(message)
+    const id = meta.recordId ?? randomUUID()
+    const createdAt = meta.createdAt ? new Date(meta.createdAt) : new Date()
+
+    writeMessageMeta(message, {
+        recordId: id,
+        createdAt: createdAt.toISOString()
+    })
+
+    let additionalArgs = Object.assign({}, message.additional_kwargs)
+
+    delete additionalArgs['preset']
+    delete additionalArgs['raw_content']
+    delete additionalArgs['type']
+
+    if (Object.keys(additionalArgs).length === 0) {
+        additionalArgs = null
+    }
+
+    let responseMetadata = Object.assign({}, message.response_metadata)
+
+    if (Object.keys(responseMetadata).length === 0) {
+        responseMetadata = null
+    }
+
+    return {
+        id,
+        content: await gzipEncode(JSON.stringify(message.content)).then((buf) =>
+            bufferToArrayBuffer(buf)
+        ),
+        parentId: parentId ?? null,
+        role: message.getType(),
+        name: message.name,
+        tool_calls: message['tool_calls'],
+        tool_call_id: message['tool_call_id'],
+        additional_kwargs_binary:
+            additionalArgs && Object.keys(additionalArgs).length > 0
+                ? await gzipEncode(JSON.stringify(additionalArgs)).then((buf) =>
+                      bufferToArrayBuffer(buf)
+                  )
+                : null,
+        response_metadata_binary:
+            responseMetadata && Object.keys(responseMetadata).length > 0
+                ? await gzipEncode(JSON.stringify(responseMetadata)).then(
+                      (buf) => bufferToArrayBuffer(buf)
+                  )
+                : null,
+        rawId: message.id ?? null,
+        conversationId,
+        createdAt
+    }
+}
+
+function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
+    return [
+        new AIMessage({
+            content: '',
+            tool_calls: steps.map((step) => ({
+                id: step.action.toolCallId,
+                name: step.action.tool,
+                args:
+                    typeof step.action.toolInput !== 'string'
+                        ? step.action.toolInput
+                        : { input: step.action.toolInput }
+            }))
+        }),
+        ...steps.map(
+            (step) =>
+                new ToolMessage({
+                    content: observationToMessageContent(step.observation),
+                    tool_call_id: step.action.toolCallId,
+                    name: step.action.tool
+                })
+        )
+    ]
+}
+
+function readMessageMeta(message: BaseMessage) {
+    const meta = message.response_metadata?.chatluna as
+        | ChatLunaMessageMeta
+        | undefined
+
+    return {
+        recordId:
+            typeof meta?.recordId === 'string' && meta.recordId.length > 0
+                ? meta.recordId
+                : undefined,
+        createdAt:
+            typeof meta?.createdAt === 'string' && meta.createdAt.length > 0
+                ? meta.createdAt
+                : undefined
+    }
+}
+
+function writeMessageMeta(message: BaseMessage, meta: ChatLunaMessageMeta) {
+    message.response_metadata = {
+        ...(message.response_metadata ?? {}),
+        chatluna: {
+            ...((message.response_metadata?.chatluna as ChatLunaMessageMeta) ??
+                {}),
+            ...meta
+        }
     }
 }

--- a/packages/core/src/migration/room_to_conversation.ts
+++ b/packages/core/src/migration/room_to_conversation.ts
@@ -38,6 +38,7 @@ import {
     validateRoomMigration,
     writeMetaValue
 } from './validators'
+import { bufferToArrayBuffer, gzipEncode } from '../utils/compression'
 
 export const BUILTIN_SCHEMA_VERSION = 1
 
@@ -482,33 +483,49 @@ async function migrateMessages(ctx: Context) {
             break
         }
 
-        const payload: MessageRecord[] = batch.flatMap((item) => {
+        const payload: MessageRecord[] = []
+
+        for (const item of batch) {
             const conversationIds = targets.get(item.conversation)
 
             if (conversationIds == null) {
-                return []
+                continue
             }
 
-            return conversationIds.map((conversationId) => ({
-                id: mapMessageId(item.conversation, conversationId, item.id)!,
-                conversationId,
-                parentId: mapMessageId(
-                    item.conversation,
+            const additionalKwargsBinary =
+                item.additional_kwargs_binary ??
+                (item.additional_kwargs != null
+                    ? await gzipEncode(item.additional_kwargs).then((buf) =>
+                          bufferToArrayBuffer(buf)
+                      )
+                    : null)
+
+            for (const conversationId of conversationIds) {
+                payload.push({
+                    id: mapMessageId(
+                        item.conversation,
+                        conversationId,
+                        item.id
+                    )!,
                     conversationId,
-                    item.parent ?? null
-                ),
-                role: item.role,
-                text: typeof item.text === 'string' ? item.text : null,
-                content: item.content ?? null,
-                name: item.name ?? null,
-                tool_call_id: item.tool_call_id ?? null,
-                tool_calls: item.tool_calls,
-                additional_kwargs: item.additional_kwargs ?? null,
-                additional_kwargs_binary: item.additional_kwargs_binary ?? null,
-                rawId: item.rawId ?? null,
-                createdAt: null
-            }))
-        })
+                    parentId: mapMessageId(
+                        item.conversation,
+                        conversationId,
+                        item.parent ?? null
+                    ),
+                    role: item.role,
+                    text: typeof item.text === 'string' ? item.text : null,
+                    content: item.content ?? null,
+                    name: item.name ?? null,
+                    tool_call_id: item.tool_call_id ?? null,
+                    tool_calls: item.tool_calls,
+                    additional_kwargs_binary: additionalKwargsBinary,
+                    response_metadata_binary: null,
+                    rawId: item.rawId ?? null,
+                    createdAt: null
+                })
+            }
+        }
 
         if (payload.length > 0) {
             await ctx.database.upsert('chatluna_message', payload)

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -619,11 +619,11 @@ export class ChatLunaService extends Service<Config> {
                     type: 'json',
                     nullable: true
                 },
-                additional_kwargs: {
-                    type: 'text',
+                additional_kwargs_binary: {
+                    type: 'binary',
                     nullable: true
                 },
-                additional_kwargs_binary: {
+                response_metadata_binary: {
                     type: 'binary',
                     nullable: true
                 },

--- a/packages/core/src/services/conversation_types.ts
+++ b/packages/core/src/services/conversation_types.ts
@@ -60,10 +60,15 @@ export interface MessageRecord {
     name?: string | null
     tool_call_id?: string | null
     tool_calls?: AIMessage['tool_calls']
-    additional_kwargs?: string | null
     additional_kwargs_binary?: ArrayBuffer | null
+    response_metadata_binary?: ArrayBuffer | null
     rawId?: string | null
     createdAt?: Date | null
+}
+
+export interface ChatLunaMessageMeta {
+    recordId?: string
+    createdAt?: string
 }
 
 export interface BindingRecord {

--- a/packages/core/src/services/types.ts
+++ b/packages/core/src/services/types.ts
@@ -130,10 +130,14 @@ export interface ResolveTargetConversationOptions extends ResolveConversationCon
 
 export interface SerializedMessageRecord extends Omit<
     MessageRecord,
-    'content' | 'additional_kwargs_binary' | 'createdAt'
+    | 'content'
+    | 'additional_kwargs_binary'
+    | 'response_metadata_binary'
+    | 'createdAt'
 > {
     content?: string | null
     additional_kwargs_binary?: string | null
+    response_metadata_binary?: string | null
     createdAt?: string | null
 }
 

--- a/packages/core/src/utils/archive.ts
+++ b/packages/core/src/utils/archive.ts
@@ -179,6 +179,9 @@ export function serializeMessage(
         additional_kwargs_binary: serializeBinary(
             message.additional_kwargs_binary
         ),
+        response_metadata_binary: serializeBinary(
+            message.response_metadata_binary
+        ),
         createdAt: message.createdAt?.toISOString() ?? null
     }
 }
@@ -191,6 +194,9 @@ export function deserializeMessage(
         content: deserializeBinary(message.content),
         additional_kwargs_binary: deserializeBinary(
             message.additional_kwargs_binary
+        ),
+        response_metadata_binary: deserializeBinary(
+            message.response_metadata_binary
         ),
         createdAt: message.createdAt ? new Date(message.createdAt) : null
     }

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -417,8 +417,8 @@ export function createMessage(
         name: 'user',
         tool_call_id: null,
         tool_calls: null,
-        additional_kwargs: null,
         additional_kwargs_binary: null,
+        response_metadata_binary: null,
         rawId: null,
         createdAt: new Date('2026-03-21T00:00:00.000Z'),
         ...overrides


### PR DESCRIPTION
This pr preserves message metadata when infinite-context compaction rewrites conversation history, so expired tool outputs can be replaced without losing record identity, timestamps, or display metadata.

## New Features

- Compact expired tool result messages into a retention placeholder before infinite-context compression to reduce history token usage without dropping conversation flow.
- Return rewritten message sets from compression so chat history can persist the compacted version directly.

## Bug fixes

- Preserve `response_metadata`, record ids, and creation timestamps when serializing and rewriting chat history.
- Store response metadata in message records, archives, and room-to-conversation migration payloads so rewritten histories survive reloads and migration.
- Keep display responses and token-count event hooks from dropping metadata or failing when the hook is absent.

## Other Changes

- Update the infinite-context summary prompt to treat expired tool-output placeholders as retention markers instead of meaningful tool output.
- Align core message types and test helpers with the new binary metadata fields.