### PR TITLE
[Fix] bump chatluna-agent to 1.0.20

### DIFF
--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.19",
+    "version": "1.0.20",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/src/service/skills.ts
+++ b/packages/extension-agent/src/service/skills.ts
@@ -285,7 +285,9 @@ export class ChatLunaAgentSkillsService implements SkillToolService {
                 )
                 .map((item) => item.name)
 
-            if (!names.some((item) => item.toLowerCase() === name.toLowerCase())) {
+            if (
+                !names.some((item) => item.toLowerCase() === name.toLowerCase())
+            ) {
                 throw new Error(`Skill is not available: ${name}`)
             }
         }

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     "peerDependencies": {
         "koishi": "^4.18.9",
         "koishi-plugin-chatluna": "^1.4.0-alpha.7",
-        "koishi-plugin-chatluna-agent": "^1.0.19",
+        "koishi-plugin-chatluna-agent": "^1.0.20",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {


### PR DESCRIPTION
description: |-

This pr bumps `koishi-plugin-chatluna-agent` to `1.0.20`, updates `extension-tools` to the matching peer dependency range, and keeps the touched skills-service check aligned with the repo lint formatting.

## New Features

None.

## Bug fixes

- fix the version mismatch between `koishi-plugin-chatluna-agent` and `koishi-plugin-chatluna-tools` peer dependency expectations

## Other Changes

- bump `packages/extension-agent/package.json` from `1.0.19` to `1.0.20`
- update `packages/extension-tools/package.json` to require `koishi-plugin-chatluna-agent@^1.0.20`
- apply the lint formatting change in `packages/extension-agent/src/service/skills.ts`
