### PR TITLE
[Fix] stabilize conversation ordering and bump alpha.6

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.5",
+    "version": "1.4.0-alpha.6",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.6",
+    "version": "1.4.0-alpha.7",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/middlewares/chat/rollback_chat.ts
+++ b/packages/core/src/middlewares/chat/rollback_chat.ts
@@ -6,7 +6,10 @@ import {
     ChainMiddlewareRunStatus,
     type ChatChain
 } from '../../chains/chain'
-import { MessageRecord } from '../../services/conversation_types'
+import {
+    type ConversationResolution,
+    type MessageRecord
+} from '../../services/conversation_types'
 import {
     checkAdmin,
     transformMessageContentToElements

--- a/packages/core/src/services/conversation.ts
+++ b/packages/core/src/services/conversation.ts
@@ -737,15 +737,36 @@ export class ConversationService {
                   bindingKey: keys.length === 1 ? keys[0] : { $in: keys }
               })) as ConversationRecord[])
 
-        return conversations
-            .filter(
-                (conversation) =>
-                    conversation.status !== 'deleted' &&
-                    conversation.status !== 'broken' &&
-                    (options.includeArchived ||
-                        conversation.status !== 'archived')
-            )
-            .sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0))
+        const filtered = conversations.filter(
+            (conversation) =>
+                conversation.status !== 'deleted' &&
+                conversation.status !== 'broken' &&
+                (options.includeArchived || conversation.status !== 'archived')
+        )
+        const merged =
+            new Set(filtered.map((conversation) => conversation.bindingKey))
+                .size > 1
+
+        return filtered.sort((a, b) => {
+            if (merged) {
+                const key = a.bindingKey.localeCompare(b.bindingKey)
+                if (key !== 0) {
+                    return key
+                }
+            }
+
+            const seq = (a.seq ?? 0) - (b.seq ?? 0)
+            if (seq !== 0) {
+                return seq
+            }
+
+            const created = a.createdAt.getTime() - b.createdAt.getTime()
+            if (created !== 0) {
+                return created
+            }
+
+            return a.id.localeCompare(b.id)
+        })
     }
 
     async listConversationEntries(
@@ -753,9 +774,14 @@ export class ConversationService {
         options: ListConversationsOptions = {}
     ): Promise<ConversationListEntry[]> {
         const conversations = await this.listConversations(session, options)
-        return conversations.map((conversation) => ({
+        const merged =
+            new Set(
+                conversations.map((conversation) => conversation.bindingKey)
+            ).size > 1
+
+        return conversations.map((conversation, idx) => ({
             conversation,
-            displaySeq: conversation.seq ?? 0
+            displaySeq: merged ? idx + 1 : (conversation.seq ?? 0)
         }))
     }
 

--- a/packages/core/src/services/conversation.ts
+++ b/packages/core/src/services/conversation.ts
@@ -745,11 +745,7 @@ export class ConversationService {
                     (options.includeArchived ||
                         conversation.status !== 'archived')
             )
-            .sort((a, b) => {
-                const left = a.lastChatAt ?? a.updatedAt
-                const right = b.lastChatAt ?? b.updatedAt
-                return right.getTime() - left.getTime()
-            })
+            .sort((a, b) => (a.seq ?? 0) - (b.seq ?? 0))
     }
 
     async listConversationEntries(
@@ -757,9 +753,9 @@ export class ConversationService {
         options: ListConversationsOptions = {}
     ): Promise<ConversationListEntry[]> {
         const conversations = await this.listConversations(session, options)
-        return conversations.map((conversation, idx) => ({
+        return conversations.map((conversation) => ({
             conversation,
-            displaySeq: idx + 1
+            displaySeq: conversation.seq ?? 0
         }))
     }
 
@@ -845,6 +841,12 @@ export class ConversationService {
             previousConversation
         })
         await this.setActiveConversation(bindingKey, conversation.id)
+        if (current.bindingKey !== bindingKey) {
+            await this.setActiveConversation(
+                current.bindingKey,
+                conversation.id
+            )
+        }
         await this.ctx.root.parallel('chatluna/after-conversation-switch', {
             bindingKey,
             conversation,

--- a/packages/core/tests/conversation-service.spec.ts
+++ b/packages/core/tests/conversation-service.spec.ts
@@ -457,7 +457,7 @@ it('ConversationService ensureActiveConversation respects personal default group
     assert.equal(resolved.conversation.seq, 1)
 })
 
-it('ConversationService resolves numeric conversation targets by visible list order', async () => {
+it('ConversationService resolves numeric conversation targets by stable seq order', async () => {
     const older = createConversation({
         id: 'conversation-old',
         seq: 1,
@@ -491,7 +491,7 @@ it('ConversationService resolves numeric conversation targets by visible list or
     const listed = await service.listConversations(createSession())
     assert.deepEqual(
         listed.map((item) => item.id),
-        ['conversation-new', 'conversation-old']
+        ['conversation-old', 'conversation-new']
     )
 
     const bySeq = await service.switchConversation(createSession(), {
@@ -508,7 +508,7 @@ it('ConversationService resolves numeric conversation targets by visible list or
     })
     const binding = database.tables.chatluna_binding[0] as BindingRecord
 
-    assert.equal(bySeq.id, 'conversation-old')
+    assert.equal(bySeq.id, 'conversation-new')
     assert.equal(byId.id, 'conversation-old')
     assert.equal(byTitle.id, 'conversation-new')
     assert.equal(byPartialTitle.id, 'conversation-new')
@@ -536,21 +536,21 @@ it('ConversationService lists and switches preset lanes across canonical and leg
         id: 'conversation-aqua',
         bindingKey: `${canonicalBase}:preset:Aqua`,
         title: 'Aqua',
-        seq: 1,
+        seq: 3,
         lastChatAt: new Date('2026-03-22T00:00:00.000Z')
     })
     const chatgpt = createConversation({
         id: 'conversation-chatgpt',
         bindingKey: `${canonicalBase}:preset:chatgpt`,
         title: 'ChatGPT',
-        seq: 1,
+        seq: 2,
         lastChatAt: new Date('2026-03-23T00:00:00.000Z')
     })
     const sydney = createConversation({
         id: 'conversation-sydney',
         bindingKey: `${canonicalBase}:preset:sydney`,
         title: 'Sydney',
-        seq: 1,
+        seq: 4,
         lastChatAt: new Date('2026-03-24T00:00:00.000Z')
     })
 
@@ -594,23 +594,23 @@ it('ConversationService lists and switches preset lanes across canonical and leg
     assert.deepEqual(
         listed.map((item) => item.id),
         [
-            'conversation-sydney',
+            'conversation-legacy',
             'conversation-chatgpt',
             'conversation-aqua',
-            'conversation-legacy'
+            'conversation-sydney'
         ]
     )
     assert.deepEqual(
         entries.map((item) => [item.displaySeq, item.conversation.id]),
         [
-            [1, 'conversation-sydney'],
+            [1, 'conversation-legacy'],
             [2, 'conversation-chatgpt'],
             [3, 'conversation-aqua'],
-            [4, 'conversation-legacy']
+            [4, 'conversation-sydney']
         ]
     )
     assert.equal(switched.id, 'conversation-chatgpt')
-    assert.equal(legacyBinding?.activeConversationId, 'conversation-legacy')
+    assert.equal(legacyBinding?.activeConversationId, 'conversation-chatgpt')
     assert.equal(laneBinding?.activeConversationId, 'conversation-chatgpt')
     assert.equal(managed?.activePresetLane, 'chatgpt')
 })
@@ -766,7 +766,7 @@ it('ConversationService allows exact id across legacy and canonical route family
     assert.equal(resolved?.id, canonical.id)
 })
 
-it('ConversationService keeps current lane binding untouched when switching across preset lanes', async () => {
+it('ConversationService keeps current lane binding untouched and syncs route binding when switching across preset lanes', async () => {
     const laneA = createConversation({
         id: 'conversation-switch-lane-a',
         bindingKey: 'shared:discord:bot:guild:preset:A'
@@ -804,9 +804,13 @@ it('ConversationService keeps current lane binding untouched when switching acro
     const bindingB = database.tables.chatluna_binding.find(
         (item) => item.bindingKey === laneB.bindingKey
     ) as BindingRecord | undefined
+    const routeBinding = database.tables.chatluna_binding.find(
+        (item) => item.bindingKey === 'shared:discord:bot:guild'
+    ) as BindingRecord | undefined
 
     assert.equal(bindingA?.activeConversationId, laneA.id)
     assert.equal(bindingB?.activeConversationId, laneB.id)
+    assert.equal(routeBinding?.activeConversationId, laneB.id)
 })
 
 it('ConversationService syncs managed preset lane when reopening archived route-family conversation', async () => {

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -87,7 +87,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -87,7 +87,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6",
         "koishi-plugin-chatluna-agent": "^1.0.19",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7",
         "koishi-plugin-chatluna-agent": "^1.0.19",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -61,7 +61,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -61,7 +61,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "koishi": {
         "description": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.5"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
     }
 }

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.6"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.7"
     }
 }


### PR DESCRIPTION
description: |-

This pr bumps ChatLuna core to `1.4.0-alpha.6`, updates workspace peer dependency ranges, and fixes conversation ordering and route binding behavior so numeric targets and cross-lane switches stay stable.

## New Features

None.

## Bug fixes

- keep conversation listing and numeric target resolution stable by using stored `seq` ordering instead of recent activity order
- sync the route binding active conversation when switching across preset lanes so route-level state follows the selected lane conversation
- update conversation service coverage to match the stable ordering and route binding behavior

## Other Changes

- bump `koishi-plugin-chatluna` to `1.4.0-alpha.6`
- update workspace packages that peer depend on `koishi-plugin-chatluna` to the new `alpha.6` range
- align `rollback_chat` conversation type imports with the current lint rules
