### PR TITLE
[Fix] normalize agent skill lookup and tool filtering

### DIFF
--- a/packages/extension-agent/src/computer/materialize.ts
+++ b/packages/extension-agent/src/computer/materialize.ts
@@ -7,10 +7,15 @@ import {
     REMOTE_SKILLS_ROOT,
     ScannedSkill
 } from '../skills/scan'
+import { quoteShellPath } from '../utils/shell'
 import { ComputerSessionApi } from './types'
 
 export class SkillMaterializer {
     private _items = new Map<string, Map<string, string>>()
+
+    clear() {
+        this._items.clear()
+    }
 
     getPath(skill: ScannedSkill, session: ComputerSessionApi) {
         if (session.backend === 'local') {
@@ -43,6 +48,7 @@ export class SkillMaterializer {
             return current
         }
 
+        await resetRemoteSkillDir(root, session)
         const files = await listSkillResources(skill.dir)
 
         await session.writeFile(posix.join(root, 'SKILL.md'), skill.raw)
@@ -83,6 +89,24 @@ export function getRemoteSkillsRoot() {
 
 export function getRemoteSkillDir(name: string) {
     return posix.join(REMOTE_SKILLS_ROOT, name)
+}
+
+async function resetRemoteSkillDir(root: string, session: ComputerSessionApi) {
+    const quoted = quoteShellPath(root)
+    const result = await session.execute(
+        `if [ -d ${quoted} ]; then rm -rf ${quoted}; elif [ -e ${quoted} ]; then rm -f ${quoted}; fi`,
+        {
+            timeout: 15000
+        }
+    )
+
+    if (result.exitCode !== 0) {
+        throw new Error(
+            result.stderr.trim() ||
+                result.stdout.trim() ||
+                `Failed to reset remote skill dir: ${root}`
+        )
+    }
 }
 
 function normalizeRemotePath(value: string) {

--- a/packages/extension-agent/src/service/index.ts
+++ b/packages/extension-agent/src/service/index.ts
@@ -8,7 +8,7 @@ import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { truncateOutput } from '../computer/backends/types'
 import type { ComputerSessionApi } from '../computer/types'
 import { createSubAgentItemConfig } from '../config/defaults'
-import { getSkillsRootPath, getSubAgentsRootPath } from '../config/path'
+import { getSubAgentsRootPath } from '../config/path'
 import { readConfig } from '../config/read'
 import { writeConfig } from '../config/write'
 import {
@@ -32,7 +32,6 @@ import {
     SubAgentInfo,
     SubAgentItemConfig
 } from '../types'
-import { createHashId } from '../utils/id'
 import { getErrorMessage } from '../utils/shell'
 import { ChatLunaAgentComputerService } from './computer'
 import { ChatLunaAgentMcpService } from './mcp'
@@ -203,14 +202,6 @@ export class ChatLunaAgentService extends Service {
             dirs: [...this.args.config.skills.dirs],
             items: { ...this.args.config.skills.items },
             githubToken: this.args.config.skills.githubToken ?? ''
-        }
-
-        for (const name of result.imported) {
-            skills.items[
-                createHashId(
-                    join(getSkillsRootPath(this.ctx), name, 'SKILL.md')
-                )
-            ] = { enabled: false, mode: 'off', remote: false }
         }
 
         await this.updateConfig('skills', skills, async () => {

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -100,7 +100,7 @@ export class ChatLunaAgentPermissionService {
             this.config.subAgent.defaults.skills
         )
 
-        return names.filter((name) => matchRule(name, rule))
+        return names.filter((name) => matchRuleIgnoreCase(name, rule))
     }
 
     filterSkills(info: SubAgentInfo, items: SkillInfo[]) {
@@ -110,7 +110,7 @@ export class ChatLunaAgentPermissionService {
         )
 
         return items.filter((item) => {
-            if (!matchRule(item.name, rule)) {
+            if (!matchRuleIgnoreCase(item.name, rule)) {
                 return false
             }
 
@@ -498,6 +498,20 @@ function matchRule(name: string, rule: PermissionRule) {
 
     if (rule.mode === 'deny') {
         return !rule.deny.includes(name)
+    }
+
+    return true
+}
+
+function matchRuleIgnoreCase(name: string, rule: PermissionRule) {
+    const value = name.toLowerCase()
+
+    if (rule.mode === 'allow') {
+        return rule.allow.some((item) => item.toLowerCase() === value)
+    }
+
+    if (rule.mode === 'deny') {
+        return !rule.deny.some((item) => item.toLowerCase() === value)
     }
 
     return true

--- a/packages/extension-agent/src/service/skills.ts
+++ b/packages/extension-agent/src/service/skills.ts
@@ -64,7 +64,7 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
                 const name = getSlashSkillName(message)
                 if (!name) return
 
-                const skill = this._visibleByName.get(name)
+                const skill = this.getVisibleSkillByName(name)
                 if (
                     !skill ||
                     !this.canUseSkill(skill.id, session, 'chatluna') ||
@@ -112,6 +112,7 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
         this._toolDispose = undefined
         this._promptDispose?.()
         this._promptDispose = undefined
+        this.ctx.chatluna_agent?.computer.materializer.clear()
         this._catalog = []
         this._skills.clear()
         this._visibleByName.clear()
@@ -125,10 +126,11 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
         const scanned = local
         this._skills = new Map(scanned.map((s) => [s.id, s]))
         this._catalog = buildSkillCatalog(scanned, this.config.skills.items)
+        this.ctx.chatluna_agent?.computer.materializer.clear()
         this._visibleByName = new Map(
             this._catalog
                 .filter((s) => s.visible)
-                .map((s) => [s.name, this._skills.get(s.id)!])
+                .map((s) => [s.name.toLowerCase(), this._skills.get(s.id)!])
         )
 
         this.pruneActiveSkills()
@@ -167,11 +169,11 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
     }
 
     getVisibleSkillByName(name: string) {
-        return this._visibleByName.get(name)
+        return this._visibleByName.get(name.toLowerCase())
     }
 
     hasActiveSkill(conversationId: string, name: string) {
-        const skill = this._visibleByName.get(name)
+        const skill = this.getVisibleSkillByName(name)
         if (!skill) {
             return false
         }
@@ -259,7 +261,7 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
     }
 
     async activateSkill(name: string, runConfig?: ChatLunaToolRunnable) {
-        const skill = this._visibleByName.get(name)
+        const skill = this.getVisibleSkillByName(name)
         const conversationId = runConfig?.configurable?.conversationId
         const sub = runConfig?.configurable?.agentContext?.subagentContext
         const session = runConfig?.configurable?.session
@@ -283,7 +285,7 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
                 )
                 .map((item) => item.name)
 
-            if (!names.includes(name)) {
+            if (!names.some((item) => item.toLowerCase() === name.toLowerCase())) {
                 throw new Error(`Skill is not available: ${name}`)
             }
         }
@@ -315,7 +317,7 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
     }
 
     async renderSkill(name: string, loaded = false) {
-        const skill = this._visibleByName.get(name)
+        const skill = this.getVisibleSkillByName(name)
         if (!skill?.enabled || skill.state !== 'ready') return undefined
 
         return await renderSkillContent(skill, loaded)

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -101,11 +101,15 @@ export class ChatLunaAgentSubAgentService {
         >[1],
         source?: Parameters<ChatLunaAgentPermissionService['canUseSubAgent']>[2]
     ) {
-        return this.getCatalogSync().find(
+        const items = this.getCatalogSync().filter(
             (item) =>
-                item.name === name &&
                 isRunnable(item) &&
                 this.permission.canUseSubAgent(item, session, source)
+        )
+
+        return (
+            items.find((item) => item.name === name) ??
+            items.find((item) => item.name.toLowerCase() === name.toLowerCase())
         )
     }
 
@@ -186,17 +190,13 @@ export class ChatLunaAgentSubAgentService {
                     return undefined
                 }
 
-                const mask = this.permission.createSubAgentToolMask(info)
-
                 return {
                     agent: await createSubAgent({
                         ctx: this.ctx,
                         permission: this.permission,
                         info,
-                        mask,
                         model: ctx.runConfig?.configurable?.model
-                    }),
-                    toolMask: mask
+                    })
                 }
             },
             refresh: async () => {

--- a/packages/extension-agent/src/sub-agent/run.ts
+++ b/packages/extension-agent/src/sub-agent/run.ts
@@ -5,8 +5,7 @@ import {
     type AgentGenerateOptions,
     type AgentToolOptions,
     type ChatLunaAgent,
-    createAgentTool,
-    type ToolMask
+    createAgentTool
 } from 'koishi-plugin-chatluna/llm-core/agent'
 import {
     ChatLunaBaseEmbeddings,
@@ -28,7 +27,6 @@ export interface CreateSubAgentOptions {
     ctx: Context
     permission: ChatLunaAgentPermissionService
     info: SubAgentInfo
-    mask: ToolMask
     model?: ChatLunaChatModel
 }
 
@@ -97,7 +95,7 @@ async function createInnerAgent(
         : []
     const subCtx =
         input.subagentContext ??
-        createFallbackSubagentContext(options.info, options.mask, input)
+        createFallbackSubagentContext(options.info, input)
     const system = renderSubAgentSystemPrompt(
         options.info,
         subCtx,
@@ -125,7 +123,7 @@ async function createInnerAgent(
             description: options.info.description,
             model: llm,
             embeddings,
-            tools: createTools(options.ctx, options.mask),
+            tools: createTools(options.ctx, options.permission, options.info),
             system,
             preset:
                 options.info.promptMode === 'preset'
@@ -140,7 +138,6 @@ async function createInnerAgent(
 
 function createFallbackSubagentContext(
     info: SubAgentInfo,
-    mask: ToolMask,
     input: AgentGenerateOptions
 ) {
     return {
@@ -149,7 +146,11 @@ function createFallbackSubagentContext(
         parentConversationId: input.conversationId ?? '',
         depth: 1,
         maxDepth: 1,
-        toolMask: mask,
+        toolMask: input.toolMask ?? {
+            mode: 'all',
+            allow: [],
+            deny: []
+        },
         disableHandoff: true,
         traceInfo: {
             runId: info.id,
@@ -161,11 +162,14 @@ function createFallbackSubagentContext(
 
 function createTools(
     ctx: Context,
-    mask: ToolMask
+    permission: ChatLunaAgentPermissionService,
+    info: SubAgentInfo
 ): ComputedRef<ChatLunaTool[]> {
     return computed(() =>
-        ctx.chatluna.platform
-            .getFilteredTools(mask)
+        permission
+            .listTools()
+            .map((item) => item.name)
+            .filter((name) => permission.canUseTool(info, name))
             .map((name) => ctx.chatluna.platform.getTool(name))
     )
 }


### PR DESCRIPTION
description: |-

This pr fixes extension-agent skill materialization, case-insensitive skill and sub-agent resolution, and delegated tool filtering so agent reloads and handoffs stay consistent.

## New Features

None.

## Bug fixes

- reset the remote skill materialization directory before rewriting skill resources so stale files do not leak across reloads
- make skill name matching case-insensitive in permission checks, activation, rendering, and active-skill lookups
- make sub-agent lookup fall back to case-insensitive name matching when the exact name differs only by casing
- stop relying on a prebuilt tool mask for sub-agent tool exposure and instead filter tools through the current permission rules
- clear cached materialized skills when the skill catalog is disposed or reloaded so later runs do not reuse stale state

## Other Changes

- remove the automatic disabled-skill config insertion during skill import
- normalize visible skill indexing to lowercase for consistent lookups across the agent services
- keep fallback sub-agent context compatible by using the incoming tool mask when present and a permissive default otherwise
