### PR TITLE
[Feature] add OpenAI Responses API support

### DIFF
--- a/packages/adapter-claude/src/client.ts
+++ b/packages/adapter-claude/src/client.ts
@@ -92,6 +92,7 @@ export class ClaudeClient extends PlatformModelClient<ClientConfig> {
             'claude-sonnet-4-5-20250929',
             'claude-opus-4-5-20251101',
             'claude-opus-4-6',
+            'claude-opus-4-7',
             'claude-sonnet-4-6',
             'claude-opus-4-1-20250805',
             'claude-haiku-4-5-20251001',

--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -47,8 +47,23 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
     async refreshModels(config?: RunnableConfig): Promise<ModelInfo[]> {
         try {
             const rawModels = await this._requester.getModels(config)
+            const models: string[] = []
 
-            return rawModels
+            for (const model of rawModels) {
+                models.push(model)
+
+                if (!model.startsWith('deepseek-v4-')) continue
+                if (model.endsWith('-thinking')) continue
+                if (model.endsWith('-instance')) continue
+
+                models.push(
+                    `${model}-high-thinking`,
+                    `${model}-max-thinking`,
+                    `${model}-instance`
+                )
+            }
+
+            return models
                 .filter(
                     (model) =>
                         model.includes('deepseek') ||

--- a/packages/adapter-deepseek/src/client.ts
+++ b/packages/adapter-deepseek/src/client.ts
@@ -99,7 +99,11 @@ export class DeepseekClient extends PlatformModelAndEmbeddingsClient<ClientConfi
                 temperature: this._config.temperature,
                 maxRetries: this._config.maxRetries,
                 llmType: 'deepseek',
-                isThinkModel: model.includes('reasoner')
+                isThinkModel:
+                    model.includes('reasoner') ||
+                    model.includes('thinking') ||
+                    (model.startsWith('deepseek-v4-') &&
+                        !model.endsWith('-instance'))
             })
         }
 

--- a/packages/adapter-deepseek/src/requester.ts
+++ b/packages/adapter-deepseek/src/requester.ts
@@ -46,9 +46,7 @@ export class DeepseekRequester
         const rawModel = params.model
         const disabled = rawModel.endsWith('-instance')
         const parsedModel = parseOpenAIModelNameWithReasoningEffort(
-            disabled
-                ? rawModel.slice(0, -'-instance'.length)
-                : rawModel
+            disabled ? rawModel.slice(0, -'-instance'.length) : rawModel
         )
         const model = parsedModel.model
         const requestContext = createRequestContext(
@@ -129,26 +127,7 @@ export class DeepseekRequester
             data = JSON.parse(data as string)
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const rawModels = (<Record<string, any>[]>data.data).map(
-                (model) => model.id as string
-            )
-            const models: string[] = []
-
-            for (const model of rawModels) {
-                models.push(model)
-
-                if (!model.startsWith('deepseek-v4-')) continue
-                if (model.endsWith('-thinking')) continue
-                if (model.endsWith('-instance')) continue
-
-                models.push(
-                    `${model}-high-thinking`,
-                    `${model}-max-thinking`,
-                    `${model}-instance`
-                )
-            }
-
-            return models
+            return (<Record<string, any>[]>data.data).map((model) => model.id)
         } catch (e) {
             if (e instanceof ChatLunaError) {
                 throw e

--- a/packages/adapter-deepseek/src/requester.ts
+++ b/packages/adapter-deepseek/src/requester.ts
@@ -13,12 +13,19 @@ import { logger } from '.'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Context } from 'koishi'
 import {
+    buildChatCompletionParams,
     completionStream,
     createEmbeddings,
-    createRequestContext
+    createRequestContext,
+    parseOpenAIModelNameWithReasoningEffort,
+    processStreamResponse
 } from '@chatluna/v1-shared-adapter'
 import { RunnableConfig } from '@langchain/core/runnables'
-import { ChatLunaError } from 'koishi-plugin-chatluna/utils/error'
+import {
+    ChatLunaError,
+    ChatLunaErrorCode
+} from 'koishi-plugin-chatluna/utils/error'
+import { sseIterable } from 'koishi-plugin-chatluna/utils/sse'
 
 export class DeepseekRequester
     extends ModelRequester
@@ -36,6 +43,14 @@ export class DeepseekRequester
     async *completionStreamInternal(
         params: ModelRequestParams
     ): AsyncGenerator<ChatGenerationChunk> {
+        const rawModel = params.model
+        const disabled = rawModel.endsWith('-instance')
+        const parsedModel = parseOpenAIModelNameWithReasoningEffort(
+            disabled
+                ? rawModel.slice(0, -'-instance'.length)
+                : rawModel
+        )
+        const model = parsedModel.model
         const requestContext = createRequestContext(
             this.ctx,
             this._config.value,
@@ -44,8 +59,47 @@ export class DeepseekRequester
             this
         )
 
-        // Deepseek specific streaming with reasoning content support
-        yield* completionStream(requestContext, params)
+        if (!model.startsWith('deepseek-v4-')) {
+            yield* completionStream(requestContext, params)
+            return
+        }
+
+        const request = (await buildChatCompletionParams(
+            { ...params, model: disabled ? model : rawModel },
+            this._plugin,
+            false,
+            true
+        )) as Awaited<ReturnType<typeof buildChatCompletionParams>> & {
+            thinking?: {
+                type: 'enabled' | 'disabled'
+            }
+        }
+
+        request.thinking = {
+            type: disabled ? 'disabled' : 'enabled'
+        }
+
+        if (disabled) {
+            delete request.reasoning_effort
+        } else {
+            delete request.temperature
+            delete request.presence_penalty
+            delete request.frequency_penalty
+            delete request.top_p
+        }
+
+        try {
+            const response = await this.post('chat/completions', request, {
+                signal: params.signal
+            })
+
+            yield* processStreamResponse(requestContext, sseIterable(response))
+        } catch (e) {
+            if (e instanceof ChatLunaError) {
+                throw e
+            }
+            throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED, e)
+        }
     }
 
     async embeddings(
@@ -75,7 +129,26 @@ export class DeepseekRequester
             data = JSON.parse(data as string)
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return (<Record<string, any>[]>data.data).map((model) => model.id)
+            const rawModels = (<Record<string, any>[]>data.data).map(
+                (model) => model.id as string
+            )
+            const models: string[] = []
+
+            for (const model of rawModels) {
+                models.push(model)
+
+                if (!model.startsWith('deepseek-v4-')) continue
+                if (model.endsWith('-thinking')) continue
+                if (model.endsWith('-instance')) continue
+
+                models.push(
+                    `${model}-high-thinking`,
+                    `${model}-max-thinking`,
+                    `${model}-instance`
+                )
+            }
+
+            return models
         } catch (e) {
             if (e instanceof ChatLunaError) {
                 throw e

--- a/packages/adapter-gemini/src/requester.ts
+++ b/packages/adapter-gemini/src/requester.ts
@@ -42,7 +42,10 @@ import {
 } from './utils'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Context } from 'koishi'
-import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
+import {
+    getMessageContent,
+    hashString
+} from 'koishi-plugin-chatluna/utils/string'
 import type {} from 'koishi-plugin-chatluna-storage-service'
 import { ToolCallChunk } from '@langchain/core/messages/tool'
 import { RunnableConfig } from '@langchain/core/runnables'
@@ -592,7 +595,7 @@ export class GeminiRequester
 
                 const file = await storageService.createTempFile(
                     buffer,
-                    'image_random'
+                    `${await hashString(imagePart.inlineData.data, 8)}.${(imagePart.inlineData.mimeType ?? 'image/png').split('/')[1]}`
                 )
 
                 messagePart.text = '[image]'

--- a/packages/adapter-openai-like/src/client.ts
+++ b/packages/adapter-openai-like/src/client.ts
@@ -20,6 +20,7 @@ import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import {
     getModelMaxContextSize,
     isEmbeddingModel,
+    isImageGenerationModel,
     isNonLLMModel,
     supportImageInput
 } from '@chatluna/v1-shared-adapter'
@@ -65,7 +66,8 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
             )
 
             const filteredModels = rawModels.filter(
-                (model) => !isNonLLMModel(model)
+                (model) =>
+                    !isNonLLMModel(model) || isImageGenerationModel(model)
             )
 
             const blacklist = this._config.blacklistModels
@@ -74,6 +76,12 @@ export class OpenAIClient extends PlatformModelAndEmbeddingsClient {
 
             const supportToolCalling = (model: string) => {
                 // const lower = model.toLowerCase()
+
+                if (isImageGenerationModel(model)) {
+                    return {
+                        capabilities: [ModelCapabilities.ImageGeneration]
+                    }
+                }
 
                 return {
                     capabilities: [

--- a/packages/adapter-openai-like/src/index.ts
+++ b/packages/adapter-openai-like/src/index.ts
@@ -67,6 +67,7 @@ export interface Config extends ChatLunaPlugin.Config {
     platform: string
     frequencyPenalty: number
     nonStreaming: boolean
+    responseApi: boolean
     googleSearch: boolean
     googleSearchSupportModel: string[]
 }
@@ -122,7 +123,8 @@ export const Config: Schema<Config> = Schema.intersect([
         temperature: Schema.percent().min(0).max(2).step(0.1).default(1),
         presencePenalty: Schema.number().min(-2).max(2).step(0.1).default(0),
         frequencyPenalty: Schema.number().min(-2).max(2).step(0.1).default(0),
-        nonStreaming: Schema.boolean().default(false)
+        nonStreaming: Schema.boolean().default(false),
+        responseApi: Schema.boolean().default(false)
     }),
     Schema.object({
         googleSearch: Schema.boolean().default(false),
@@ -149,6 +151,9 @@ export const usage = `
 - API 请求地址：\`https://api.bltcy.ai/v1\`
 `
 
-export const inject = ['chatluna']
+export const inject = {
+    required: ['chatluna'],
+    optional: ['chatluna_storage']
+}
 
 export const name = 'chatluna-openai-like-adapter'

--- a/packages/adapter-openai-like/src/index.ts
+++ b/packages/adapter-openai-like/src/index.ts
@@ -7,6 +7,7 @@ import {
 import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
 import { OpenAIClient } from './client'
 import { ModelCapabilities } from 'koishi-plugin-chatluna/llm-core/platform/types'
+import type { ResponseBuiltinToolName } from '@chatluna/v1-shared-adapter'
 
 export let logger: Logger
 export const reusable = true
@@ -70,6 +71,9 @@ export interface Config extends ChatLunaPlugin.Config {
     responseApi: boolean
     googleSearch: boolean
     googleSearchSupportModel: string[]
+    responseBuiltinTools: ResponseBuiltinToolName[]
+    responseBuiltinToolSupportModel: string[]
+    responseFileSearchVectorStoreIds: string[]
 }
 
 export const Config: Schema<Config> = Schema.intersect([
@@ -86,11 +90,16 @@ export const Config: Schema<Config> = Schema.intersect([
                 ]).default('LLM 大语言模型'),
                 modelCapabilities: Schema.array(
                     Schema.union([
+                        ModelCapabilities.TextInput,
                         ModelCapabilities.ToolCall,
-                        ModelCapabilities.ImageInput
+                        ModelCapabilities.ImageInput,
+                        ModelCapabilities.ImageGeneration
                     ])
                 )
-                    .default([ModelCapabilities.ToolCall])
+                    .default([
+                        ModelCapabilities.TextInput,
+                        ModelCapabilities.ToolCall
+                    ])
                     .role('checkbox'),
                 contextSize: Schema.number().default(128000)
             })
@@ -130,7 +139,34 @@ export const Config: Schema<Config> = Schema.intersect([
         googleSearch: Schema.boolean().default(false),
         googleSearchSupportModel: Schema.array(Schema.string()).default([
             'gemini-2.0'
-        ])
+        ]),
+        responseBuiltinTools: Schema.array(
+            Schema.union([
+                'web_search',
+                'web_search_preview',
+                'image_generation',
+                'code_interpreter',
+                'file_search'
+            ])
+        )
+            .default([])
+            .role('checkbox'),
+        responseBuiltinToolSupportModel: Schema.array(Schema.string()).default([
+            'gpt-4o',
+            'gpt-4o-mini',
+            'gpt-4.1',
+            'gpt-4.1-mini',
+            'gpt-4.1-nano',
+            'gpt-5',
+            'gpt-5-mini',
+            'gpt-5-nano',
+            'o3',
+            'o3-mini',
+            'o4-mini'
+        ]),
+        responseFileSearchVectorStoreIds: Schema.array(Schema.string()).default(
+            []
+        )
     })
 ]).i18n({
     'zh-CN': require('./locales/zh-CN.schema.yml'),

--- a/packages/adapter-openai-like/src/locales/en-US.schema.yml
+++ b/packages/adapter-openai-like/src/locales/en-US.schema.yml
@@ -38,6 +38,7 @@ $inner:
       presencePenalty: 'Token presence penalty (-2 to 2, step 0.1, discourages repetition)'
       frequencyPenalty: 'Token frequency penalty (-2 to 2, step 0.1, reduces repetition)'
       nonStreaming: 'Force disable streaming response. When enabled, requests will always be made in non-streaming mode, even if the stream parameter is configured.'
+      responseApi: 'Enable OpenAI Responses API. Disabled by default; when disabled, Chat Completions API is used.'
 
     - $desc: Other settings
       googleSearch: Whether to enable Google search. (Only valid for Gemini models that support Google search and use the new-api)

--- a/packages/adapter-openai-like/src/locales/en-US.schema.yml
+++ b/packages/adapter-openai-like/src/locales/en-US.schema.yml
@@ -43,3 +43,6 @@ $inner:
     - $desc: Other settings
       googleSearch: Whether to enable Google search. (Only valid for Gemini models that support Google search and use the new-api)
       googleSearchSupportModel: List of models supported by Google search.
+      responseBuiltinTools: 'Enabled OpenAI Responses API built-in tools. Supports web search, image generation, code interpreter, and file search; computer tools are not exposed.'
+      responseBuiltinToolSupportModel: 'Models that support Responses API built-in tools.'
+      responseFileSearchVectorStoreIds: 'Vector Store IDs used by file_search. Required when file_search is enabled.'

--- a/packages/adapter-openai-like/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-openai-like/src/locales/zh-CN.schema.yml
@@ -43,3 +43,6 @@ $inner:
     - $desc: 其他设置
       googleSearch: 是否启用 Google 搜索。（只对支持 google 搜索的 gemini 模型 且为 new-api 的端点有效）
       googleSearchSupportModel: Google 搜索支持的模型列表。
+      responseBuiltinTools: 启用的 OpenAI Responses API 内置工具。可选网页搜索、图片生成、代码解释器和文件搜索；computer 类工具未提供。
+      responseBuiltinToolSupportModel: OpenAI Responses API 内置工具支持的模型列表。
+      responseFileSearchVectorStoreIds: 文件搜索使用的 Vector Store ID 列表。启用 file_search 时必须填写。

--- a/packages/adapter-openai-like/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-openai-like/src/locales/zh-CN.schema.yml
@@ -38,6 +38,7 @@ $inner:
       presencePenalty: 重复惩罚系数，数值越高，越不易重复出现已出现过至少一次的 Token（范围：-2~2，步长：0.1）。
       frequencyPenalty: 频率惩罚系数，数值越高，越不易重复出现次数较多的 Token（范围：-2~2，步长：0.1）。
       nonStreaming: 强制不启用流式返回。开启后，将总是以非流式发起请求，即便配置了 stream 参数。
+      responseApi: 是否启用 OpenAI Responses API。默认关闭，关闭时继续使用 Chat Completions API。
 
     - $desc: 其他设置
       googleSearch: 是否启用 Google 搜索。（只对支持 google 搜索的 gemini 模型 且为 new-api 的端点有效）

--- a/packages/adapter-openai-like/src/requester.ts
+++ b/packages/adapter-openai-like/src/requester.ts
@@ -17,7 +17,10 @@ import {
     completionStream,
     createEmbeddings,
     createRequestContext,
-    getModels
+    getModels,
+    responseApiCompletion,
+    responseApiCompletionStream,
+    ResponseImageProvider
 } from '@chatluna/v1-shared-adapter'
 import { BaseMessageChunk } from '@langchain/core/messages'
 import { RunnableConfig } from '@langchain/core/runnables'
@@ -36,7 +39,10 @@ export class OpenAIRequester
     }
 
     async completion(params: ModelRequestParams): Promise<ChatGeneration> {
-        if (!this._pluginConfig.nonStreaming) {
+        if (
+            !this._pluginConfig.nonStreaming &&
+            !this._pluginConfig.responseApi
+        ) {
             return super.completion(params)
         }
 
@@ -47,6 +53,19 @@ export class OpenAIRequester
             this._plugin,
             this
         )
+
+        if (this._pluginConfig.responseApi) {
+            return responseApiCompletion(
+                requestContext,
+                params,
+                this._pluginConfig.googleSearch &&
+                    this._pluginConfig.googleSearchSupportModel.includes(
+                        params.model
+                    ),
+                true,
+                this._imageProvider()
+            )
+        }
 
         return completion(
             requestContext,
@@ -62,7 +81,10 @@ export class OpenAIRequester
     async *completionStream(
         params: ModelRequestParams
     ): AsyncGenerator<ChatGenerationChunk> {
-        if (!this._pluginConfig.nonStreaming) {
+        if (
+            !this._pluginConfig.nonStreaming ||
+            this._pluginConfig.responseApi
+        ) {
             yield* super.completionStream(params)
             return
         }
@@ -87,6 +109,20 @@ export class OpenAIRequester
             this._plugin,
             this
         )
+
+        if (this._pluginConfig.responseApi) {
+            yield* responseApiCompletionStream(
+                requestContext,
+                params,
+                this._pluginConfig.googleSearch &&
+                    this._pluginConfig.googleSearchSupportModel.includes(
+                        params.model
+                    ),
+                true,
+                this._imageProvider()
+            )
+            return
+        }
 
         yield* completionStream(
             requestContext,
@@ -127,6 +163,32 @@ export class OpenAIRequester
 
     get logger() {
         return logger
+    }
+
+    private _imageProvider(): ResponseImageProvider {
+        return async (item) => {
+            const storage = (
+                this.ctx as Context & {
+                    chatluna_storage?: {
+                        createTempFile(
+                            buffer: Buffer,
+                            name: string
+                        ): Promise<{ url: string }>
+                    }
+                }
+            ).chatluna_storage
+
+            if (!storage) {
+                return `data:image/png;base64,${item.result}`
+            }
+
+            const file = await storage.createTempFile(
+                Buffer.from(item.result as string, 'base64'),
+                'image_random'
+            )
+
+            return file.url
+        }
     }
 
     public buildHeaders() {

--- a/packages/adapter-openai-like/src/requester.ts
+++ b/packages/adapter-openai-like/src/requester.ts
@@ -20,6 +20,7 @@ import {
     getModels,
     responseApiCompletion,
     responseApiCompletionStream,
+    type ResponseBuiltinTool,
     ResponseImageProvider
 } from '@chatluna/v1-shared-adapter'
 import { BaseMessageChunk } from '@langchain/core/messages'
@@ -60,10 +61,14 @@ export class OpenAIRequester
             return responseApiCompletion(
                 requestContext,
                 params,
-                this._pluginConfig.googleSearch &&
-                    this._pluginConfig.googleSearchSupportModel.includes(
-                        params.model
-                    ),
+                {
+                    googleSearch:
+                        this._pluginConfig.googleSearch &&
+                        this._pluginConfig.googleSearchSupportModel.includes(
+                            params.model
+                        ),
+                    builtinTools: this._responseBuiltinTools(params)
+                },
                 true,
                 this._imageProvider()
             )
@@ -113,10 +118,14 @@ export class OpenAIRequester
             yield* responseApiCompletionStream(
                 requestContext,
                 params,
-                this._pluginConfig.googleSearch &&
-                    this._pluginConfig.googleSearchSupportModel.includes(
-                        params.model
-                    ),
+                {
+                    googleSearch:
+                        this._pluginConfig.googleSearch &&
+                        this._pluginConfig.googleSearchSupportModel.includes(
+                            params.model
+                        ),
+                    builtinTools: this._responseBuiltinTools(params)
+                },
                 true,
                 this._imageProvider()
             )
@@ -160,6 +169,48 @@ export class OpenAIRequester
         return await getModels(requestContext, config)
     }
 
+    private _responseBuiltinTools(
+        params: ModelRequestParams
+    ): ResponseBuiltinTool[] {
+        if (
+            !this._pluginConfig.responseBuiltinToolSupportModel.includes(
+                params.model
+            )
+        ) {
+            return []
+        }
+
+        const result: ResponseBuiltinTool[] = []
+
+        for (const type of this._pluginConfig.responseBuiltinTools) {
+            if (type === 'file_search') {
+                if (
+                    this._pluginConfig.responseFileSearchVectorStoreIds.length >
+                    0
+                ) {
+                    result.push({
+                        type,
+                        vector_store_ids:
+                            this._pluginConfig.responseFileSearchVectorStoreIds
+                    })
+                }
+                continue
+            }
+
+            if (type === 'code_interpreter') {
+                result.push({
+                    type,
+                    container: { type: 'auto' }
+                })
+                continue
+            }
+
+            result.push({ type })
+        }
+
+        return result
+    }
+
     get logger() {
         return logger
     }
@@ -167,14 +218,22 @@ export class OpenAIRequester
     private _imageProvider(): ResponseImageProvider {
         return async (item) => {
             const storage = this.ctx.chatluna_storage
+            const format =
+                item.output_format === 'png' ||
+                item.output_format === 'jpeg' ||
+                item.output_format === 'webp'
+                    ? item.output_format
+                    : 'png'
+            const ext = format === 'jpeg' ? 'jpg' : format
+            const mime = format === 'jpeg' ? 'image/jpeg' : `image/${format}`
 
             if (!storage) {
-                return `data:image/png;base64,${item.result}`
+                return `data:${mime};base64,${item.result}`
             }
 
             const file = await storage.createTempFile(
                 Buffer.from(item.result as string, 'base64'),
-                `${await hashString(item.result as string, 8)}.png`
+                `${await hashString(item.result as string, 8)}.${ext}`
             )
 
             return file.url

--- a/packages/adapter-openai-like/src/requester.ts
+++ b/packages/adapter-openai-like/src/requester.ts
@@ -24,6 +24,8 @@ import {
 } from '@chatluna/v1-shared-adapter'
 import { BaseMessageChunk } from '@langchain/core/messages'
 import { RunnableConfig } from '@langchain/core/runnables'
+import { hashString } from 'koishi-plugin-chatluna/utils/string'
+import type {} from 'koishi-plugin-chatluna-storage-service'
 
 export class OpenAIRequester
     extends ModelRequester
@@ -81,10 +83,7 @@ export class OpenAIRequester
     async *completionStream(
         params: ModelRequestParams
     ): AsyncGenerator<ChatGenerationChunk> {
-        if (
-            !this._pluginConfig.nonStreaming ||
-            this._pluginConfig.responseApi
-        ) {
+        if (!this._pluginConfig.nonStreaming) {
             yield* super.completionStream(params)
             return
         }
@@ -167,16 +166,7 @@ export class OpenAIRequester
 
     private _imageProvider(): ResponseImageProvider {
         return async (item) => {
-            const storage = (
-                this.ctx as Context & {
-                    chatluna_storage?: {
-                        createTempFile(
-                            buffer: Buffer,
-                            name: string
-                        ): Promise<{ url: string }>
-                    }
-                }
-            ).chatluna_storage
+            const storage = this.ctx.chatluna_storage
 
             if (!storage) {
                 return `data:image/png;base64,${item.result}`
@@ -184,7 +174,7 @@ export class OpenAIRequester
 
             const file = await storage.createTempFile(
                 Buffer.from(item.result as string, 'base64'),
-                'image_random'
+                `${await hashString(item.result as string, 8)}.png`
             )
 
             return file.url

--- a/packages/adapter-openai/src/index.ts
+++ b/packages/adapter-openai/src/index.ts
@@ -2,6 +2,7 @@ import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Context, Logger, Schema } from 'koishi'
 import { OpenAIClient } from './client'
 import { createLogger } from 'koishi-plugin-chatluna/utils/logger'
+import type { ResponseBuiltinToolName } from '@chatluna/v1-shared-adapter'
 
 export let logger: Logger
 
@@ -42,6 +43,9 @@ export interface Config extends ChatLunaPlugin.Config {
     presencePenalty: number
     frequencyPenalty: number
     responseApi: boolean
+    responseBuiltinTools: ResponseBuiltinToolName[]
+    responseBuiltinToolSupportModel: string[]
+    responseFileSearchVectorStoreIds: string[]
 }
 
 export const Config: Schema<Config> = Schema.intersect([
@@ -68,6 +72,35 @@ export const Config: Schema<Config> = Schema.intersect([
         presencePenalty: Schema.number().min(-2).max(2).step(0.1).default(0),
         frequencyPenalty: Schema.number().min(-2).max(2).step(0.1).default(0),
         responseApi: Schema.boolean().default(false)
+    }),
+    Schema.object({
+        responseBuiltinTools: Schema.array(
+            Schema.union([
+                'web_search',
+                'web_search_preview',
+                'image_generation',
+                'code_interpreter',
+                'file_search'
+            ])
+        )
+            .default([])
+            .role('checkbox'),
+        responseBuiltinToolSupportModel: Schema.array(Schema.string()).default([
+            'gpt-4o',
+            'gpt-4o-mini',
+            'gpt-4.1',
+            'gpt-4.1-mini',
+            'gpt-4.1-nano',
+            'gpt-5',
+            'gpt-5-mini',
+            'gpt-5-nano',
+            'o3',
+            'o3-mini',
+            'o4-mini'
+        ]),
+        responseFileSearchVectorStoreIds: Schema.array(Schema.string()).default(
+            []
+        )
     })
 ]).i18n({
     'zh-CN': require('./locales/zh-CN.schema.yml'),

--- a/packages/adapter-openai/src/index.ts
+++ b/packages/adapter-openai/src/index.ts
@@ -41,6 +41,7 @@ export interface Config extends ChatLunaPlugin.Config {
     temperature: number
     presencePenalty: number
     frequencyPenalty: number
+    responseApi: boolean
 }
 
 export const Config: Schema<Config> = Schema.intersect([
@@ -65,7 +66,8 @@ export const Config: Schema<Config> = Schema.intersect([
             .default(0.35),
         temperature: Schema.percent().min(0).max(2).step(0.1).default(1),
         presencePenalty: Schema.number().min(-2).max(2).step(0.1).default(0),
-        frequencyPenalty: Schema.number().min(-2).max(2).step(0.1).default(0)
+        frequencyPenalty: Schema.number().min(-2).max(2).step(0.1).default(0),
+        responseApi: Schema.boolean().default(false)
     })
 ]).i18n({
     'zh-CN': require('./locales/zh-CN.schema.yml'),
@@ -87,6 +89,9 @@ export const usage = `
 - API 请求地址：\`https://api.bltcy.ai/v1\`
 `
 
-export const inject = ['chatluna']
+export const inject = {
+    required: ['chatluna'],
+    optional: ['chatluna_storage']
+}
 
 export const name = 'chatluna-openai-adapter'

--- a/packages/adapter-openai/src/locales/en-US.schema.yml
+++ b/packages/adapter-openai/src/locales/en-US.schema.yml
@@ -13,3 +13,4 @@ $inner:
     temperature: 'Sampling temperature (higher values increase randomness)'
     presencePenalty: 'Token presence penalty (-2 to 2, step 0.1, discourages token repetition)'
     frequencyPenalty: 'Token frequency penalty (-2 to 2, step 0.1, reduces frequent token repetition)'
+    responseApi: 'Enable OpenAI Responses API. Disabled by default; when disabled, Chat Completions API is used.'

--- a/packages/adapter-openai/src/locales/en-US.schema.yml
+++ b/packages/adapter-openai/src/locales/en-US.schema.yml
@@ -14,3 +14,8 @@ $inner:
     presencePenalty: 'Token presence penalty (-2 to 2, step 0.1, discourages token repetition)'
     frequencyPenalty: 'Token frequency penalty (-2 to 2, step 0.1, reduces frequent token repetition)'
     responseApi: 'Enable OpenAI Responses API. Disabled by default; when disabled, Chat Completions API is used.'
+
+  - $desc: 'Other settings'
+    responseBuiltinTools: 'Enabled OpenAI Responses API built-in tools. Supports web search, image generation, code interpreter, and file search; computer tools are not exposed.'
+    responseBuiltinToolSupportModel: 'Models that support Responses API built-in tools.'
+    responseFileSearchVectorStoreIds: 'Vector Store IDs used by file_search. Required when file_search is enabled.'

--- a/packages/adapter-openai/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-openai/src/locales/zh-CN.schema.yml
@@ -13,3 +13,4 @@ $inner:
       temperature: 回复的随机性程度，数值越高，回复越随机。
       presencePenalty: 重复惩罚系数，数值越高，越不易重复出现已出现过至少一次的 Token（范围：-2~2，步长：0.1）。
       frequencyPenalty: 频率惩罚系数，数值越高，越不易重复出现次数较多的 Token（范围：-2~2，步长：0.1）。
+      responseApi: 是否启用 OpenAI Responses API。默认关闭，关闭时继续使用 Chat Completions API。

--- a/packages/adapter-openai/src/locales/zh-CN.schema.yml
+++ b/packages/adapter-openai/src/locales/zh-CN.schema.yml
@@ -14,3 +14,8 @@ $inner:
       presencePenalty: 重复惩罚系数，数值越高，越不易重复出现已出现过至少一次的 Token（范围：-2~2，步长：0.1）。
       frequencyPenalty: 频率惩罚系数，数值越高，越不易重复出现次数较多的 Token（范围：-2~2，步长：0.1）。
       responseApi: 是否启用 OpenAI Responses API。默认关闭，关闭时继续使用 Chat Completions API。
+
+    - $desc: 其他设置
+      responseBuiltinTools: 启用的 OpenAI Responses API 内置工具。可选网页搜索、图片生成、代码解释器和文件搜索；computer 类工具未提供。
+      responseBuiltinToolSupportModel: OpenAI Responses API 内置工具支持的模型列表。
+      responseFileSearchVectorStoreIds: 文件搜索使用的 Vector Store ID 列表。启用 file_search 时必须填写。

--- a/packages/adapter-openai/src/requester.ts
+++ b/packages/adapter-openai/src/requester.ts
@@ -9,13 +9,15 @@ import {
     ClientConfig,
     ClientConfigPool
 } from 'koishi-plugin-chatluna/llm-core/platform/config'
-import { logger } from '.'
+import { Config, logger } from '.'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Context } from 'koishi'
 import {
     completionStream,
     createEmbeddings,
-    createRequestContext
+    createRequestContext,
+    responseApiCompletionStream,
+    ResponseImageProvider
 } from '@chatluna/v1-shared-adapter'
 import { RunnableConfig } from '@langchain/core/runnables'
 import { ChatLunaError } from 'koishi-plugin-chatluna/utils/error'
@@ -27,7 +29,7 @@ export class OpenAIRequester
     constructor(
         ctx: Context,
         _configPool: ClientConfigPool<ClientConfig>,
-        _pluginConfig: ChatLunaPlugin.Config,
+        public _pluginConfig: Config,
         _plugin: ChatLunaPlugin
     ) {
         super(ctx, _configPool, _pluginConfig, _plugin)
@@ -44,7 +46,44 @@ export class OpenAIRequester
             this
         )
 
+        if (this._pluginConfig.responseApi) {
+            yield* responseApiCompletionStream(
+                requestContext,
+                params,
+                false,
+                true,
+                this._imageProvider()
+            )
+            return
+        }
+
         yield* completionStream(requestContext, params)
+    }
+
+    private _imageProvider(): ResponseImageProvider {
+        return async (item) => {
+            const storage = (
+                this.ctx as Context & {
+                    chatluna_storage?: {
+                        createTempFile(
+                            buffer: Buffer,
+                            name: string
+                        ): Promise<{ url: string }>
+                    }
+                }
+            ).chatluna_storage
+
+            if (!storage) {
+                return `data:image/png;base64,${item.result}`
+            }
+
+            const file = await storage.createTempFile(
+                Buffer.from(item.result as string, 'base64'),
+                'image_random'
+            )
+
+            return file.url
+        }
     }
 
     async embeddings(

--- a/packages/adapter-openai/src/requester.ts
+++ b/packages/adapter-openai/src/requester.ts
@@ -21,6 +21,8 @@ import {
 } from '@chatluna/v1-shared-adapter'
 import { RunnableConfig } from '@langchain/core/runnables'
 import { ChatLunaError } from 'koishi-plugin-chatluna/utils/error'
+import { hashString } from 'koishi-plugin-chatluna/utils/string'
+import type {} from 'koishi-plugin-chatluna-storage-service'
 
 export class OpenAIRequester
     extends ModelRequester
@@ -62,16 +64,7 @@ export class OpenAIRequester
 
     private _imageProvider(): ResponseImageProvider {
         return async (item) => {
-            const storage = (
-                this.ctx as Context & {
-                    chatluna_storage?: {
-                        createTempFile(
-                            buffer: Buffer,
-                            name: string
-                        ): Promise<{ url: string }>
-                    }
-                }
-            ).chatluna_storage
+            const storage = this.ctx.chatluna_storage
 
             if (!storage) {
                 return `data:image/png;base64,${item.result}`
@@ -79,7 +72,7 @@ export class OpenAIRequester
 
             const file = await storage.createTempFile(
                 Buffer.from(item.result as string, 'base64'),
-                'image_random'
+                `${await hashString(item.result as string, 8)}.png`
             )
 
             return file.url

--- a/packages/adapter-openai/src/requester.ts
+++ b/packages/adapter-openai/src/requester.ts
@@ -17,6 +17,7 @@ import {
     createEmbeddings,
     createRequestContext,
     responseApiCompletionStream,
+    type ResponseBuiltinTool,
     ResponseImageProvider
 } from '@chatluna/v1-shared-adapter'
 import { RunnableConfig } from '@langchain/core/runnables'
@@ -52,7 +53,9 @@ export class OpenAIRequester
             yield* responseApiCompletionStream(
                 requestContext,
                 params,
-                false,
+                {
+                    builtinTools: this._responseBuiltinTools(params)
+                },
                 true,
                 this._imageProvider()
             )
@@ -65,18 +68,68 @@ export class OpenAIRequester
     private _imageProvider(): ResponseImageProvider {
         return async (item) => {
             const storage = this.ctx.chatluna_storage
+            const format =
+                item.output_format === 'png' ||
+                item.output_format === 'jpeg' ||
+                item.output_format === 'webp'
+                    ? item.output_format
+                    : 'png'
+            const ext = format === 'jpeg' ? 'jpg' : format
+            const mime = format === 'jpeg' ? 'image/jpeg' : `image/${format}`
 
             if (!storage) {
-                return `data:image/png;base64,${item.result}`
+                return `data:${mime};base64,${item.result}`
             }
 
             const file = await storage.createTempFile(
                 Buffer.from(item.result as string, 'base64'),
-                `${await hashString(item.result as string, 8)}.png`
+                `${await hashString(item.result as string, 8)}.${ext}`
             )
 
             return file.url
         }
+    }
+
+    private _responseBuiltinTools(
+        params: ModelRequestParams
+    ): ResponseBuiltinTool[] {
+        if (
+            !this._pluginConfig.responseBuiltinToolSupportModel.includes(
+                params.model
+            )
+        ) {
+            return []
+        }
+
+        const result: ResponseBuiltinTool[] = []
+
+        for (const type of this._pluginConfig.responseBuiltinTools) {
+            if (type === 'file_search') {
+                if (
+                    this._pluginConfig.responseFileSearchVectorStoreIds.length >
+                    0
+                ) {
+                    result.push({
+                        type,
+                        vector_store_ids:
+                            this._pluginConfig.responseFileSearchVectorStoreIds
+                    })
+                }
+                continue
+            }
+
+            if (type === 'code_interpreter') {
+                result.push({
+                    type,
+                    container: { type: 'auto' }
+                })
+                continue
+            }
+
+            result.push({ type })
+        }
+
+        return result
     }
 
     async embeddings(

--- a/packages/core/src/llm-core/platform/client.ts
+++ b/packages/core/src/llm-core/platform/client.ts
@@ -120,6 +120,8 @@ export abstract class BasePlatformClient<
                       )
                 this._modelInfos[model.name] = model
             }
+
+            return models
         } catch (e) {
             if (
                 e instanceof ChatLunaError &&

--- a/packages/core/src/llm-core/platform/client.ts
+++ b/packages/core/src/llm-core/platform/client.ts
@@ -9,6 +9,7 @@ import {
 } from 'koishi-plugin-chatluna/llm-core/platform/model'
 import {
     FileHandlingConfig,
+    ModelCapabilities,
     ModelInfo,
     PlatformClientNames
 } from 'koishi-plugin-chatluna/llm-core/platform/types'
@@ -107,6 +108,16 @@ export abstract class BasePlatformClient<
             this._modelInfos = {}
 
             for (const model of models) {
+                model.capabilities = model.capabilities.includes(
+                    ModelCapabilities.ImageGeneration
+                )
+                    ? [ModelCapabilities.ImageGeneration]
+                    : Array.from(
+                          new Set([
+                              ...model.capabilities,
+                              ModelCapabilities.TextInput
+                          ])
+                      )
                 this._modelInfos[model.name] = model
             }
         } catch (e) {

--- a/packages/core/src/llm-core/platform/types.ts
+++ b/packages/core/src/llm-core/platform/types.ts
@@ -130,6 +130,7 @@ export interface PlatformModelInfo extends ModelInfo {
 }
 
 export enum ModelCapabilities {
+    TextInput = 'text_input',
     ToolCall = 'tool_call',
     ImageInput = 'image_input',
     Thinking = 'thinking',

--- a/packages/core/src/utils/schema.ts
+++ b/packages/core/src/utils/schema.ts
@@ -6,6 +6,18 @@ import { PlatformService } from 'koishi-plugin-chatluna/llm-core/platform/servic
 import { ModelType } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import type {} from '@koishijs/plugin-notifier'
 
+import { parseRawModelName } from './model'
+
+function compareSchemaName(a: string, b: string) {
+    const [aPlatform, aName] = parseRawModelName(a)
+    const [bPlatform, bName] = parseRawModelName(b)
+
+    return (
+        (aPlatform ?? '').localeCompare(bPlatform ?? '') ||
+        (aName ?? '').localeCompare(bName ?? '')
+    )
+}
+
 /**
  * Sets up the model selection schema by automatically watching for model changes
  * in the platform service and updating the 'model' schema.
@@ -139,7 +151,9 @@ export function listModelNames(
             (model) => model.platform + '/' + model.name
         )
 
-        return includeNone ? ['无'].concat(names) : names
+        return includeNone
+            ? ['无'].concat(names).sort(compareSchemaName)
+            : names.sort(compareSchemaName)
     })
 }
 
@@ -160,6 +174,7 @@ function getVectorStores(ctx: Context, service: PlatformService) {
     return computed(() =>
         ['无']
             .concat(vectorStoreNamesRef.value)
+            .sort(compareSchemaName)
             .map((name) => Schema.const(name).description(name))
     )
 }
@@ -167,8 +182,9 @@ function getVectorStores(ctx: Context, service: PlatformService) {
 function getChatChainNames(service: PlatformService) {
     const chains = service.chatChains
     return computed(() =>
-        chains.value.map((info) =>
-            Schema.const(info.name).i18n(info.description)
-        )
+        chains.value
+            .slice()
+            .sort((a, b) => compareSchemaName(a.name, b.name))
+            .map((info) => Schema.const(info.name).i18n(info.description))
     )
 }

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -7,6 +7,7 @@ export type OpenAIReasoningEffort =
     | 'low'
     | 'medium'
     | 'high'
+    | 'max'
     | 'xhigh'
 
 export const reasoningEffortModelSuffixes = [
@@ -34,7 +35,7 @@ export function parseOpenAIModelNameWithReasoningEffort(modelName: string): {
     let reasoningEffort: OpenAIReasoningEffort | undefined
 
     const explicitMatch = model.match(
-        /-(none|minimal|low|medium|high|xhigh|tiny)-thinking$/
+        /-(none|minimal|low|medium|high|max|xhigh|tiny)-thinking$/
     )
 
     if (explicitMatch?.[1]) {

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -83,6 +83,12 @@ export function isNonLLMModel(modelName: string): boolean {
     )
 }
 
+export function isImageGenerationModel(modelName: string): boolean {
+    return isNonLLMModel(modelName) && ['dall-e', 'image'].some((keyword) =>
+        modelName.includes(keyword)
+    )
+}
+
 export function getModelMaxContextSize(info: ModelInfo): number {
     const maxTokens = info.maxTokens
 

--- a/packages/shared-adapter/src/client.ts
+++ b/packages/shared-adapter/src/client.ts
@@ -84,8 +84,9 @@ export function isNonLLMModel(modelName: string): boolean {
 }
 
 export function isImageGenerationModel(modelName: string): boolean {
-    return isNonLLMModel(modelName) && ['dall-e', 'image'].some((keyword) =>
-        modelName.includes(keyword)
+    return (
+        isNonLLMModel(modelName) &&
+        ['dall-e', 'image'].some((keyword) => modelName.includes(keyword))
     )
 }
 

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -626,6 +626,16 @@ export async function* processResponseApiStream<
                     })
                 }
 
+                yield new ChatGenerationChunk({
+                    message: new AIMessageChunk({
+                        content: '',
+                        additional_kwargs: {
+                            conversation: data.response.conversation
+                        }
+                    }),
+                    text: ''
+                })
+
                 if (usageMetadata) {
                     yield new ChatGenerationChunk({
                         generationInfo: {

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -13,14 +13,23 @@ import { SSEEvent, sseIterable } from 'koishi-plugin-chatluna/utils/sse'
 import {
     ChatCompletionResponse,
     ChatCompletionResponseMessageRoleEnum,
-    CreateEmbeddingResponse
+    CreateEmbeddingResponse,
+    ResponseObject,
+    ResponseOutputItem,
+    ResponseStreamEvent
 } from './types'
 import {
     convertDeltaToMessageChunk,
     convertMessageToMessageChunk,
     formatToolsToOpenAITools,
+    formatToolsToResponseTools,
     langchainMessageToOpenAIMessage,
-    openAIUsageToUsageMetadata
+    langchainMessageToResponseInput,
+    openAIResponseUsageToUsageMetadata,
+    openAIUsageToUsageMetadata,
+    responseOutputImageItems,
+    responseOutputText,
+    responseOutputToolCalls
 } from './utils'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import { Context } from 'koishi'
@@ -45,6 +54,10 @@ interface RequestContext<
     plugin: ChatLunaPlugin
     modelRequester: ModelRequester<T, R>
 }
+
+export type ResponseImageProvider = (
+    item: Extract<ResponseOutputItem, { type: 'image_generation_call' }>
+) => Promise<string>
 
 export async function buildChatCompletionParams(
     params: ModelRequestParams,
@@ -109,6 +122,52 @@ export async function buildChatCompletionParams(
         delete base.n
         delete base.top_p
     }
+    return deepAssign({}, base, params.overrideRequestParams ?? {})
+}
+
+export async function buildResponseParams(
+    params: ModelRequestParams,
+    plugin: ChatLunaPlugin,
+    enableGoogleSearch: boolean,
+    supportImageInput?: boolean
+) {
+    const parsedModel = parseOpenAIModelNameWithReasoningEffort(params.model)
+    const normalizedModel = parsedModel.model
+
+    const base = {
+        model: normalizedModel,
+        input: await langchainMessageToResponseInput(
+            params.input,
+            plugin,
+            normalizedModel,
+            supportImageInput
+        ),
+        tools:
+            enableGoogleSearch || params.tools != null
+                ? formatToolsToResponseTools(
+                      params.tools ?? [],
+                      enableGoogleSearch
+                  )
+                : undefined,
+        max_output_tokens: normalizedModel.includes('vision')
+            ? undefined
+            : params.maxTokens,
+        temperature: params.temperature === 0 ? undefined : params.temperature,
+        top_p: params.topP,
+        prompt_cache_key: params.id,
+        reasoning:
+            parsedModel.reasoningEffort == null ||
+            parsedModel.reasoningEffort === 'none'
+                ? undefined
+                : { effort: parsedModel.reasoningEffort },
+        stream: true,
+        stream_options: {
+            include_obfuscation: false
+        },
+        store: false,
+        parallel_tool_calls: true
+    }
+
     return deepAssign({}, base, params.overrideRequestParams ?? {})
 }
 
@@ -370,6 +429,245 @@ export async function processResponse<
     }
 }
 
+export async function responseToChatGeneration(
+    response: ResponseObject,
+    imageProvider?: ResponseImageProvider
+) {
+    if (response.error) {
+        throw new ChatLunaError(
+            ChatLunaErrorCode.API_REQUEST_FAILED,
+            new Error(response.error.message ?? JSON.stringify(response.error))
+        )
+    }
+
+    const text = responseOutputText(response)
+    const toolCalls = responseOutputToolCalls(response)
+    const images = imageProvider
+        ? await Promise.all(
+              responseOutputImageItems(response).map((item) =>
+                  imageProvider(item)
+              )
+          )
+        : []
+    const usageMetadata = response.usage
+        ? openAIResponseUsageToUsageMetadata(response.usage)
+        : undefined
+    const message = new AIMessageChunk({
+        content:
+            images.length > 0
+                ? [
+                      ...(text.length > 0
+                          ? [{ type: 'text' as const, text }]
+                          : []),
+                      ...images.map((image) => ({
+                          type: 'image_url' as const,
+                          image_url: image
+                      }))
+                  ]
+                : text,
+        tool_call_chunks: toolCalls.map((call, index) => ({
+            name: call.name,
+            args: call.arguments,
+            id: call.call_id,
+            index
+        })),
+        usage_metadata: usageMetadata,
+        additional_kwargs: {
+            conversation: response.conversation
+        }
+    })
+
+    return new ChatGenerationChunk({
+        generationInfo:
+            usageMetadata == null
+                ? undefined
+                : {
+                      usage_metadata: usageMetadata
+                  },
+        message,
+        text
+    })
+}
+
+export async function processResponseApiResponse(
+    response: Response,
+    imageProvider?: ResponseImageProvider
+) {
+    if (response.status !== 200) {
+        throw new ChatLunaError(
+            ChatLunaErrorCode.API_REQUEST_FAILED,
+            new Error(
+                'Error when calling responses, Status: ' +
+                    response.status +
+                    ' ' +
+                    response.statusText +
+                    ', Response: ' +
+                    (await response.text())
+            )
+        )
+    }
+
+    const responseText = await response.text()
+
+    try {
+        return await responseToChatGeneration(
+            JSON.parse(responseText) as ResponseObject,
+            imageProvider
+        )
+    } catch (e) {
+        if (e instanceof ChatLunaError) throw e
+        throw new ChatLunaError(
+            ChatLunaErrorCode.API_REQUEST_FAILED,
+            new Error(
+                'Error when calling responses, Error: ' +
+                    e +
+                    ', Response: ' +
+                    responseText
+            )
+        )
+    }
+}
+
+// eslint-disable-next-line generator-star-spacing
+export async function* processResponseApiStream<
+    T extends ClientConfig,
+    R extends ChatLunaPlugin.Config
+>(
+    requestContext: RequestContext<T, R>,
+    iterator: AsyncGenerator<SSEEvent, string, unknown>,
+    imageProvider?: ResponseImageProvider
+) {
+    const args = new Map<number, string>()
+    const calls = new Map<
+        number,
+        { name?: string; callId?: string; itemId?: string }
+    >()
+    let errorCount = 0
+
+    for await (const event of iterator) {
+        const chunk = event.data
+        if (chunk === '[DONE]') break
+        if (chunk === '' || chunk == null || chunk === 'undefined') continue
+
+        try {
+            const data = JSON.parse(chunk) as ResponseStreamEvent
+
+            if (data.type === 'response.output_text.delta' && data.delta) {
+                yield new ChatGenerationChunk({
+                    message: new AIMessageChunk(data.delta),
+                    text: data.delta
+                })
+                continue
+            }
+
+            if (
+                data.type === 'response.output_item.added' &&
+                data.item?.type === 'function_call'
+            ) {
+                const item = data.item as Extract<
+                    ResponseOutputItem,
+                    { type: 'function_call' }
+                >
+                calls.set(data.output_index ?? calls.size, {
+                    name: item.name,
+                    callId: item.call_id,
+                    itemId: item.id
+                })
+                continue
+            }
+
+            if (data.type === 'response.function_call_arguments.delta') {
+                const index = data.output_index ?? 0
+                args.set(index, (args.get(index) ?? '') + (data.delta ?? ''))
+                continue
+            }
+
+            if (data.type === 'response.function_call_arguments.done') {
+                const index = data.output_index ?? 0
+                const call = calls.get(index)
+                yield new ChatGenerationChunk({
+                    message: new AIMessageChunk({
+                        content: '',
+                        tool_call_chunks: [
+                            {
+                                name: data.name ?? call?.name,
+                                args: data.arguments ?? args.get(index) ?? '',
+                                id: call?.callId ?? data.item_id,
+                                index
+                            }
+                        ]
+                    }),
+                    text: ''
+                })
+                continue
+            }
+
+            if (data.type === 'response.completed' && data.response) {
+                const usageMetadata = data.response.usage
+                    ? openAIResponseUsageToUsageMetadata(data.response.usage)
+                    : undefined
+                const images = imageProvider
+                    ? await Promise.all(
+                          responseOutputImageItems(data.response).map((item) =>
+                              imageProvider(item)
+                          )
+                      )
+                    : []
+
+                if (images.length > 0) {
+                    yield new ChatGenerationChunk({
+                        message: new AIMessageChunk({
+                            content: images.map((image) => ({
+                                type: 'image_url' as const,
+                                image_url: image
+                            }))
+                        }),
+                        text: ''
+                    })
+                }
+
+                if (usageMetadata) {
+                    yield new ChatGenerationChunk({
+                        generationInfo: {
+                            usage_metadata: usageMetadata
+                        },
+                        message: new AIMessageChunk({
+                            content: '',
+                            usage_metadata: usageMetadata,
+                            additional_kwargs: {
+                                conversation: data.response.conversation
+                            }
+                        }),
+                        text: ''
+                    })
+                }
+                continue
+            }
+
+            if (
+                data.type === 'response.failed' ||
+                data.type === 'response.incomplete' ||
+                data.type === 'response.error'
+            ) {
+                throw new ChatLunaError(
+                    ChatLunaErrorCode.API_REQUEST_FAILED,
+                    new Error(chunk)
+                )
+            }
+        } catch (e) {
+            if (e instanceof ChatLunaError) throw e
+            if (errorCount > 5) {
+                requestContext.modelRequester.logger.error(
+                    'error with responses chunk',
+                    chunk
+                )
+                throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED, e)
+            }
+            errorCount++
+        }
+    }
+}
+
 // eslint-disable-next-line generator-star-spacing
 export async function* completionStream<
     T extends ClientConfig,
@@ -461,6 +759,88 @@ export async function completion<
         } else {
             throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED, e)
         }
+    }
+}
+
+// eslint-disable-next-line generator-star-spacing
+export async function* responseApiCompletionStream<
+    T extends ClientConfig,
+    R extends ChatLunaPlugin.Config
+>(
+    requestContext: RequestContext<T, R>,
+    params: ModelRequestParams,
+    enableGoogleSearch?: boolean,
+    supportImageInput?: boolean,
+    imageProvider?: ResponseImageProvider
+): AsyncGenerator<ChatGenerationChunk> {
+    const { modelRequester } = requestContext
+    const request = await buildResponseParams(
+        params,
+        requestContext.plugin,
+        enableGoogleSearch ?? false,
+        supportImageInput ?? true
+    )
+
+    try {
+        const response = await modelRequester.post('responses', request, {
+            signal: params.signal
+        })
+
+        yield* processResponseApiStream(
+            requestContext,
+            sseIterable(response),
+            imageProvider
+        )
+    } catch (e) {
+        if (requestContext.ctx.chatluna.currentConfig.isLog) {
+            await trackLogToLocal(
+                'Request',
+                JSON.stringify(request),
+                requestContext.ctx.logger('')
+            )
+        }
+        if (e instanceof ChatLunaError) throw e
+        throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED, e)
+    }
+}
+
+export async function responseApiCompletion<
+    T extends ClientConfig,
+    R extends ChatLunaPlugin.Config
+>(
+    requestContext: RequestContext<T, R>,
+    params: ModelRequestParams,
+    enableGoogleSearch?: boolean,
+    supportImageInput?: boolean,
+    imageProvider?: ResponseImageProvider
+): Promise<ChatGenerationChunk> {
+    const { modelRequester } = requestContext
+    const request = await buildResponseParams(
+        params,
+        requestContext.plugin,
+        enableGoogleSearch ?? false,
+        supportImageInput ?? true
+    )
+
+    delete request.stream
+    delete request.stream_options
+
+    try {
+        const response = await modelRequester.post('responses', request, {
+            signal: params.signal
+        })
+
+        return await processResponseApiResponse(response, imageProvider)
+    } catch (e) {
+        if (requestContext.ctx.chatluna.currentConfig.isLog) {
+            await trackLogToLocal(
+                'Request',
+                JSON.stringify(request),
+                requestContext.ctx.logger('')
+            )
+        }
+        if (e instanceof ChatLunaError) throw e
+        throw new ChatLunaError(ChatLunaErrorCode.API_REQUEST_FAILED, e)
     }
 }
 

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -552,6 +552,7 @@ export async function* processResponseApiStream<
         { name?: string; callId?: string; itemId?: string }
     >()
     let errorCount = 0
+    let sentConversation = false
 
     for await (const event of iterator) {
         const chunk = event.data
@@ -635,15 +636,18 @@ export async function* processResponseApiStream<
                     })
                 }
 
-                yield new ChatGenerationChunk({
-                    message: new AIMessageChunk({
-                        content: '',
-                        additional_kwargs: {
-                            conversation: data.response.conversation
-                        }
-                    }),
-                    text: ''
-                })
+                if (!sentConversation) {
+                    sentConversation = true
+                    yield new ChatGenerationChunk({
+                        message: new AIMessageChunk({
+                            content: '',
+                            additional_kwargs: {
+                                conversation: data.response.conversation
+                            }
+                        }),
+                        text: ''
+                    })
+                }
 
                 if (usageMetadata) {
                     yield new ChatGenerationChunk({
@@ -652,10 +656,7 @@ export async function* processResponseApiStream<
                         },
                         message: new AIMessageChunk({
                             content: '',
-                            usage_metadata: usageMetadata,
-                            additional_kwargs: {
-                                conversation: data.response.conversation
-                            }
+                            usage_metadata: usageMetadata
                         }),
                         text: ''
                     })

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -14,6 +14,7 @@ import {
     ChatCompletionResponse,
     ChatCompletionResponseMessageRoleEnum,
     CreateEmbeddingResponse,
+    type ResponseBuiltinTool,
     ResponseObject,
     ResponseOutputItem,
     ResponseStreamEvent
@@ -58,6 +59,11 @@ interface RequestContext<
 export type ResponseImageProvider = (
     item: Extract<ResponseOutputItem, { type: 'image_generation_call' }>
 ) => Promise<string>
+
+export interface ResponseToolOptions {
+    googleSearch?: boolean
+    builtinTools?: ResponseBuiltinTool[]
+}
 
 export async function buildChatCompletionParams(
     params: ModelRequestParams,
@@ -128,7 +134,7 @@ export async function buildChatCompletionParams(
 export async function buildResponseParams(
     params: ModelRequestParams,
     plugin: ChatLunaPlugin,
-    enableGoogleSearch: boolean,
+    opts: ResponseToolOptions = {},
     supportImageInput?: boolean
 ) {
     const parsedModel = parseOpenAIModelNameWithReasoningEffort(params.model)
@@ -143,10 +149,13 @@ export async function buildResponseParams(
             supportImageInput
         ),
         tools:
-            enableGoogleSearch || params.tools != null
+            opts.googleSearch ||
+            (opts.builtinTools?.length ?? 0) > 0 ||
+            params.tools != null
                 ? formatToolsToResponseTools(
                       params.tools ?? [],
-                      enableGoogleSearch
+                      opts.googleSearch ?? false,
+                      opts.builtinTools
                   )
                 : undefined,
         max_output_tokens: normalizedModel.includes('vision')
@@ -779,7 +788,7 @@ export async function* responseApiCompletionStream<
 >(
     requestContext: RequestContext<T, R>,
     params: ModelRequestParams,
-    enableGoogleSearch?: boolean,
+    opts: ResponseToolOptions = {},
     supportImageInput?: boolean,
     imageProvider?: ResponseImageProvider
 ): AsyncGenerator<ChatGenerationChunk> {
@@ -787,7 +796,7 @@ export async function* responseApiCompletionStream<
     const request = await buildResponseParams(
         params,
         requestContext.plugin,
-        enableGoogleSearch ?? false,
+        opts,
         supportImageInput ?? true
     )
 
@@ -820,7 +829,7 @@ export async function responseApiCompletion<
 >(
     requestContext: RequestContext<T, R>,
     params: ModelRequestParams,
-    enableGoogleSearch?: boolean,
+    opts: ResponseToolOptions = {},
     supportImageInput?: boolean,
     imageProvider?: ResponseImageProvider
 ): Promise<ChatGenerationChunk> {
@@ -828,7 +837,7 @@ export async function responseApiCompletion<
     const request = await buildResponseParams(
         params,
         requestContext.plugin,
-        enableGoogleSearch ?? false,
+        opts,
         supportImageInput ?? true
     )
 

--- a/packages/shared-adapter/src/types.ts
+++ b/packages/shared-adapter/src/types.ts
@@ -93,7 +93,7 @@ export interface ResponseTool {
     description?: string
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     parameters?: { [key: string]: any }
-    strict?: boolean | null
+    strict?: boolean
 }
 
 export interface ResponseObject {

--- a/packages/shared-adapter/src/types.ts
+++ b/packages/shared-adapter/src/types.ts
@@ -38,6 +38,128 @@ export interface ChatCompletionUsage {
     completion_tokens_details?: ChatCompletionCompletionTokensDetails
 }
 
+export interface ResponseUsage {
+    input_tokens: number
+    output_tokens: number
+    total_tokens: number
+    input_tokens_details?: {
+        cached_tokens?: number
+    }
+    output_tokens_details?: {
+        reasoning_tokens?: number
+    }
+}
+
+export type ResponseInputContent =
+    | {
+          type: 'input_text'
+          text: string
+      }
+    | {
+          type: 'input_image'
+          image_url: string
+          detail?: 'low' | 'high' | 'auto' | 'original'
+      }
+    | {
+          type: 'input_file'
+          file_url?: string
+          file_data?: string
+          file_id?: string
+          filename?: string
+      }
+
+export type ResponseInputItem =
+    | {
+          type: 'message'
+          role: 'system' | 'developer' | 'user' | 'assistant'
+          content: string | ResponseInputContent[]
+      }
+    | {
+          type: 'function_call'
+          call_id: string
+          name: string
+          arguments: string
+          status?: 'completed' | 'in_progress' | 'incomplete'
+      }
+    | {
+          type: 'function_call_output'
+          call_id: string
+          output: string | ResponseInputContent[]
+      }
+
+export interface ResponseTool {
+    type: 'function'
+    name: string
+    description?: string
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    parameters?: { [key: string]: any }
+    strict?: boolean | null
+}
+
+export interface ResponseObject {
+    id: string
+    object: 'response'
+    output_text?: string
+    output?: ResponseOutputItem[]
+    usage?: ResponseUsage
+    error?: { message?: string } | null
+    conversation?: { id: string } | null
+}
+
+export type ResponseOutputItem =
+    | {
+          type: 'message'
+          role?: string
+          content?: ResponseOutputContent[]
+      }
+    | {
+          type: 'function_call'
+          id?: string
+          call_id: string
+          name: string
+          arguments: string
+          status?: string
+      }
+    | {
+          type: 'image_generation_call'
+          id?: string
+          result?: string | null
+          status?: string
+      }
+    | {
+          type: string
+          [key: string]: unknown
+      }
+
+export type ResponseOutputContent =
+    | {
+          type: 'output_text'
+          text: string
+      }
+    | {
+          type: 'refusal'
+          refusal: string
+      }
+    | {
+          type: string
+          [key: string]: unknown
+      }
+
+export interface ResponseStreamEvent {
+    type: string
+    sequence_number?: number
+    item_id?: string
+    output_index?: number
+    content_index?: number
+    delta?: string
+    text?: string
+    name?: string
+    arguments?: string
+    item?: ResponseOutputItem
+    response?: ResponseObject
+    partial_image_b64?: string
+}
+
 export interface ChatCompletionTextPart {
     type: 'text'
     text: string

--- a/packages/shared-adapter/src/types.ts
+++ b/packages/shared-adapter/src/types.ts
@@ -87,14 +87,92 @@ export type ResponseInputItem =
           output: string | ResponseInputContent[]
       }
 
-export interface ResponseTool {
-    type: 'function'
-    name: string
-    description?: string
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    parameters?: { [key: string]: any }
-    strict?: boolean
-}
+export type ResponseBuiltinToolName =
+    | 'web_search'
+    | 'web_search_preview'
+    | 'image_generation'
+    | 'code_interpreter'
+    | 'file_search'
+
+export type ResponseBuiltinTool =
+    | {
+          type: 'web_search' | 'web_search_2025_08_26'
+          filters?: {
+              allowed_domains?: string[] | null
+          } | null
+          search_context_size?: 'low' | 'medium' | 'high'
+          user_location?: {
+              city?: string | null
+              country?: string | null
+              region?: string | null
+              timezone?: string | null
+              type?: 'approximate'
+          } | null
+      }
+    | {
+          type: 'web_search_preview' | 'web_search_preview_2025_03_11'
+          search_content_types?: ('text' | 'image')[]
+          search_context_size?: 'low' | 'medium' | 'high'
+          user_location?: {
+              type: 'approximate'
+              city?: string | null
+              country?: string | null
+              region?: string | null
+              timezone?: string | null
+          } | null
+      }
+    | {
+          type: 'image_generation'
+          action?: 'generate' | 'edit' | 'auto'
+          background?: 'transparent' | 'opaque' | 'auto'
+          input_fidelity?: 'high' | 'low' | null
+          input_image_mask?: {
+              file_id?: string
+              image_url?: string
+          }
+          model?: string
+          moderation?: 'auto' | 'low'
+          output_compression?: number
+          output_format?: 'png' | 'webp' | 'jpeg'
+          partial_images?: number
+          quality?: 'low' | 'medium' | 'high' | 'auto'
+          size?: '1024x1024' | '1024x1536' | '1536x1024' | 'auto'
+      }
+    | {
+          type: 'code_interpreter'
+          container:
+              | string
+              | {
+                    type: 'auto'
+                    file_ids?: string[]
+                    memory_limit?: '1g' | '4g' | '16g' | '64g' | null
+                }
+      }
+    | {
+          type: 'file_search'
+          vector_store_ids: string[]
+          filters?: Record<string, unknown> | null
+          max_num_results?: number
+          ranking_options?: {
+              ranker?: 'auto' | 'default-2024-11-15'
+              score_threshold?: number
+              hybrid_search?: {
+                  embedding_weight: number
+                  text_weight: number
+              }
+          }
+      }
+
+export type ResponseTool =
+    | {
+          type: 'function'
+          name: string
+          description?: string
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          parameters?: { [key: string]: any }
+          strict?: boolean
+      }
+    | ResponseBuiltinTool
 
 export interface ResponseObject {
     id: string
@@ -124,6 +202,7 @@ export type ResponseOutputItem =
           type: 'image_generation_call'
           id?: string
           result?: string | null
+          output_format?: 'png' | 'jpeg' | 'webp'
           status?: string
       }
     | {

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -20,6 +20,7 @@ import {
     ChatCompletionResponseMessageRoleEnum,
     ChatCompletionTool,
     ChatCompletionUsage,
+    type ResponseBuiltinTool,
     ResponseInputContent,
     ResponseInputItem,
     ResponseObject,
@@ -227,18 +228,32 @@ export function responseInputContent(
 
 export function formatToolsToResponseTools(
     tools: StructuredTool[],
-    includeGoogleSearch: boolean
+    includeGoogleSearch: boolean,
+    builtinTools: ResponseBuiltinTool[] = []
 ): ResponseTool[] | undefined {
-    const result = formatToolsToOpenAITools(tools, includeGoogleSearch)?.map(
-        (tool) => ({
+    const result: ResponseTool[] = (
+        formatToolsToOpenAITools(tools, includeGoogleSearch) ?? []
+    ).map((tool) => {
+        if (tool.function.name === 'googleSearch') {
+            return {
+                type: 'web_search' as const
+            }
+        }
+
+        return {
             type: 'function' as const,
             name: tool.function.name,
             description: tool.function.description,
             parameters: tool.function.parameters
-        })
-    )
+        }
+    })
 
-    return result?.length ? result : undefined
+    for (const tool of builtinTools) {
+        if (result.some((item) => item.type === tool.type)) continue
+        result.push(tool)
+    }
+
+    return result.length ? result : undefined
 }
 
 export function responseOutputText(response: ResponseObject): string {

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -19,7 +19,14 @@ import {
     ChatCompletionResponseMessage,
     ChatCompletionResponseMessageRoleEnum,
     ChatCompletionTool,
-    ChatCompletionUsage
+    ChatCompletionUsage,
+    ResponseInputContent,
+    ResponseInputItem,
+    ResponseObject,
+    ResponseOutputContent,
+    ResponseOutputItem,
+    ResponseTool,
+    ResponseUsage
 } from './types'
 import { ChatLunaPlugin } from 'koishi-plugin-chatluna/services/chat'
 import {
@@ -94,6 +101,183 @@ export function openAIUsageToUsageMetadata(
         cacheReadTokens: usage.prompt_tokens_details?.cached_tokens,
         reasoningTokens: usage.completion_tokens_details?.reasoning_tokens
     })
+}
+
+export function openAIResponseUsageToUsageMetadata(
+    usage: ResponseUsage
+): UsageMetadata {
+    return createUsageMetadata({
+        inputTokens: usage.input_tokens,
+        outputTokens: usage.output_tokens,
+        totalTokens: usage.total_tokens,
+        cacheReadTokens: usage.input_tokens_details?.cached_tokens,
+        reasoningTokens: usage.output_tokens_details?.reasoning_tokens
+    })
+}
+
+export async function langchainMessageToResponseInput(
+    messages: BaseMessage[],
+    plugin: ChatLunaPlugin,
+    model?: string,
+    supportImageInputType?: boolean
+): Promise<ResponseInputItem[]> {
+    const chatMessages = await langchainMessageToOpenAIMessage(
+        messages,
+        plugin,
+        model,
+        supportImageInputType
+    )
+    const result: ResponseInputItem[] = []
+
+    for (const msg of chatMessages) {
+        if (msg.role === 'tool') {
+            result.push({
+                type: 'function_call_output',
+                call_id: msg.tool_call_id,
+                output: responseInputContent(msg.content)
+            })
+            continue
+        }
+
+        if (msg.role === 'function') {
+            result.push({
+                type: 'message',
+                role: 'user',
+                content: responseInputContent(msg.content)
+            })
+            continue
+        }
+
+        if (msg.content != null && msg.content !== '') {
+            result.push({
+                type: 'message',
+                role:
+                    msg.role === 'system' ||
+                    msg.role === 'assistant' ||
+                    msg.role === 'user'
+                        ? msg.role
+                        : 'user',
+                content: responseInputContent(msg.content)
+            })
+        }
+
+        if (msg.role !== 'assistant' || !Array.isArray(msg.tool_calls)) {
+            continue
+        }
+
+        result.push(
+            ...msg.tool_calls.map((toolCall) => ({
+                type: 'function_call' as const,
+                call_id: toolCall.id,
+                name: toolCall.function.name,
+                arguments: toolCall.function.arguments,
+                status: 'completed' as const
+            }))
+        )
+    }
+
+    return result
+}
+
+export function responseInputContent(
+    content: ChatCompletionResponseMessage['content']
+): string | ResponseInputContent[] {
+    if (typeof content === 'string') return content
+    if (!Array.isArray(content)) return ''
+
+    return content
+        .map((part) => {
+            if (part.type === 'text') {
+                const text = part.text as string
+                return {
+                    type: 'input_text',
+                    text
+                } satisfies ResponseInputContent
+            }
+
+            if (part.type === 'image_url') {
+                const raw = part.image_url as
+                    | string
+                    | { url: string; detail?: 'low' | 'high' }
+                const imageUrl = typeof raw === 'string' ? raw : raw.url
+                const detail = typeof raw === 'string' ? undefined : raw.detail
+
+                return {
+                    type: 'input_image',
+                    image_url: imageUrl,
+                    detail: detail ?? 'auto'
+                } satisfies ResponseInputContent
+            }
+
+            if (part.type === 'file_url') {
+                const raw = part['file_url'] as
+                    | string
+                    | { url: string; filename?: string }
+                return {
+                    type: 'input_file',
+                    file_url: typeof raw === 'string' ? raw : raw.url,
+                    filename: typeof raw === 'string' ? undefined : raw.filename
+                } satisfies ResponseInputContent
+            }
+
+            return undefined
+        })
+        .filter((part) => part != null)
+}
+
+export function formatToolsToResponseTools(
+    tools: StructuredTool[],
+    includeGoogleSearch: boolean
+): ResponseTool[] | undefined {
+    const result = formatToolsToOpenAITools(tools, includeGoogleSearch)?.map(
+        (tool) => ({
+            type: 'function' as const,
+            name: tool.function.name,
+            description: tool.function.description,
+            parameters: tool.function.parameters,
+            strict: null
+        })
+    )
+
+    return result?.length ? result : undefined
+}
+
+export function responseOutputText(response: ResponseObject): string {
+    if ((response.output_text?.length ?? 0) > 0) return response.output_text
+
+    return (response.output ?? [])
+        .flatMap((item) => {
+            if (item.type !== 'message') return []
+            return ((item.content ?? []) as ResponseOutputContent[]).map(
+                (part) => {
+                    if (part.type === 'output_text') return part.text
+                    if (part.type === 'refusal') return part.refusal
+                    return ''
+                }
+            )
+        })
+        .join('')
+}
+
+export function responseOutputToolCalls(response: ResponseObject) {
+    return (response.output ?? []).filter(
+        (
+            item
+        ): item is Extract<ResponseOutputItem, { type: 'function_call' }> =>
+            item.type === 'function_call'
+    )
+}
+
+export function responseOutputImageItems(response: ResponseObject) {
+    return (response.output ?? [])
+        .filter((item) => item.type === 'image_generation_call' && item.result)
+        .map(
+            (item) =>
+                item as Extract<
+                    ResponseOutputItem,
+                    { type: 'image_generation_call' }
+                >
+        )
 }
 
 export async function langchainMessageToOpenAIMessage(

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -234,8 +234,7 @@ export function formatToolsToResponseTools(
             type: 'function' as const,
             name: tool.function.name,
             description: tool.function.description,
-            parameters: tool.function.parameters,
-            strict: null
+            parameters: tool.function.parameters
         })
     )
 


### PR DESCRIPTION
This pr adds OpenAI Responses API support across OpenAI-compatible adapters, shared request handling, DeepSeek v4 thinking variants, and related model metadata.

## New Features

- OpenAI and OpenAI-like adapters can opt into the OpenAI Responses API with a new `responseApi` config option.
- Shared adapter support for Responses API request building, streaming and non-streaming response parsing, tool calls, usage metadata, image outputs, and Google search tools.
- DeepSeek v4 thinking variants are exposed and handled with explicit thinking enable and disable modes.
- `max` reasoning effort suffix is supported for OpenAI-compatible model names.

## Bug fixes

See the list of fixed issues below

- No linked fixed issues.

## Other Changes

- Added optional `chatluna_storage` injection so generated images can be stored as temporary files when available.
- Added `claude-opus-4-7` to the Claude model list.
- Added English and Chinese schema text for the Responses API config option.