### PR TITLE
[Fix] Keep conversation commands on the active preset lane

### DIFF
--- a/packages/core/src/commands/conversation.ts
+++ b/packages/core/src/commands/conversation.ts
@@ -58,26 +58,33 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
     const switchCommand = ctx.command('chatluna.switch <conversation:string>', {
         authority: 1
     })
-    switchCommand.action(async ({ session }, conversation) => {
-        await chain.receiveCommand(
-            session,
-            'conversation_switch',
-            {
-                conversation_manage: {
-                    targetConversation: await completeConversationTarget(
-                        ctx,
-                        session,
-                        conversation,
-                        undefined,
-                        false,
-                        'commands.chatluna.conversation.options.conversation',
-                        true
-                    )
-                }
-            },
-            ctx
-        )
-    })
+    switchCommand
+        .option('preset', '-p <preset:string>')
+        .action(async ({ options, session }, conversation) => {
+            const presetLane =
+                options.preset == null || options.preset.trim().length < 1
+                    ? undefined
+                    : options.preset.trim()
+            await chain.receiveCommand(
+                session,
+                'conversation_switch',
+                {
+                    conversation_manage: {
+                        targetConversation: await completeConversationTarget(
+                            ctx,
+                            session,
+                            conversation,
+                            presetLane,
+                            false,
+                            'commands.chatluna.conversation.options.conversation',
+                            presetLane == null
+                        ),
+                        presetLane
+                    }
+                },
+                ctx
+            )
+        })
 
     ctx.command('chatluna.list', {
         authority: 1
@@ -86,7 +93,12 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
         .option('limit', '-l <limit:number>')
         .option('archived', '-a')
         .option('all', '--all')
+        .option('preset', '-P <preset:string>')
         .action(async ({ options, session }) => {
+            const presetLane =
+                options.preset == null || options.preset.trim().length < 1
+                    ? undefined
+                    : options.preset.trim()
             await chain.receiveCommand(
                 session,
                 'conversation_list',
@@ -94,6 +106,7 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
                     page: options.page ?? 1,
                     limit: options.limit ?? 5,
                     conversation_manage: {
+                        presetLane,
                         includeArchived:
                             options.archived === true || options.all === true
                     }
@@ -147,7 +160,7 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
                             session,
                             conversation,
                             presetLane,
-                            true,
+                            false,
                             'commands.chatluna.conversation.options.conversation',
                             presetLane == null
                         ),
@@ -166,11 +179,15 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
     )
     restoreCommand
         .option('preset', '-p <preset:string>')
+        .option('archived', '-a')
+        .option('all', '--all')
         .action(async ({ options, session }, conversation) => {
             const presetLane =
                 options.preset == null || options.preset.trim().length < 1
                     ? undefined
                     : options.preset.trim()
+            const includeArchived =
+                options.archived === true || options.all === true
             await chain.receiveCommand(
                 session,
                 'conversation_restore',
@@ -181,11 +198,13 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
                             session,
                             conversation,
                             presetLane,
-                            true,
+                            includeArchived,
                             'commands.chatluna.conversation.options.conversation',
-                            presetLane == null
+                            presetLane == null,
+                            true
                         ),
-                        presetLane
+                        presetLane,
+                        includeArchived
                     }
                 },
                 ctx
@@ -197,11 +216,15 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
     })
     exportCommand
         .option('preset', '-p <preset:string>')
+        .option('archived', '-a')
+        .option('all', '--all')
         .action(async ({ options, session }, conversation) => {
             const presetLane =
                 options.preset == null || options.preset.trim().length < 1
                     ? undefined
                     : options.preset.trim()
+            const includeArchived =
+                options.archived === true || options.all === true
             await chain.receiveCommand(
                 session,
                 'conversation_export',
@@ -212,11 +235,13 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
                             session,
                             conversation,
                             presetLane,
-                            true,
+                            includeArchived,
                             'commands.chatluna.conversation.options.conversation',
-                            presetLane == null
+                            presetLane == null,
+                            true
                         ),
-                        presetLane
+                        presetLane,
+                        includeArchived
                     }
                 },
                 ctx
@@ -231,11 +256,15 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
     )
     compressCommand
         .option('preset', '-p <preset:string>')
+        .option('archived', '-a')
+        .option('all', '--all')
         .action(async ({ options, session }, conversation) => {
             const presetLane =
                 options.preset == null || options.preset.trim().length < 1
                     ? undefined
                     : options.preset.trim()
+            const includeArchived =
+                options.archived === true || options.all === true
             await chain.receiveCommand(
                 session,
                 'conversation_compress',
@@ -247,11 +276,13 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
                             session,
                             conversation,
                             presetLane,
-                            true,
+                            includeArchived,
                             'commands.chatluna.conversation.options.conversation',
-                            presetLane == null
+                            presetLane == null,
+                            true
                         ),
-                        presetLane
+                        presetLane,
+                        includeArchived
                     },
                     i18n_base: 'commands.chatluna.compress.messages'
                 },
@@ -288,11 +319,15 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
         authority: 1
     })
         .option('preset', '-p <preset:string>')
+        .option('archived', '-a')
+        .option('all', '--all')
         .action(async ({ options, session }, conversation) => {
             const presetLane =
                 options.preset == null || options.preset.trim().length < 1
                     ? undefined
                     : options.preset.trim()
+            const includeArchived =
+                options.archived === true || options.all === true
             await chain.receiveCommand(
                 session,
                 'conversation_delete',
@@ -303,11 +338,13 @@ export function apply(ctx: Context, _config: Config, chain: ChatChain) {
                             session,
                             conversation,
                             presetLane,
-                            true,
+                            includeArchived,
                             'commands.chatluna.conversation.options.conversation',
-                            presetLane == null
+                            presetLane == null,
+                            true
                         ),
-                        presetLane
+                        presetLane,
+                        includeArchived
                     }
                 },
                 ctx

--- a/packages/core/src/locales/en-US.yml
+++ b/packages/core/src/locales/en-US.yml
@@ -89,18 +89,24 @@ commands:
                 conversation: Target conversation by seq, ID, or title.
             options:
                 preset: Preset lane.
+                archived: Include archived conversations.
+                all: Include archived conversations.
         export:
             description: Export a conversation as a markdown transcript.
             arguments:
                 conversation: Target conversation by seq, ID, or title.
             options:
                 preset: Preset lane.
+                archived: Include archived conversations.
+                all: Include archived conversations.
         compress:
             description: Compress a conversation without referencing rooms.
             arguments:
                 conversation: Target conversation by seq, ID, or title.
             options:
                 preset: Preset lane.
+                archived: Include archived conversations.
+                all: Include archived conversations.
             messages:
                 success: '{0} -> {1}, {2}%'
                 skipped: 'Compression skipped. {0} -> {1}, {2}%'
@@ -112,6 +118,8 @@ commands:
                 conversation: Target conversation by seq, ID, or title.
             options:
                 preset: Preset lane.
+                archived: Include archived conversations.
+                all: Include archived conversations.
         use:
             description: Update the active conversation usage settings.
             model:

--- a/packages/core/src/locales/zh-CN.yml
+++ b/packages/core/src/locales/zh-CN.yml
@@ -89,18 +89,24 @@ commands:
                 conversation: 目标会话，可使用序号、ID 或标题。
             options:
                 preset: 预设分流。
+                archived: 包含已归档会话。
+                all: 包含已归档会话。
         export:
             description: 将会话导出为 Markdown 记录。
             arguments:
                 conversation: 目标会话，可使用序号、ID 或标题。
             options:
                 preset: 预设分流。
+                archived: 包含已归档会话。
+                all: 包含已归档会话。
         compress:
             description: 在不引用房间的情况下压缩一个会话。
             arguments:
                 conversation: 目标会话，可使用序号、ID 或标题。
             options:
                 preset: 预设分流。
+                archived: 包含已归档会话。
+                all: 包含已归档会话。
             messages:
                 success: '{0} -> {1}, {2}%'
                 skipped: '未执行压缩。{0} -> {1}, {2}%'
@@ -112,6 +118,8 @@ commands:
                 conversation: 目标会话，可使用序号、ID 或标题。
             options:
                 preset: 预设分流。
+                archived: 包含已归档会话。
+                all: 包含已归档会话。
         use:
             description: 调整当前会话的使用配置。
             model:

--- a/packages/core/src/middlewares/chat/rollback_chat.ts
+++ b/packages/core/src/middlewares/chat/rollback_chat.ts
@@ -22,39 +22,44 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             if (command !== 'rollback') return ChainMiddlewareRunStatus.SKIPPED
 
             const rollbackRound = context.options.rollback_round ?? 1
-            let conversation =
-                context.options.resolvedConversation != null
-                    ? await ctx.chatluna.conversation.resolveCommandConversation(
-                          session,
-                          {
-                              conversationId:
-                                  context.options.resolvedConversation.id,
-                              presetLane: context.options.presetLane,
-                              allPresetLanes: context.options.allPresetLanes,
-                              permission: 'manage'
-                          }
-                      )
-                    : await ctx.chatluna.conversation.resolveCommandConversation(
-                          session,
-                          {
-                              conversationId: context.options.conversationId,
-                              targetConversation:
-                                  context.options.targetConversation,
-                              presetLane: context.options.presetLane,
-                              allPresetLanes: context.options.allPresetLanes,
-                              permission: 'manage'
-                          }
-                      )
+            const hasTarget =
+                context.options.resolvedConversation != null ||
+                context.options.conversationId != null ||
+                context.options.targetConversation != null
+            let conversation = !hasTarget
+                ? null
+                : context.options.resolvedConversation != null
+                  ? await ctx.chatluna.conversation.resolveCommandConversation(
+                        session,
+                        {
+                            conversationId:
+                                context.options.resolvedConversation.id,
+                            presetLane: context.options.presetLane,
+                            allPresetLanes: context.options.allPresetLanes,
+                            permission: 'manage'
+                        }
+                    )
+                  : await ctx.chatluna.conversation.resolveCommandConversation(
+                        session,
+                        {
+                            conversationId: context.options.conversationId,
+                            targetConversation:
+                                context.options.targetConversation,
+                            presetLane: context.options.presetLane,
+                            allPresetLanes: context.options.allPresetLanes,
+                            permission: 'manage'
+                        }
+                    )
 
-            if (
-                conversation == null &&
-                context.options.conversationId == null &&
-                context.options.targetConversation == null &&
-                context.options.resolvedConversation == null
-            ) {
+            if (conversation == null && !hasTarget) {
                 conversation = (
                     await ctx.chatluna.conversation.getCurrentConversation(
-                        session
+                        session,
+                        {
+                            presetLane: context.options.presetLane,
+                            useRoutePresetLane:
+                                context.options.presetLane == null
+                        }
                     )
                 ).conversation
 

--- a/packages/core/src/middlewares/chat/stop_chat.ts
+++ b/packages/core/src/middlewares/chat/stop_chat.ts
@@ -10,34 +10,44 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
             if (command !== 'stop_chat') return ChainMiddlewareRunStatus.SKIPPED
 
-            let conversation =
-                context.options.resolvedConversation != null
-                    ? await ctx.chatluna.conversation.resolveCommandConversation(
-                          session,
-                          {
-                              conversationId:
-                                  context.options.resolvedConversation.id,
-                              presetLane: context.options.presetLane,
-                              allPresetLanes: context.options.allPresetLanes,
-                              permission: 'manage'
-                          }
-                      )
-                    : await ctx.chatluna.conversation.resolveCommandConversation(
-                          session,
-                          {
-                              conversationId: context.options.conversationId,
-                              targetConversation:
-                                  context.options.targetConversation,
-                              presetLane: context.options.presetLane,
-                              allPresetLanes: context.options.allPresetLanes,
-                              permission: 'manage'
-                          }
-                      )
+            const hasTarget =
+                context.options.resolvedConversation != null ||
+                context.options.conversationId != null ||
+                context.options.targetConversation != null
+            let conversation = !hasTarget
+                ? null
+                : context.options.resolvedConversation != null
+                  ? await ctx.chatluna.conversation.resolveCommandConversation(
+                        session,
+                        {
+                            conversationId:
+                                context.options.resolvedConversation.id,
+                            presetLane: context.options.presetLane,
+                            allPresetLanes: context.options.allPresetLanes,
+                            permission: 'manage'
+                        }
+                    )
+                  : await ctx.chatluna.conversation.resolveCommandConversation(
+                        session,
+                        {
+                            conversationId: context.options.conversationId,
+                            targetConversation:
+                                context.options.targetConversation,
+                            presetLane: context.options.presetLane,
+                            allPresetLanes: context.options.allPresetLanes,
+                            permission: 'manage'
+                        }
+                    )
 
             if (conversation == null) {
                 conversation = (
                     await ctx.chatluna.conversation.getCurrentConversation(
-                        session
+                        session,
+                        {
+                            presetLane: context.options.presetLane,
+                            useRoutePresetLane:
+                                context.options.presetLane == null
+                        }
                     )
                 ).conversation
 

--- a/packages/core/src/middlewares/conversation/request_conversation.ts
+++ b/packages/core/src/middlewares/conversation/request_conversation.ts
@@ -43,7 +43,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             const useRoutePresetLane =
                 context.options.presetLane == null &&
                 context.options.conversationId == null &&
-                (context.command == null || context.command.length === 0)
+                context.options.resolvedConversation == null &&
+                context.options.targetConversation == null
             const resolved =
                 await ctx.chatluna.conversation.ensureActiveConversation(
                     session,

--- a/packages/core/src/middlewares/conversation/resolve_conversation.ts
+++ b/packages/core/src/middlewares/conversation/resolve_conversation.ts
@@ -31,8 +31,9 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             const targetConversation = getTargetConversation(context)
             const useRoutePresetLane =
                 presetLane == null &&
-                targetConversation == null &&
-                (context.command == null || context.command.length === 0)
+                context.options.conversationId == null &&
+                context.options.resolvedConversation == null &&
+                targetConversation == null
 
             context.options.presetLane = presetLane
 

--- a/packages/core/src/middlewares/system/conversation_manage.ts
+++ b/packages/core/src/middlewares/system/conversation_manage.ts
@@ -134,6 +134,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     middleware('conversation_switch', async (session, context) => {
         const targetConversation =
             context.options.conversation_manage?.targetConversation
+        const presetLane = context.options.conversation_manage?.presetLane
 
         if (targetConversation == null) {
             context.message = session.text(
@@ -146,7 +147,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             const conversation =
                 await ctx.chatluna.conversation.switchConversation(session, {
                     targetConversation,
-                    allPresetLanes: true
+                    presetLane,
+                    allPresetLanes: presetLane == null
                 })
 
             context.options.conversationId = conversation.id
@@ -171,17 +173,20 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     middleware('conversation_list', async (session, context) => {
         const page = context.options.page ?? 1
         const limit = context.options.limit ?? 5
+        const presetLane = context.options.conversation_manage?.presetLane
         const includeArchived =
             context.options.conversation_manage?.includeArchived === true
         const resolved = await ctx.chatluna.conversation.getCurrentConversation(
             session,
             {
-                useRoutePresetLane: true
+                presetLane,
+                useRoutePresetLane: presetLane == null
             }
         )
         const conversations =
             await ctx.chatluna.conversation.listConversationEntries(session, {
-                allPresetLanes: true,
+                presetLane,
+                allPresetLanes: presetLane == null,
                 includeArchived
             })
 
@@ -212,7 +217,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
             }
         })
 
-        const key = `${getBaseBindingKey(resolved.bindingKey)}:all`
+        const key = `${presetLane == null ? getBaseBindingKey(resolved.bindingKey) : resolved.bindingKey}:${includeArchived ? 'all' : 'active'}`
         await pagination.push(conversations, key)
         context.message = await pagination.getFormattedPage(page, limit, key)
         return ChainMiddlewareRunStatus.STOP
@@ -282,12 +287,15 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
     middleware('conversation_delete', async (session, context) => {
         try {
             const presetLane = context.options.conversation_manage?.presetLane
+            const includeArchived =
+                context.options.conversation_manage?.includeArchived === true
             const conversation =
                 await ctx.chatluna.conversation.deleteConversation(session, {
                     conversationId: context.options.conversationId,
                     targetConversation:
                         context.options.conversation_manage?.targetConversation,
                     presetLane,
+                    includeArchived: includeArchived || undefined,
                     allPresetLanes: presetLane == null
                 })
 
@@ -374,11 +382,14 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
         try {
             const presetLane = context.options.conversation_manage?.presetLane
+            const includeArchived =
+                context.options.conversation_manage?.includeArchived === true
             const result = await ctx.chatluna.conversation.archiveConversation(
                 session,
                 {
                     targetConversation,
                     presetLane,
+                    includeArchived: includeArchived || undefined,
                     allPresetLanes: presetLane == null
                 }
             )
@@ -407,12 +418,14 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
         try {
             const presetLane = context.options.conversation_manage?.presetLane
+            const includeArchived =
+                context.options.conversation_manage?.includeArchived === true
             const conversation =
                 await ctx.chatluna.conversation.reopenConversation(session, {
                     targetConversation,
                     presetLane,
                     allPresetLanes: presetLane == null,
-                    includeArchived: true
+                    includeArchived: includeArchived || undefined
                 })
 
             context.options.conversationId = conversation.id
@@ -439,13 +452,15 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
 
         try {
             const presetLane = context.options.conversation_manage?.presetLane
+            const includeArchived =
+                context.options.conversation_manage?.includeArchived === true
             const result = await ctx.chatluna.conversation.exportConversation(
                 session,
                 {
                     targetConversation,
                     presetLane,
                     allPresetLanes: presetLane == null,
-                    includeArchived: true
+                    includeArchived: includeArchived || undefined
                 }
             )
 
@@ -721,6 +736,8 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
         const key =
             context.options.i18n_base ?? 'commands.chatluna.compress.messages'
         const presetLane = context.options.conversation_manage?.presetLane
+        const includeArchived =
+            context.options.conversation_manage?.includeArchived === true
         const resolved = await ctx.chatluna.conversation.resolveContext(
             session,
             { presetLane, conversationId: context.options.conversationId }
@@ -739,9 +756,7 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                           targetConversation,
                           conversationId: context.options.conversationId,
                           permission: 'manage',
-                          includeArchived:
-                              context.options.conversation_manage
-                                  ?.includeArchived === true
+                          includeArchived: includeArchived || undefined
                       }
                   )
                 : null

--- a/packages/core/src/services/conversation.ts
+++ b/packages/core/src/services/conversation.ts
@@ -1555,8 +1555,6 @@ export class ConversationService {
         }
 
         const target = options.targetConversation?.trim()
-        const useDisplaySeq =
-            options.allPresetLanes === true && options.presetLane == null
 
         if (target == null || target.length === 0) {
             return resolved.conversation ?? null
@@ -1576,11 +1574,9 @@ export class ConversationService {
 
         if (/^\d+$/.test(target)) {
             const seq = Number(target)
-            const bySeq = useDisplaySeq
-                ? entries
-                      .filter((item) => item.displaySeq === seq)
-                      .map((item) => item.conversation)
-                : conversations.filter((c) => c.seq === seq)
+            const bySeq = entries
+                .filter((item) => item.displaySeq === seq)
+                .map((item) => item.conversation)
             if (bySeq.length === 1) {
                 return bySeq[0]
             }
@@ -1618,29 +1614,12 @@ export class ConversationService {
             ...options,
             bindingKey: resolved.bindingKey,
             query: normalized,
-            exactId: target,
-            seq:
-                /^\d+$/.test(target) && !useDisplaySeq
-                    ? Number(target)
-                    : undefined
+            exactId: target
         })
 
         const globalById = globalMatches.find((c) => c.id === target)
         if (globalById != null) {
             return globalById
-        }
-
-        if (/^\d+$/.test(target) && !useDisplaySeq) {
-            const seq = Number(target)
-            const globalBySeq = globalMatches.filter((c) => c.seq === seq)
-
-            if (globalBySeq.length === 1) {
-                return globalBySeq[0]
-            }
-
-            if (globalBySeq.length > 1) {
-                throw new Error('Conversation target is ambiguous.')
-            }
         }
 
         const globalExactTitle = globalMatches.filter(

--- a/packages/core/src/utils/conversation.ts
+++ b/packages/core/src/utils/conversation.ts
@@ -12,7 +12,8 @@ export async function completeConversationTarget(
     presetLane?: string,
     includeArchived = true,
     suffix = 'commands.chatluna.chat.text.options.conversation',
-    allPresetLanes = false
+    allPresetLanes = false,
+    resolveIncludeArchived = includeArchived
 ) {
     const value =
         target == null || target.trim().length < 1 ? undefined : target.trim()
@@ -32,39 +33,41 @@ export async function completeConversationTarget(
         new Set(
             entries.flatMap((item) => [
                 item.conversation.id,
-                String(
-                    allPresetLanes && presetLane == null
-                        ? item.displaySeq
-                        : (item.conversation.seq ?? '')
-                ),
+                String(item.displaySeq),
                 item.conversation.title
             ])
         )
     ).filter((item) => item.length > 0)
 
-    if (expect.length === 0) {
-        return value
-    }
+    if (/^\d+$/.test(value)) {
+        const seq = Number(value)
+        const bySeq = entries.filter((item) => item.displaySeq === seq)
 
-    if (expect.includes(value)) {
-        return value
+        if (bySeq.length === 1) {
+            return bySeq[0].conversation.id
+        }
     }
 
     try {
-        if (
-            (await ctx.chatluna.conversation.resolveCommandConversation(
+        const conversation =
+            await ctx.chatluna.conversation.resolveCommandConversation(
                 session,
                 {
                     targetConversation: value,
                     presetLane,
-                    includeArchived,
+                    includeArchived: resolveIncludeArchived,
                     allPresetLanes
                 }
-            )) != null
-        ) {
-            return value
+            )
+
+        if (conversation != null) {
+            return conversation.id
         }
     } catch {}
+
+    if (expect.length === 0) {
+        return value
+    }
 
     return session.suggest({
         actual: value,

--- a/packages/core/tests/conversation-resolve.spec.ts
+++ b/packages/core/tests/conversation-resolve.spec.ts
@@ -1,0 +1,121 @@
+/// <reference types="mocha" />
+
+import { assert } from 'chai'
+import { ChainMiddlewareRunStatus } from '../src/chains/chain'
+import { apply as applyResolve } from '../src/middlewares/conversation/resolve_conversation'
+import { apply as applyRequest } from '../src/middlewares/conversation/request_conversation'
+import { createMemoryService, createSession } from './helpers'
+
+it('resolve_conversation inherits active preset lane for explicit commands without target', async () => {
+    const { app, ctx } = await createMemoryService()
+
+    try {
+        const session = createSession() as any
+        let run:
+            | ((
+                  session: any,
+                  context: any
+              ) => Promise<ChainMiddlewareRunStatus>)
+            | undefined
+        let useRoutePresetLane: boolean | undefined
+
+        ctx.chatluna.conversation.resolveContext = async (_session, opts) => {
+            useRoutePresetLane = opts.useRoutePresetLane
+            return {
+                bindingKey: 'shared:discord:bot:guild:preset:helper',
+                constraint: {},
+                effectiveModel: 'test-platform/test-model',
+                effectivePreset: 'default-preset',
+                effectiveChatMode: 'plugin',
+                conversation: null
+            }
+        }
+
+        applyResolve(
+            ctx as never,
+            {} as never,
+            {
+                middleware: (_name, fn) => {
+                    run = fn as never
+                    return {
+                        after() {
+                            return this
+                        },
+                        before() {
+                            return this
+                        }
+                    }
+                }
+            } as never
+        )
+
+        const status = await run!(session, {
+            command: 'chat',
+            options: {}
+        })
+
+        assert.equal(status, ChainMiddlewareRunStatus.CONTINUE)
+        assert.equal(useRoutePresetLane, true)
+    } finally {
+        await app.stop()
+    }
+})
+
+it('request_conversation inherits active preset lane for explicit commands without target', async () => {
+    const { app, ctx } = await createMemoryService()
+
+    try {
+        const session = createSession() as any
+        let run:
+            | ((
+                  session: any,
+                  context: any
+              ) => Promise<ChainMiddlewareRunStatus>)
+            | undefined
+        let useRoutePresetLane: boolean | undefined
+
+        ctx.chatluna.conversation.ensureActiveConversation = async (
+            _session,
+            opts
+        ) => {
+            useRoutePresetLane = opts.useRoutePresetLane
+            throw new Error('stop-after-ensure')
+        }
+
+        applyRequest(
+            ctx as never,
+            {
+                streamResponse: false,
+                splitMessage: false
+            } as never,
+            {
+                middleware: (_name, fn) => {
+                    run = fn as never
+                    return {
+                        after() {
+                            return this
+                        }
+                    }
+                }
+            } as never
+        )
+
+        try {
+            await run!(session, {
+                command: 'voice',
+                options: {
+                    inputMessage: {
+                        content: 'hello'
+                    }
+                }
+            })
+            assert.fail('Expected middleware to stop after ensure.')
+        } catch (err) {
+            assert.match(String(err), /stop-after-ensure/)
+        }
+
+        assert.equal(useRoutePresetLane, true)
+    } finally {
+        await app.stop()
+    }
+})

--- a/packages/core/tests/conversation-service.spec.ts
+++ b/packages/core/tests/conversation-service.spec.ts
@@ -30,6 +30,8 @@ it('ConversationService resolves routed constraints and preset lanes', async () 
         createdBy: 'admin',
         createdAt: new Date(),
         updatedAt: new Date(),
+        users: null,
+        excludeUsers: null,
         guildId: 'guild',
         routeMode: 'custom',
         routeKey: 'team-alpha',
@@ -49,6 +51,8 @@ it('ConversationService resolves routed constraints and preset lanes', async () 
         createdBy: 'admin',
         createdAt: new Date(),
         updatedAt: new Date(),
+        users: null,
+        excludeUsers: null,
         defaultPreset: 'constraint-default-preset',
         defaultChatMode: 'chat-mode-x',
         fixedModel: null,
@@ -89,6 +93,8 @@ it('ConversationService gives fixed preset precedence over preset lane', async (
         createdBy: 'admin',
         createdAt: new Date(),
         updatedAt: new Date(),
+        users: null,
+        excludeUsers: null,
         fixedPreset: 'fixed-preset'
     }
 
@@ -421,7 +427,7 @@ it('ConversationService ensureActiveConversation respects personal default group
     assert.equal(resolved.conversation.seq, 1)
 })
 
-it('ConversationService switches and resolves friendly conversation targets within the same binding', async () => {
+it('ConversationService resolves numeric conversation targets by visible list order', async () => {
     const older = createConversation({
         id: 'conversation-old',
         seq: 1,
@@ -472,7 +478,7 @@ it('ConversationService switches and resolves friendly conversation targets with
     })
     const binding = database.tables.chatluna_binding[0] as BindingRecord
 
-    assert.equal(bySeq.id, 'conversation-new')
+    assert.equal(bySeq.id, 'conversation-old')
     assert.equal(byId.id, 'conversation-old')
     assert.equal(byTitle.id, 'conversation-new')
     assert.equal(byPartialTitle.id, 'conversation-new')
@@ -820,6 +826,7 @@ it('ConversationService records compression metadata and use rejects fixed field
         id: 'summary',
         conversationId: conversation.id,
         text: 'compressed summary',
+        content: await gzipEncode(JSON.stringify('compressed summary')),
         name: 'infinite_context'
     })
     const { service } = await createService({
@@ -1172,6 +1179,7 @@ it('ConversationService emits conversation lifecycle events for switch archive r
                 createMessage({
                     id: 'summary-message',
                     conversationId: next.id,
+                    content: await gzipEncode(JSON.stringify('summary')),
                     name: 'infinite_context',
                     text: 'summary'
                 }) as unknown as TableRow

--- a/packages/core/tests/conversation-target.spec.ts
+++ b/packages/core/tests/conversation-target.spec.ts
@@ -2,8 +2,14 @@
 
 import { assert } from 'chai'
 import { completeConversationTarget } from '../src/utils/conversation'
+import {
+    createConversation,
+    createService,
+    createSession,
+    type TableRow
+} from './helpers'
 
-it('completeConversationTarget accepts exact display seq without suggest', async () => {
+it('completeConversationTarget resolves display seq to canonical id', async () => {
     let called = false
 
     const result = await completeConversationTarget(
@@ -27,7 +33,15 @@ it('completeConversationTarget accepts exact display seq without suggest', async
                                 seq: 1
                             }
                         }
-                    ]
+                    ],
+                    resolveCommandConversation: async (
+                        _session,
+                        opts: { targetConversation?: string }
+                    ) => {
+                        return opts.targetConversation === '2'
+                            ? { id: 'conversation-2' }
+                            : null
+                    }
                 }
             }
         } as never,
@@ -45,7 +59,7 @@ it('completeConversationTarget accepts exact display seq without suggest', async
         true
     )
 
-    assert.equal(result, '2')
+    assert.equal(result, 'conversation-2')
     assert.equal(called, false)
 })
 
@@ -89,4 +103,83 @@ it('completeConversationTarget accepts accessible target outside current list', 
 
     assert.equal(result, 'conversation-remote')
     assert.equal(called, false)
+})
+
+it('completeConversationTarget keeps visible numbering stable when archived conversations are hidden', async () => {
+    const archived = createConversation({
+        id: 'conversation-archived',
+        status: 'archived',
+        lastChatAt: new Date('2026-03-23T00:00:00.000Z')
+    })
+    const older = createConversation({
+        id: 'conversation-old',
+        title: 'Older',
+        seq: 1,
+        lastChatAt: new Date('2026-03-20T00:00:00.000Z')
+    })
+    const newer = createConversation({
+        id: 'conversation-new',
+        title: 'Newer',
+        seq: 2,
+        lastChatAt: new Date('2026-03-22T00:00:00.000Z')
+    })
+    const { service, ctx } = await createService({
+        tables: {
+            chatluna_conversation: [
+                archived as unknown as TableRow,
+                older as unknown as TableRow,
+                newer as unknown as TableRow
+            ],
+            chatluna_binding: [
+                {
+                    bindingKey: older.bindingKey,
+                    activeConversationId: older.id,
+                    lastConversationId: null,
+                    updatedAt: new Date()
+                } as unknown as TableRow
+            ]
+        }
+    })
+
+    ctx.chatluna.conversation = service as never
+
+    const result = await completeConversationTarget(
+        ctx as never,
+        createSession(),
+        '2',
+        undefined,
+        false,
+        'commands.chatluna.chat.text.options.conversation',
+        false,
+        true
+    )
+
+    assert.equal(result, older.id)
+})
+
+it('completeConversationTarget still resolves archived ids outside the visible list', async () => {
+    const archived = createConversation({
+        id: 'conversation-archived-hidden',
+        status: 'archived'
+    })
+    const { service, ctx } = await createService({
+        tables: {
+            chatluna_conversation: [archived as unknown as TableRow]
+        }
+    })
+
+    ctx.chatluna.conversation = service as never
+
+    const result = await completeConversationTarget(
+        ctx as never,
+        createSession(),
+        archived.id,
+        undefined,
+        false,
+        'commands.chatluna.chat.text.options.conversation',
+        false,
+        true
+    )
+
+    assert.equal(result, archived.id)
 })

--- a/packages/core/tests/rollback-chat.spec.ts
+++ b/packages/core/tests/rollback-chat.spec.ts
@@ -3,6 +3,7 @@
 import { assert } from 'chai'
 import { ChainMiddlewareRunStatus } from '../src/chains/chain'
 import { apply } from '../src/middlewares/chat/rollback_chat'
+import { apply as applyStop } from '../src/middlewares/chat/stop_chat'
 import {
     createConversation,
     createMemoryService,
@@ -263,6 +264,279 @@ it('rollback_chat keeps history untouched when rebuilding the input fails', asyn
             )[0].latestMessageId,
             'message-transform-failure'
         )
+    } finally {
+        await app.stop()
+    }
+})
+
+it('rollback_chat falls back to the active preset lane conversation', async () => {
+    const main = createConversation({
+        id: 'conversation-main-lane',
+        latestMessageId: 'message-main-lane'
+    })
+    const helper = createConversation({
+        id: 'conversation-helper-lane',
+        bindingKey: 'shared:discord:bot:guild:preset:helper',
+        latestMessageId: 'message-helper-lane'
+    })
+    const mainMessage = createMessage({
+        id: 'message-main-lane',
+        conversationId: main.id,
+        text: 'main lane',
+        content: null
+    })
+    const helperMessage = createMessage({
+        id: 'message-helper-lane',
+        conversationId: helper.id,
+        text: 'helper lane',
+        content: null
+    })
+    const { app, ctx, database } = await createMemoryService({
+        tables: {
+            chatluna_conversation: [
+                main as unknown as TableRow,
+                helper as unknown as TableRow
+            ],
+            chatluna_binding: [
+                {
+                    bindingKey: main.bindingKey,
+                    activeConversationId: main.id,
+                    lastConversationId: null,
+                    updatedAt: new Date()
+                } as TableRow,
+                {
+                    bindingKey: helper.bindingKey,
+                    activeConversationId: helper.id,
+                    lastConversationId: null,
+                    updatedAt: new Date()
+                } as TableRow
+            ],
+            chatluna_message: [
+                mainMessage as unknown as TableRow,
+                helperMessage as unknown as TableRow
+            ],
+            chatluna_constraint: [
+                {
+                    id: 1,
+                    name: 'managed:discord:bot:guild:guild',
+                    enabled: true,
+                    priority: 1000,
+                    createdBy: 'user',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    platform: 'discord',
+                    selfId: 'bot',
+                    guildId: 'guild',
+                    channelId: null,
+                    direct: false,
+                    users: null,
+                    excludeUsers: null,
+                    routeMode: null,
+                    routeKey: null,
+                    activePresetLane: 'helper',
+                    defaultModel: null,
+                    defaultPreset: null,
+                    defaultChatMode: null,
+                    fixedModel: null,
+                    fixedPreset: null,
+                    fixedChatMode: null,
+                    lockConversation: false,
+                    allowNew: true,
+                    allowSwitch: true,
+                    allowArchive: true,
+                    allowExport: true,
+                    manageMode: 'anyone'
+                } as unknown as TableRow
+            ]
+        }
+    })
+
+    try {
+        const sent: string[] = []
+        const syncCalls: string[] = []
+        const session = createSession() as any
+        let run:
+            | ((
+                  session: any,
+                  context: any
+              ) => Promise<ChainMiddlewareRunStatus>)
+            | undefined
+        const withSync =
+            ctx.chatluna.conversationRuntime.withConversationSync.bind(
+                ctx.chatluna.conversationRuntime
+            )
+
+        ctx.chatluna.conversationRuntime.withConversationSync = async (
+            current,
+            callback
+        ) => {
+            syncCalls.push(current.id)
+            return withSync(current, callback)
+        }
+        ctx.chatluna.messageTransformer.transform = async () => 'transformed'
+        session.text = (key, params) =>
+            key === '.rollback_success' ? `${key}:${params?.[0]}` : key
+        session.send = async (msg) => {
+            sent.push(msg)
+        }
+
+        apply(
+            ctx as never,
+            {
+                includeQuoteReply: false
+            } as never,
+            {
+                middleware: (_name, fn) => {
+                    run = fn as never
+                    return {
+                        after() {
+                            return this
+                        },
+                        before() {
+                            return this
+                        }
+                    }
+                }
+            } as never
+        )
+
+        const status = await run!(session, {
+            command: 'rollback',
+            message: '',
+            options: {
+                rollback_round: 1
+            }
+        })
+
+        assert.equal(status, ChainMiddlewareRunStatus.CONTINUE)
+        assert.deepEqual(syncCalls, [helper.id])
+        assert.equal(
+            (
+                await database.get('chatluna_message', {
+                    conversationId: helper.id
+                })
+            ).length,
+            0
+        )
+        assert.equal(
+            (
+                await database.get('chatluna_message', {
+                    conversationId: main.id
+                })
+            ).length,
+            1
+        )
+        assert.deepEqual(sent, ['.rollback_success:1'])
+    } finally {
+        await app.stop()
+    }
+})
+
+it('stop_chat falls back to the active preset lane conversation', async () => {
+    const main = createConversation({
+        id: 'conversation-main-stop'
+    })
+    const helper = createConversation({
+        id: 'conversation-helper-stop',
+        bindingKey: 'shared:discord:bot:guild:preset:helper'
+    })
+    const { app, ctx } = await createMemoryService({
+        tables: {
+            chatluna_conversation: [
+                main as unknown as TableRow,
+                helper as unknown as TableRow
+            ],
+            chatluna_binding: [
+                {
+                    bindingKey: main.bindingKey,
+                    activeConversationId: main.id,
+                    lastConversationId: null,
+                    updatedAt: new Date()
+                } as TableRow,
+                {
+                    bindingKey: helper.bindingKey,
+                    activeConversationId: helper.id,
+                    lastConversationId: null,
+                    updatedAt: new Date()
+                } as TableRow
+            ],
+            chatluna_constraint: [
+                {
+                    id: 1,
+                    name: 'managed:discord:bot:guild:guild',
+                    enabled: true,
+                    priority: 1000,
+                    createdBy: 'user',
+                    createdAt: new Date(),
+                    updatedAt: new Date(),
+                    platform: 'discord',
+                    selfId: 'bot',
+                    guildId: 'guild',
+                    channelId: null,
+                    direct: false,
+                    users: null,
+                    excludeUsers: null,
+                    routeMode: null,
+                    routeKey: null,
+                    activePresetLane: 'helper',
+                    defaultModel: null,
+                    defaultPreset: null,
+                    defaultChatMode: null,
+                    fixedModel: null,
+                    fixedPreset: null,
+                    fixedChatMode: null,
+                    lockConversation: false,
+                    allowNew: true,
+                    allowSwitch: true,
+                    allowArchive: true,
+                    allowExport: true,
+                    manageMode: 'anyone'
+                } as unknown as TableRow
+            ]
+        }
+    })
+
+    try {
+        const session = createSession() as any
+        let run:
+            | ((
+                  session: any,
+                  context: any
+              ) => Promise<ChainMiddlewareRunStatus>)
+            | undefined
+        let stoppedId: string | undefined
+
+        ctx.chatluna.conversationRuntime.stopConversationRequest = (id) => {
+            stoppedId = id
+            return true
+        }
+        session.text = (key) => key
+
+        applyStop(
+            ctx as never,
+            {} as never,
+            {
+                middleware: (_name, fn) => {
+                    run = fn as never
+                    return {
+                        after() {
+                            return this
+                        },
+                        before() {
+                            return this
+                        }
+                    }
+                }
+            } as never
+        )
+
+        const status = await run!(session, {
+            command: 'stop_chat',
+            options: {}
+        })
+
+        assert.equal(status, ChainMiddlewareRunStatus.STOP)
+        assert.equal(stoppedId, helper.id)
     } finally {
         await app.stop()
     }


### PR DESCRIPTION
This pr keeps conversation management commands aligned with the active preset lane, fixes numeric target resolution to follow the visible conversation list, and only includes archived conversations when commands explicitly request them.

## New Features

- Added `--preset` support to `chatluna.list`.
- Added `--archived` and `--all` options to restore, export, compress, and delete conversation commands.

## Bug fixes

- Fixed `switch`, `list`, `rollback`, and `stop_chat` so they resolve the active conversation from the current preset lane.
- Fixed numeric conversation targets so they resolve by the visible list order instead of raw sequence values.
- Fixed conversation target completion so archived conversations stay hidden unless a command opts in.

## Other Changes

- Updated English and Chinese locale entries for the new conversation command options.
- Added regression tests for conversation resolution, target completion, rollback fallback, and stop fallback.