### PR TITLE
[Fix] preserve tool masks across sub-agent handoff

### DIFF
--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.20",
+    "version": "1.0.21",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -141,7 +141,15 @@ export class ChatLunaAgentPermissionService {
 
     listTools(): ToolInfo[] {
         const registry = this.getRegistry()
-        const key = Object.keys(registry).sort().join('\n')
+        const key = JSON.stringify(
+            Object.values(registry)
+                .map((item) => ({
+                    name: item.name,
+                    description: item.description,
+                    meta: item.meta
+                }))
+                .sort((a, b) => a.name.localeCompare(b.name))
+        )
         if (this._toolCache && this._toolCacheKey === key) {
             return this._toolCache
         }

--- a/packages/extension-agent/src/service/permissions.ts
+++ b/packages/extension-agent/src/service/permissions.ts
@@ -290,13 +290,28 @@ export class ChatLunaAgentPermissionService {
         return buildToolMask(allNames, allow)
     }
 
-    createSubAgentToolMask(info: SubAgentInfo): ToolMask {
-        const allNames = this.listTools().map((item) => item.name)
-        const allow = allNames.filter((name) => this.canUseTool(info, name))
-        return buildToolMask(allNames, allow)
+    async createSubAgentToolMask(
+        info: SubAgentInfo,
+        session?: Session,
+        source: string = 'chatluna'
+    ): Promise<ToolMask> {
+        const tools = this.listTools()
+        const allNames = tools.map((item) => item.name)
+        const allow = tools
+            .filter(
+                (item) =>
+                    this.canUseTool(info, item.name) &&
+                    this.isSessionAllowed(session, source, item)
+            )
+            .map((item) => item.name)
+        const mask = buildToolMask(allNames, allow)
+        return {
+            ...mask,
+            toolCallMask: await this.createToolCallMask(session, mask)
+        }
     }
 
-    async createToolCallMask(session: Session, mask?: ToolMask) {
+    async createToolCallMask(session?: Session, mask?: ToolMask) {
         const allNames = this.listTools()
             .map((item) => item.name)
             .filter((name) => applyToolMask(name, mask))

--- a/packages/extension-agent/src/service/sub_agent.ts
+++ b/packages/extension-agent/src/service/sub_agent.ts
@@ -196,7 +196,12 @@ export class ChatLunaAgentSubAgentService {
                         permission: this.permission,
                         info,
                         model: ctx.runConfig?.configurable?.model
-                    })
+                    }),
+                    toolMask: await this.permission.createSubAgentToolMask(
+                        info,
+                        ctx.session,
+                        ctx.source ?? 'chatluna'
+                    )
                 }
             },
             refresh: async () => {

--- a/packages/extension-agent/src/sub-agent/run.ts
+++ b/packages/extension-agent/src/sub-agent/run.ts
@@ -223,8 +223,9 @@ async function resolveSkillPrompt(
     toolMask: ToolMask
 ) {
     const service = ctx.chatluna_agent?.skills
+    const toolCallMask = toolMask.toolCallMask ?? toolMask
     if (!service) return undefined
-    if (!applyToolMask('skill', toolMask)) return undefined
+    if (!applyToolMask('skill', toolCallMask)) return undefined
     if (!permission.canUseTool(info, 'skill')) return undefined
 
     const skills = permission.filterSkills(

--- a/packages/extension-agent/src/sub-agent/run.ts
+++ b/packages/extension-agent/src/sub-agent/run.ts
@@ -4,8 +4,10 @@ import { HumanMessage } from '@langchain/core/messages'
 import {
     type AgentGenerateOptions,
     type AgentToolOptions,
+    applyToolMask,
     type ChatLunaAgent,
-    createAgentTool
+    createAgentTool,
+    type ToolMask
 } from 'koishi-plugin-chatluna/llm-core/agent'
 import {
     ChatLunaBaseEmbeddings,
@@ -49,7 +51,9 @@ export async function createSubAgent(
 
             return await base.agent.generate({
                 ...input,
-                prompt
+                prompt,
+                toolMask: base.toolMask,
+                subagentContext: base.subCtx
             })
         },
         async stream(input) {
@@ -64,7 +68,9 @@ export async function createSubAgent(
 
             return await base.agent.stream({
                 ...input,
-                prompt
+                prompt,
+                toolMask: base.toolMask,
+                subagentContext: base.subCtx
             })
         },
         asTool(toolOptions?: AgentToolOptions) {
@@ -79,12 +85,19 @@ async function createInnerAgent(
     options: CreateSubAgentOptions,
     input: AgentGenerateOptions
 ) {
+    const source = input.source ?? 'chatluna'
+    const toolMask = await options.permission.createSubAgentToolMask(
+        options.info,
+        input.session,
+        source
+    )
     const llm = await resolveModel(options.ctx, options.info, options.model)
     const embeddings = await resolveEmbeddings(options.ctx)
     const skills = await resolveSkillPrompt(
         options.ctx,
         options.permission,
-        options.info
+        options.info,
+        toolMask
     )
     const computer = options.ctx.chatluna_agent?.computer
     const backends = computer
@@ -94,8 +107,9 @@ async function createInnerAgent(
           )
         : []
     const subCtx =
-        input.subagentContext ??
-        createFallbackSubagentContext(options.info, input)
+        input.subagentContext != null
+            ? { ...input.subagentContext, toolMask }
+            : createFallbackSubagentContext(options.info, input, toolMask)
     const system = renderSubAgentSystemPrompt(
         options.info,
         subCtx,
@@ -117,6 +131,8 @@ async function createInnerAgent(
 
     return {
         llm,
+        toolMask,
+        subCtx,
         agent: await options.ctx.chatluna.createAgent({
             id: options.info.id,
             name: options.info.name,
@@ -131,14 +147,16 @@ async function createInnerAgent(
                     : undefined,
             mode: 'tool-calling',
             maxSteps: options.info.maxTurns,
-            handleParsingErrors: true
+            handleParsingErrors: true,
+            toolMask
         })
     }
 }
 
 function createFallbackSubagentContext(
     info: SubAgentInfo,
-    input: AgentGenerateOptions
+    input: AgentGenerateOptions,
+    toolMask: ToolMask
 ) {
     return {
         agentId: info.id,
@@ -146,11 +164,7 @@ function createFallbackSubagentContext(
         parentConversationId: input.conversationId ?? '',
         depth: 1,
         maxDepth: 1,
-        toolMask: input.toolMask ?? {
-            mode: 'all',
-            allow: [],
-            deny: []
-        },
+        toolMask,
         disableHandoff: true,
         traceInfo: {
             runId: info.id,
@@ -205,10 +219,12 @@ async function resolveEmbeddings(ctx: Context) {
 async function resolveSkillPrompt(
     ctx: Context,
     permission: ChatLunaAgentPermissionService,
-    info: SubAgentInfo
+    info: SubAgentInfo,
+    toolMask: ToolMask
 ) {
     const service = ctx.chatluna_agent?.skills
     if (!service) return undefined
+    if (!applyToolMask('skill', toolMask)) return undefined
     if (!permission.canUseTool(info, 'skill')) return undefined
 
     const skills = permission.filterSkills(

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -71,7 +71,7 @@
     "peerDependencies": {
         "koishi": "^4.18.9",
         "koishi-plugin-chatluna": "^1.4.0-alpha.7",
-        "koishi-plugin-chatluna-agent": "^1.0.20",
+        "koishi-plugin-chatluna-agent": "^1.0.21",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {


### PR DESCRIPTION
This pr fixes sub-agent handoff tool masking so delegated runs inherit the effective session-aware tool permissions, including MCP and skill tool visibility.

## New Features

None.

## Bug fixes

- build sub-agent tool masks with session and source aware filtering so delegated runs cannot see tools blocked for the current request
- carry the computed tool mask and sub-agent context through both `generate` and `stream` handoffs so nested agent runs use the same effective permissions
- attach the computed `toolCallMask` to sub-agent tool masks so downstream tool-call filtering matches the exposed tool list
- prevent skill prompt injection when the computed sub-agent tool mask does not allow the `skill` tool

## Other Changes

- make `createSubAgentToolMask` asynchronous so it can include session-aware tool-call filtering
- pass the resolved sub-agent tool mask back from `ChatLunaAgentSubAgentService` for delegated agent creation
- keep fallback sub-agent contexts synchronized with the computed tool mask instead of rebuilding a separate default mask
