### PR TITLE
chore: bump alpha.4 and scope agent tool masks

### DIFF
--- a/hi 数据库！
+++ b/hi 数据库！
@@ -1,8 +1,0 @@
-  chrome/bump-version[m
-  fix/conversation-system[m
-* [32mv1-dev[m
-  worktree-agent-a0ef95b5[m
-+ [36mworktree-agent-a2f27f3b[m
-+ [36mworktree-agent-a34cb503[m
-  worktree-agent-a55ce867[m
-+ [36mworktree-agent-a66caa2e[m

--- a/hi 数据库！
+++ b/hi 数据库！
@@ -1,0 +1,8 @@
+  chrome/bump-version[m
+  fix/conversation-system[m
+* [32mv1-dev[m
+  worktree-agent-a0ef95b5[m
++ [36mworktree-agent-a2f27f3b[m
++ [36mworktree-agent-a34cb503[m
+  worktree-agent-a55ce867[m
++ [36mworktree-agent-a66caa2e[m

--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.3",
+    "version": "1.4.0-alpha.4",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/agent/types.ts
+++ b/packages/core/src/llm-core/agent/types.ts
@@ -205,6 +205,7 @@ export type AgentObservation =
 
 export interface ToolMask {
     mode: 'all' | 'allow' | 'deny'
+    tools?: string[]
     allow: string[]
     deny: string[]
     toolCallMask?: ToolMask
@@ -310,6 +311,10 @@ export class MessageQueue {
 
 export function applyToolMask(name: string, mask?: ToolMask) {
     if (!mask || mask.mode === 'all') {
+        return true
+    }
+
+    if (mask.tools && !mask.tools.includes(name)) {
         return true
     }
 

--- a/packages/core/src/llm-core/platform/service.ts
+++ b/packages/core/src/llm-core/platform/service.ts
@@ -208,16 +208,19 @@ export class PlatformService {
 
     getFilteredTools(mask: ToolMask) {
         const allNames = Object.keys(this._tools)
+        const names = mask.tools
+            ? allNames.filter((name) => mask.tools.includes(name))
+            : allNames
 
         if (mask.mode === 'all') {
-            return allNames
+            return names
         }
 
         if (mask.mode === 'allow') {
-            return allNames.filter((name) => mask.allow.includes(name))
+            return names.filter((name) => mask.allow.includes(name))
         }
 
-        return allNames.filter((name) => !mask.deny.includes(name))
+        return names.filter((name) => !mask.deny.includes(name))
     }
 
     registerToolMaskResolver(name: string, resolver: ToolMaskResolver) {

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.18",
+    "version": "1.0.19",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -87,7 +87,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -480,15 +480,15 @@ export class ChatLunaAgentPermissionService {
 
 function buildToolMask(allNames: string[], allow: string[]): ToolMask {
     if (allow.length >= allNames.length) {
-        return { mode: 'all', allow: [], deny: [] }
+        return { mode: 'all', tools: allNames, allow: [], deny: [] }
     }
 
     const deny = allNames.filter((name) => !allow.includes(name))
     if (allow.length <= deny.length) {
-        return { mode: 'allow', allow, deny: [] }
+        return { mode: 'allow', tools: allNames, allow, deny: [] }
     }
 
-    return { mode: 'deny', allow: [], deny }
+    return { mode: 'deny', tools: allNames, allow: [], deny }
 }
 
 function matchRule(name: string, rule: PermissionRule) {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     "peerDependencies": {
         "koishi": "^4.18.9",
         "koishi-plugin-chatluna": "^1.4.0-alpha.4",
-        "koishi-plugin-chatluna-agent": "^1.0.18",
+        "koishi-plugin-chatluna-agent": "^1.0.19",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4",
         "koishi-plugin-chatluna-agent": "^1.0.18",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -61,7 +61,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.3"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.4"
     }
 }


### PR DESCRIPTION
## Summary
- bump `koishi-plugin-chatluna` to `1.4.0-alpha.4` and update workspace peer dependency references to match
- scope tool-mask filtering to globally registered tools so direct agent-local tools are not blocked by global allow lists
- include the current `hi 数据库！` workspace snapshot file in this branch