### PR TITLE
[Fix] avoid eager config selection during client init

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -46,7 +46,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-azure-openai-adapter",
     "description": "azure openai adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -47,7 +47,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-claude-adapter",
     "description": "claude adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-dify-adapter",
     "description": "dify adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-doubao-adapter",
     "description": "doubao adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-google-gemini-adapter",
     "description": "google-gemini adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -63,7 +63,7 @@
     ],
     "dependencies": {
         "@anatine/zod-openapi": "^2.2.8",
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "openapi3-ts": "^4.5.0",
         "zod": "3.25.76",

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-hunyuan-adapter",
     "description": "hunyuan adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80"
     },
     "devDependencies": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-ollama-adapter",
     "description": "ollama adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai-like/src/index.ts
+++ b/packages/adapter-openai-like/src/index.ts
@@ -154,15 +154,14 @@ export const Config: Schema<Config> = Schema.intersect([
         responseBuiltinToolSupportModel: Schema.array(Schema.string()).default([
             'gpt-4o',
             'gpt-4o-mini',
-            'gpt-4.1',
-            'gpt-4.1-mini',
-            'gpt-4.1-nano',
+            'gpt-5.1',
+            'gpt-5.2',
+            'gpt-5.3',
+            'gpt-5.4',
+            'gpt-5.5',
             'gpt-5',
             'gpt-5-mini',
-            'gpt-5-nano',
-            'o3',
-            'o3-mini',
-            'o4-mini'
+            'gpt-5-nano'
         ]),
         responseFileSearchVectorStoreIds: Schema.array(Schema.string()).default(
             []

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-qwen-adapter",
     "description": "qwen adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-rmkv-adapter",
     "description": "rwkv adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -45,7 +45,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "1.0.32",
+        "@chatluna/v1-shared-adapter": "1.0.34",
         "@langchain/core": "^0.3.80",
         "zod-to-json-schema": "3.23.5"
     },

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -61,7 +61,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-spark-adapter",
     "description": "spark adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "zod": "3.25.76",
         "zod-to-json-schema": "^3.24.6"

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-wenxin-adapter",
     "description": "wenxin adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-zhipu-adapter",
     "description": "zhipu(chatglm) adapter for chatluna",
-    "version": "1.4.0-alpha.0",
+    "version": "1.4.0-alpha.1",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -60,7 +60,7 @@
         "adapter"
     ],
     "dependencies": {
-        "@chatluna/v1-shared-adapter": "^1.0.32",
+        "@chatluna/v1-shared-adapter": "^1.0.34",
         "@langchain/core": "^0.3.80",
         "jsonwebtoken": "^9.0.2",
         "zod": "3.25.76",

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.8",
+    "version": "1.4.0-alpha.9",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/platform/client.ts
+++ b/packages/core/src/llm-core/platform/client.ts
@@ -48,7 +48,16 @@ export abstract class BasePlatformClient<
 
         let retryCount = 0
 
-        const maxRetries = this.config?.maxRetries ?? 1
+        const cfg =
+            this.configPool.findAvailableConfig() ??
+            this.configPool.getConfigs()[0]
+
+        if (cfg == null) {
+            unlock()
+            return false
+        }
+
+        const maxRetries = cfg.value.maxRetries ?? 5
 
         while (retryCount < (maxRetries ?? 1)) {
             try {
@@ -65,7 +74,13 @@ export abstract class BasePlatformClient<
                 }
 
                 if (retryCount === maxRetries - 1) {
-                    const oldConfig = this.configPool.getConfig(true)
+                    const oldConfig = this.configPool.findAvailableConfig()
+
+                    if (oldConfig == null) {
+                        this.ctx.logger.error(e)
+                        unlock()
+                        return false
+                    }
 
                     // refresh
                     this.configPool.getConfig(false)
@@ -74,7 +89,7 @@ export abstract class BasePlatformClient<
 
                     this.ctx.logger.error(e)
 
-                    if (this.configPool.findAvailableConfig() !== null) {
+                    if (this.configPool.findAvailableConfig() != null) {
                         retryCount = 0
                         continue
                     }

--- a/packages/core/src/llm-core/platform/client.ts
+++ b/packages/core/src/llm-core/platform/client.ts
@@ -1,7 +1,8 @@
-import { Context } from 'koishi'
+import { Context, sleep } from 'koishi'
 import {
     ClientConfig,
-    ClientConfigPool
+    ClientConfigPool,
+    ClientConfigWrapper
 } from 'koishi-plugin-chatluna/llm-core/platform/config'
 import {
     ChatLunaBaseEmbeddings,
@@ -60,7 +61,10 @@ export abstract class BasePlatformClient<
         const maxRetries = cfg.value.maxRetries ?? 5
 
         while (retryCount < (maxRetries ?? 1)) {
+            let oldConfig: ClientConfigWrapper<T> | undefined
+
             try {
+                oldConfig = this.configPool.getConfig(true)
                 await this.init(config)
                 unlock()
                 return true
@@ -73,9 +77,15 @@ export abstract class BasePlatformClient<
                     throw e
                 }
 
-                if (retryCount === maxRetries - 1) {
-                    const oldConfig = this.configPool.findAvailableConfig()
+                if (
+                    e instanceof ChatLunaError &&
+                    e.errorCode === ChatLunaErrorCode.NOT_AVAILABLE_CONFIG
+                ) {
+                    unlock()
+                    return false
+                }
 
+                if (retryCount === maxRetries - 1) {
                     if (oldConfig == null) {
                         this.ctx.logger.error(e)
                         unlock()
@@ -99,6 +109,7 @@ export abstract class BasePlatformClient<
                 }
             }
 
+            await sleep(1000 * 2 ** retryCount)
             retryCount++
         }
 

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -1205,7 +1205,7 @@ export namespace ChatLunaPlugin {
                 Schema.const('default'),
                 Schema.const('balance')
             ]).default('default'),
-            maxRetries: Schema.number().min(1).max(6).default(3),
+            maxRetries: Schema.number().min(1).max(6).default(5),
             timeout: Schema.number().default(300 * 1000),
             proxyMode: Schema.union([
                 Schema.const('system'),

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -89,7 +89,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -70,7 +70,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9",
         "koishi-plugin-chatluna-agent": "^1.0.21",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -61,7 +61,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.8"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.9"
     }
 }

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@chatluna/v1-shared-adapter",
     "description": "chatluna shared adapter",
-    "version": "1.0.33",
+    "version": "1.0.34",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",


### PR DESCRIPTION
## Summary
- stop reading `maxRetries` through `getConfig(true)` during client startup so adapters can still read retry settings from the configured default entry before any available config is selected
- return cleanly when no available config remains instead of re-throwing `NOT_AVAILABLE_CONFIG` from the startup path
- raise the default retry count to 5 so initial model refreshes have more room to recover

Closes #841