### PR TITLE
fix(core): stop blacklisted sessions before allow_reply

### DIFF
--- a/packages/core/src/middlewares/chat/allow_reply.ts
+++ b/packages/core/src/middlewares/chat/allow_reply.ts
@@ -12,6 +12,12 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             context.options.reply_status = false
 
+            // 黑名单检查
+            if ((await session.resolve(config.blackList)) === 1) {
+                context.message = session.text('chatluna.block_message')
+                return ChainMiddlewareRunStatus.STOP
+            }
+
             const content = h
                 .select(session.elements, 'text')
                 .join('')


### PR DESCRIPTION
## Summary
- move blacklist gating into `allow_reply` so blacklisted sessions stop before any reply allowance checks
- keep the existing `allow_reply` path unchanged for non-blacklisted sessions

## Testing
- `yarn fast-build core`

Closes #822