### PR TITLE
[Fix] preserve chat turn boundaries and queue ordering

### DIFF
--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -636,16 +636,13 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         }
 
         const buildConversationRounds = (items: BaseMessage[]) => {
-            const hasUser = items.some((message) =>
-                isChatLunaUserMessage(message)
-            )
             const rounds: BaseMessage[][] = []
             let current: BaseMessage[] = []
 
             for (const message of items) {
-                const isStart = hasUser
-                    ? isChatLunaUserMessage(message)
-                    : message.getType() === 'human'
+                const isStart =
+                    isChatLunaUserMessage(message) ||
+                    message.getType() === 'human'
 
                 if (isStart) {
                     if (current.length > 0) {

--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -42,6 +42,7 @@ import { chunkArray } from 'koishi-plugin-chatluna/llm-core/utils/chunk'
 import { encodingForModel } from '../utils/tiktoken'
 import { formatFunctionDefinitions } from '../utils/function_def'
 import { getMessageContent } from 'koishi-plugin-chatluna/utils/string'
+import { isChatLunaUserMessage } from 'koishi-plugin-chatluna/utils/langchain'
 import { logger } from 'koishi-plugin-chatluna'
 
 export interface ChatLunaModelCallOptions extends BaseChatModelCallOptions {
@@ -635,11 +636,18 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         }
 
         const buildConversationRounds = (items: BaseMessage[]) => {
+            const hasUser = items.some((message) =>
+                isChatLunaUserMessage(message)
+            )
             const rounds: BaseMessage[][] = []
             let current: BaseMessage[] = []
 
             for (const message of items) {
-                if (message.getType() === 'human') {
+                const isStart = hasUser
+                    ? isChatLunaUserMessage(message)
+                    : message.getType() === 'human'
+
+                if (isStart) {
                     if (current.length > 0) {
                         rounds.push(current)
                     }
@@ -795,7 +803,29 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
 
     async getNumTokens(text: string, modelName: string = this.modelName) {
         // fallback to approximate calculation if tiktoken is not available
-        let numTokens = Math.ceil(text.length / 4)
+        let rawCount = 0
+        for (const char of text) {
+            rawCount += char.charCodeAt(0) <= 0x7f ? 0.25 : 2 / 3
+        }
+        let numTokens = Math.ceil(rawCount)
+
+        if (
+            ![
+                'gpt-',
+                'o1',
+                'o3',
+                'o4',
+                'chatgpt-',
+                'text-',
+                'davinci',
+                'babbage',
+                'curie',
+                'ada',
+                'code-'
+            ].some((prefix) => modelName.startsWith(prefix))
+        ) {
+            return numTokens
+        }
 
         if (!this.__encoding) {
             try {

--- a/packages/core/src/llm-core/prompt/chat_history.ts
+++ b/packages/core/src/llm-core/prompt/chat_history.ts
@@ -119,17 +119,15 @@ export function createChatHistoryMiddleware(): PromptPipelineMiddleware {
 
 /**
  * Split a flat message list into conversation rounds. Marked ChatLuna user
- * messages start rounds; old unmarked history falls back to human messages.
+ * messages start rounds; old unmarked human messages still start rounds.
  */
 function buildConversationRounds(messages: BaseMessage[]): BaseMessage[][] {
-    const hasUser = messages.some((message) => isChatLunaUserMessage(message))
     const rounds: BaseMessage[][] = []
     let current: BaseMessage[] = []
 
     for (const message of messages) {
-        const isStart = hasUser
-            ? isChatLunaUserMessage(message)
-            : message.getType() === 'human'
+        const isStart =
+            isChatLunaUserMessage(message) || message.getType() === 'human'
 
         if (isStart) {
             if (current.length > 0) {

--- a/packages/core/src/llm-core/prompt/chat_history.ts
+++ b/packages/core/src/llm-core/prompt/chat_history.ts
@@ -6,6 +6,7 @@ import {
 } from './context_manager'
 import { countMessagesTokens, countMessageTokens } from './system_prompts'
 import { logger } from 'koishi-plugin-chatluna'
+import { isChatLunaUserMessage } from 'koishi-plugin-chatluna/utils/langchain'
 
 // ---------------------------------------------------------------------------
 // chat_history pipeline middleware
@@ -117,16 +118,20 @@ export function createChatHistoryMiddleware(): PromptPipelineMiddleware {
 }
 
 /**
- * Split a flat message list into conversation rounds.
- * A round starts with a human message and includes all following non-human
- * messages until the next human message.
+ * Split a flat message list into conversation rounds. Marked ChatLuna user
+ * messages start rounds; old unmarked history falls back to human messages.
  */
 function buildConversationRounds(messages: BaseMessage[]): BaseMessage[][] {
+    const hasUser = messages.some((message) => isChatLunaUserMessage(message))
     const rounds: BaseMessage[][] = []
     let current: BaseMessage[] = []
 
     for (const message of messages) {
-        if (message.getType() === 'human') {
+        const isStart = hasUser
+            ? isChatLunaUserMessage(message)
+            : message.getType() === 'human'
+
+        if (isStart) {
             if (current.length > 0) {
                 rounds.push(current)
             }

--- a/packages/core/src/llm-core/utils/tiktoken.ts
+++ b/packages/core/src/llm-core/utils/tiktoken.ts
@@ -58,7 +58,7 @@ export async function getEncoding(
     }
 
     const url =
-        globalProxyAddress.length > 0
+        (globalProxyAddress?.length ?? 0) > 0
             ? `https://tiktoken.pages.dev/js/${encoding}.json`
             : `https://jsd.onmicrosoft.cn/npm/tiktoken@latest/encoders/${encoding}.json`
 

--- a/packages/core/src/middlewares/chat/message_delay.ts
+++ b/packages/core/src/middlewares/chat/message_delay.ts
@@ -21,10 +21,15 @@ interface MessageTurnStarter {
 
 interface MessageTurn {
     userName: string
-    messages: Message[]
+    messages: QueuedMessage[]
     starter?: MessageTurnStarter
     timeout?: Disposable
     state: 'collecting' | 'waiting' | 'processing'
+}
+
+interface QueuedMessage {
+    message: Message
+    timestamp: number
 }
 
 interface ConversationQueue {
@@ -105,7 +110,10 @@ export function apply(ctx: Context, config: Config, chain: ChatChain) {
                 )
             }
 
-            turn.messages.push(inputMessage)
+            turn.messages.push({
+                message: inputMessage,
+                timestamp: session.timestamp
+            })
 
             const statusPromise = awaitTurnStart(turn, context)
 
@@ -283,7 +291,11 @@ function startHeadTurn(
 
     conversation.inFlight = true
     head.state = 'processing'
-    starter.context.options.inputMessage = mergeMessages(head.messages)
+    starter.context.options.inputMessage = mergeMessages(
+        head.messages
+            .sort((a, b) => a.timestamp - b.timestamp)
+            .map((msg) => msg.message)
+    )
     head.messages = []
     starter.resolve(ChainMiddlewareRunStatus.CONTINUE)
 }

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -105,8 +105,12 @@ export class ChatLunaService extends Service<Config> {
         this._renderer = new DefaultRenderer(ctx, config)
         this._promptRenderer = new ChatLunaPromptRenderService()
         this._contextManager = new ChatLunaContextManagerService(ctx)
-        this._conversation = new ConversationService(ctx, config)
         this._conversationRuntime = new ConversationRuntime(this)
+        this._conversation = new ConversationService(
+            ctx,
+            config,
+            this._conversationRuntime
+        )
 
         this._createTempDir()
         this._defineDatabase()

--- a/packages/core/src/services/conversation.ts
+++ b/packages/core/src/services/conversation.ts
@@ -55,6 +55,7 @@ import {
     ConversationArchivePayload,
     ListConversationsOptions
 } from './types'
+import type { ConversationRuntime } from './conversation_runtime'
 
 function matchTargetConversation(
     target: string,
@@ -121,7 +122,8 @@ export class ConversationService {
 
     constructor(
         private readonly ctx: Context,
-        private readonly config: Config
+        private readonly config: Config,
+        private readonly runtime: ConversationRuntime
     ) {}
 
     async getConversation(id: string) {
@@ -1118,7 +1120,7 @@ export class ConversationService {
             throw new Error('Conversation not found.')
         }
 
-        return this.ctx.chatluna.conversationRuntime.withConversationSync(
+        return this.runtime.withConversationSync(
             conversation,
             async () => {
                 const current = await this.getConversation(conversationId)
@@ -1226,7 +1228,7 @@ export class ConversationService {
                 const updatedConversation = await this.getConversation(
                     current.id
                 )
-                await this.ctx.chatluna.conversationRuntime.clearConversationInterfaceLocked(
+                await this.runtime.clearConversationInterfaceLocked(
                     updatedConversation ?? current
                 )
                 await this.ctx.root.parallel(
@@ -1282,7 +1284,7 @@ export class ConversationService {
             throw new Error('Conversation restore is disabled by constraint.')
         }
 
-        return this.ctx.chatluna.conversationRuntime.withConversationSync(
+        return this.runtime.withConversationSync(
             conversation,
             async () => {
                 const current = await this.getConversation(conversation.id)
@@ -1375,7 +1377,7 @@ export class ConversationService {
                         updatedConversation.bindingKey,
                         updatedConversation.id
                     )
-                    await this.ctx.chatluna.conversationRuntime.clearConversationInterfaceLocked(
+                    await this.runtime.clearConversationInterfaceLocked(
                         updatedConversation
                     )
                     await this.ctx.root.parallel(
@@ -1479,7 +1481,7 @@ export class ConversationService {
             throw new Error('Conversation delete is locked by constraint.')
         }
 
-        return this.ctx.chatluna.conversationRuntime.withConversationSync(
+        return this.runtime.withConversationSync(
             conversation,
             async () => {
                 const current = await this.getConversation(conversation.id)
@@ -1506,7 +1508,7 @@ export class ConversationService {
                     conversationId: current.id
                 })
                 await this.removeAcl(current.id)
-                await this.ctx.chatluna.conversationRuntime.clearConversationInterfaceLocked(
+                await this.runtime.clearConversationInterfaceLocked(
                     updated ?? current
                 )
                 await this.ctx.root.parallel(
@@ -1588,9 +1590,7 @@ export class ConversationService {
             throw new Error('Conversation not found.')
         }
 
-        await this.ctx.chatluna.conversationRuntime.clearConversationInterface(
-            updated
-        )
+        await this.runtime.clearConversationInterface(updated)
         return updated
     }
 

--- a/packages/core/src/services/conversation.ts
+++ b/packages/core/src/services/conversation.ts
@@ -1120,133 +1120,125 @@ export class ConversationService {
             throw new Error('Conversation not found.')
         }
 
-        return this.runtime.withConversationSync(
-            conversation,
-            async () => {
-                const current = await this.getConversation(conversationId)
-                if (current == null) {
-                    throw new Error('Conversation not found.')
-                }
+        return this.runtime.withConversationSync(conversation, async () => {
+            const current = await this.getConversation(conversationId)
+            if (current == null) {
+                throw new Error('Conversation not found.')
+            }
 
-                if (
-                    inactiveBefore != null &&
-                    (current.status !== 'active' ||
-                        current.updatedAt.getTime() >= inactiveBefore.getTime())
-                ) {
-                    return null
-                }
+            if (
+                inactiveBefore != null &&
+                (current.status !== 'active' ||
+                    current.updatedAt.getTime() >= inactiveBefore.getTime())
+            ) {
+                return null
+            }
 
-                if (
-                    current.status === 'archived' &&
-                    current.archiveId != null
-                ) {
-                    const archive = await this.getArchive(current.archiveId)
-                    if (archive != null) {
-                        return {
-                            conversation: current,
-                            archive,
-                            path: archive.path
-                        }
-                    }
-                }
-
-                await this.ctx.root.parallel(
-                    'chatluna/before-conversation-archive',
-                    {
-                        conversation: current
-                    }
-                )
-
-                const archiveDir = await this.ensureDataDir(
-                    path.join('archive', current.id)
-                )
-                const messages = await this.listMessages(current.id)
-                const payload: ConversationArchivePayload = {
-                    formatVersion: 1,
-                    exportedAt: new Date().toISOString(),
-                    conversation: serializeConversation(current),
-                    messages: messages.map(serializeMessage)
-                }
-                const messageLines = payload.messages
-                    .map((message) => JSON.stringify(message))
-                    .join('\n')
-                const messageBuffer = await gzipEncode(messageLines)
-                const checksum = createHash('sha256')
-                    .update(messageBuffer)
-                    .digest('hex')
-
-                await fs.writeFile(
-                    path.join(archiveDir, 'conversation.json'),
-                    JSON.stringify(payload.conversation, null, 2),
-                    'utf8'
-                )
-                await fs.writeFile(
-                    path.join(archiveDir, 'messages.jsonl.gz'),
-                    messageBuffer
-                )
-
-                const now = new Date()
-                const manifest: ArchiveManifest = {
-                    format: 'chatluna-archive',
-                    formatVersion: payload.formatVersion,
-                    conversationId: current.id,
-                    messageCount: payload.messages.length,
-                    checksum,
-                    size: messageBuffer.byteLength,
-                    createdAt: now.toISOString()
-                }
-                await fs.writeFile(
-                    path.join(archiveDir, 'manifest.json'),
-                    JSON.stringify(manifest, null, 2),
-                    'utf8'
-                )
-
-                const archive: ArchiveRecord = {
-                    id: randomUUID(),
-                    conversationId: manifest.conversationId,
-                    path: archiveDir,
-                    formatVersion: manifest.formatVersion,
-                    messageCount: manifest.messageCount,
-                    checksum: manifest.checksum,
-                    size: manifest.size,
-                    state: 'ready',
-                    createdAt: now,
-                    restoredAt: null
-                }
-
-                await this.ctx.database.upsert('chatluna_archive', [archive])
-                await this.touchConversation(current.id, {
-                    status: 'archived',
-                    archivedAt: now,
-                    archiveId: archive.id
-                })
-                await unbindConversation(this.ctx, current.id)
-                await this.ctx.database.remove('chatluna_message', {
-                    conversationId: current.id
-                })
-
-                const updatedConversation = await this.getConversation(
-                    current.id
-                )
-                await this.runtime.clearConversationInterfaceLocked(
-                    updatedConversation ?? current
-                )
-                await this.ctx.root.parallel(
-                    'chatluna/after-conversation-archive',
-                    {
-                        conversation: updatedConversation ?? current,
+            if (current.status === 'archived' && current.archiveId != null) {
+                const archive = await this.getArchive(current.archiveId)
+                if (archive != null) {
+                    return {
+                        conversation: current,
                         archive,
-                        path: archiveDir
+                        path: archive.path
                     }
-                )
+                }
+            }
 
-                return {
+            await this.ctx.root.parallel(
+                'chatluna/before-conversation-archive',
+                {
+                    conversation: current
+                }
+            )
+
+            const archiveDir = await this.ensureDataDir(
+                path.join('archive', current.id)
+            )
+            const messages = await this.listMessages(current.id)
+            const payload: ConversationArchivePayload = {
+                formatVersion: 1,
+                exportedAt: new Date().toISOString(),
+                conversation: serializeConversation(current),
+                messages: messages.map(serializeMessage)
+            }
+            const messageLines = payload.messages
+                .map((message) => JSON.stringify(message))
+                .join('\n')
+            const messageBuffer = await gzipEncode(messageLines)
+            const checksum = createHash('sha256')
+                .update(messageBuffer)
+                .digest('hex')
+
+            await fs.writeFile(
+                path.join(archiveDir, 'conversation.json'),
+                JSON.stringify(payload.conversation, null, 2),
+                'utf8'
+            )
+            await fs.writeFile(
+                path.join(archiveDir, 'messages.jsonl.gz'),
+                messageBuffer
+            )
+
+            const now = new Date()
+            const manifest: ArchiveManifest = {
+                format: 'chatluna-archive',
+                formatVersion: payload.formatVersion,
+                conversationId: current.id,
+                messageCount: payload.messages.length,
+                checksum,
+                size: messageBuffer.byteLength,
+                createdAt: now.toISOString()
+            }
+            await fs.writeFile(
+                path.join(archiveDir, 'manifest.json'),
+                JSON.stringify(manifest, null, 2),
+                'utf8'
+            )
+
+            const archive: ArchiveRecord = {
+                id: randomUUID(),
+                conversationId: manifest.conversationId,
+                path: archiveDir,
+                formatVersion: manifest.formatVersion,
+                messageCount: manifest.messageCount,
+                checksum: manifest.checksum,
+                size: manifest.size,
+                state: 'ready',
+                createdAt: now,
+                restoredAt: null
+            }
+
+            await this.ctx.database.upsert('chatluna_archive', [archive])
+            await this.touchConversation(current.id, {
+                status: 'archived',
+                archivedAt: now,
+                archiveId: archive.id
+            })
+            await unbindConversation(this.ctx, current.id)
+            await this.ctx.database.remove('chatluna_message', {
+                conversationId: current.id
+            })
+
+            const updatedConversation = await this.getConversation(current.id)
+            await this.runtime.clearConversationInterfaceLocked(
+                updatedConversation ?? current
+            )
+            await this.ctx.root.parallel(
+                'chatluna/after-conversation-archive',
+                {
                     conversation: updatedConversation ?? current,
                     archive,
                     path: archiveDir
                 }
+            )
+
+            return {
+                conversation: updatedConversation ?? current,
+                archive,
+                path: archiveDir
             }
-        )
+        })
     }
 
     async restoreConversation(
@@ -1284,122 +1276,117 @@ export class ConversationService {
             throw new Error('Conversation restore is disabled by constraint.')
         }
 
-        return this.runtime.withConversationSync(
-            conversation,
-            async () => {
-                const current = await this.getConversation(conversation.id)
-                if (current == null) {
-                    throw new Error('Conversation not found.')
+        return this.runtime.withConversationSync(conversation, async () => {
+            const current = await this.getConversation(conversation.id)
+            if (current == null) {
+                throw new Error('Conversation not found.')
+            }
+
+            await this.ctx.root.parallel(
+                'chatluna/before-conversation-restore',
+                {
+                    conversation: current,
+                    archive
+                }
+            )
+
+            await this.ctx.database.upsert('chatluna_archive', [
+                {
+                    ...archive,
+                    state: 'restoring'
+                }
+            ])
+
+            try {
+                const payload = await readArchivePayload(archive.path)
+                const restoredConversation = deserializeConversation(
+                    payload.conversation
+                )
+                const restoredMessages = payload.messages.map((message) => ({
+                    ...deserializeMessage(message),
+                    conversationId: current.id
+                }))
+
+                await this.ctx.database.remove('chatluna_message', {
+                    conversationId: current.id
+                })
+
+                if (restoredMessages.length > 0) {
+                    await this.ctx.database.upsert(
+                        'chatluna_message',
+                        restoredMessages
+                    )
                 }
 
-                await this.ctx.root.parallel(
-                    'chatluna/before-conversation-restore',
+                await this.ctx.database.upsert('chatluna_conversation', [
                     {
-                        conversation: current,
+                        ...current,
+                        ...restoredConversation,
+                        id: current.id,
+                        status: 'active',
+                        archivedAt: null,
+                        archiveId: null,
+                        updatedAt: new Date()
+                    }
+                ])
+                await this.ctx.database.upsert('chatluna_archive', [
+                    {
+                        ...archive,
+                        state: 'ready',
+                        restoredAt: new Date()
+                    }
+                ])
+
+                const updatedConversation = await this.getConversation(
+                    current.id
+                )
+                if (updatedConversation == null) {
+                    throw new Error('Conversation restore failed.')
+                }
+
+                if (
+                    options.allPresetLanes &&
+                    getLookupKeys(
+                        session,
+                        resolved.constraint.bindingKey,
+                        true
+                    ).includes(
+                        getBaseBindingKey(updatedConversation.bindingKey)
+                    )
+                ) {
+                    await this.updateManagedConstraint(session, {
+                        activePresetLane:
+                            getPresetLane(updatedConversation.bindingKey) ??
+                            null
+                    })
+                }
+
+                await this.setActiveConversation(
+                    updatedConversation.bindingKey,
+                    updatedConversation.id
+                )
+                await this.runtime.clearConversationInterfaceLocked(
+                    updatedConversation
+                )
+                await this.ctx.root.parallel(
+                    'chatluna/after-conversation-restore',
+                    {
+                        conversation: updatedConversation,
                         archive
                     }
                 )
 
+                return updatedConversation
+            } catch (error) {
                 await this.ctx.database.upsert('chatluna_archive', [
                     {
                         ...archive,
-                        state: 'restoring'
+                        state: 'broken'
                     }
                 ])
-
-                try {
-                    const payload = await readArchivePayload(archive.path)
-                    const restoredConversation = deserializeConversation(
-                        payload.conversation
-                    )
-                    const restoredMessages = payload.messages.map(
-                        (message) => ({
-                            ...deserializeMessage(message),
-                            conversationId: current.id
-                        })
-                    )
-
-                    await this.ctx.database.remove('chatluna_message', {
-                        conversationId: current.id
-                    })
-
-                    if (restoredMessages.length > 0) {
-                        await this.ctx.database.upsert(
-                            'chatluna_message',
-                            restoredMessages
-                        )
-                    }
-
-                    await this.ctx.database.upsert('chatluna_conversation', [
-                        {
-                            ...current,
-                            ...restoredConversation,
-                            id: current.id,
-                            status: 'active',
-                            archivedAt: null,
-                            archiveId: null,
-                            updatedAt: new Date()
-                        }
-                    ])
-                    await this.ctx.database.upsert('chatluna_archive', [
-                        {
-                            ...archive,
-                            state: 'ready',
-                            restoredAt: new Date()
-                        }
-                    ])
-
-                    const updatedConversation = await this.getConversation(
-                        current.id
-                    )
-                    if (updatedConversation == null) {
-                        throw new Error('Conversation restore failed.')
-                    }
-
-                    if (
-                        options.allPresetLanes &&
-                        getLookupKeys(
-                            session,
-                            resolved.constraint.bindingKey,
-                            true
-                        ).includes(
-                            getBaseBindingKey(updatedConversation.bindingKey)
-                        )
-                    ) {
-                        await this.updateManagedConstraint(session, {
-                            activePresetLane:
-                                getPresetLane(updatedConversation.bindingKey) ??
-                                null
-                        })
-                    }
-
-                    await this.setActiveConversation(
-                        updatedConversation.bindingKey,
-                        updatedConversation.id
-                    )
-                    await this.runtime.clearConversationInterfaceLocked(
-                        updatedConversation
-                    )
-                    await this.ctx.root.parallel(
-                        'chatluna/after-conversation-restore',
-                        {
-                            conversation: updatedConversation,
-                            archive
-                        }
-                    )
-
-                    return updatedConversation
-                } catch (error) {
-                    await this.ctx.database.upsert('chatluna_archive', [
-                        {
-                            ...archive,
-                            state: 'broken'
-                        }
-                    ])
-                    throw error
-                }
+                throw error
             }
-        )
+        })
     }
 
     async exportMarkdown(conversation: ConversationRecord) {
@@ -1481,45 +1468,39 @@ export class ConversationService {
             throw new Error('Conversation delete is locked by constraint.')
         }
 
-        return this.runtime.withConversationSync(
-            conversation,
-            async () => {
-                const current = await this.getConversation(conversation.id)
-                if (current == null) {
-                    throw new Error('Conversation not found.')
-                }
-
-                await this.ctx.root.parallel(
-                    'chatluna/before-conversation-delete',
-                    {
-                        conversation: current
-                    }
-                )
-
-                await removeArchive(this.ctx, current.archiveId)
-
-                const updated = await this.touchConversation(current.id, {
-                    status: 'deleted',
-                    archivedAt: null,
-                    archiveId: null
-                })
-                await unbindConversation(this.ctx, current.id)
-                await this.ctx.database.remove('chatluna_message', {
-                    conversationId: current.id
-                })
-                await this.removeAcl(current.id)
-                await this.runtime.clearConversationInterfaceLocked(
-                    updated ?? current
-                )
-                await this.ctx.root.parallel(
-                    'chatluna/after-conversation-delete',
-                    {
-                        conversation: updated ?? current
-                    }
-                )
-                return updated ?? current
+        return this.runtime.withConversationSync(conversation, async () => {
+            const current = await this.getConversation(conversation.id)
+            if (current == null) {
+                throw new Error('Conversation not found.')
             }
-        )
+
+            await this.ctx.root.parallel(
+                'chatluna/before-conversation-delete',
+                {
+                    conversation: current
+                }
+            )
+
+            await removeArchive(this.ctx, current.archiveId)
+
+            const updated = await this.touchConversation(current.id, {
+                status: 'deleted',
+                archivedAt: null,
+                archiveId: null
+            })
+            await unbindConversation(this.ctx, current.id)
+            await this.ctx.database.remove('chatluna_message', {
+                conversationId: current.id
+            })
+            await this.removeAcl(current.id)
+            await this.runtime.clearConversationInterfaceLocked(
+                updated ?? current
+            )
+            await this.ctx.root.parallel('chatluna/after-conversation-delete', {
+                conversation: updated ?? current
+            })
+            return updated ?? current
+        })
     }
 
     async updateConversationUsage(

--- a/packages/core/src/services/conversation_runtime.ts
+++ b/packages/core/src/services/conversation_runtime.ts
@@ -11,6 +11,7 @@ import {
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
 import type { ClientConfig } from '../llm-core/platform/config'
+import { markChatLunaUserMessage } from 'koishi-plugin-chatluna/utils/langchain'
 import { parseRawModelName } from '../utils/model'
 import { ConversationRecord } from './conversation_types'
 import { Message } from '../types'
@@ -154,6 +155,7 @@ export class ConversationRuntime {
                     preset: conversation.preset
                 }
             })
+            markChatLunaUserMessage(humanMessage)
 
             const mask =
                 options.toolMask ??

--- a/packages/core/src/services/conversation_types.ts
+++ b/packages/core/src/services/conversation_types.ts
@@ -69,6 +69,7 @@ export interface MessageRecord {
 export interface ChatLunaMessageMeta {
     recordId?: string
     createdAt?: string
+    source?: 'user'
 }
 
 export interface BindingRecord {

--- a/packages/core/src/utils/langchain.ts
+++ b/packages/core/src/utils/langchain.ts
@@ -1,9 +1,32 @@
 import type {
+    BaseMessage,
     MessageContent,
     MessageContentComplex,
     MessageContentImageUrl,
     MessageContentText
 } from '@langchain/core/messages'
+
+type ChatLunaMessageMeta = {
+    source?: 'user'
+}
+
+export function markChatLunaUserMessage(msg: BaseMessage) {
+    msg.response_metadata = {
+        ...(msg.response_metadata ?? {}),
+        chatluna: {
+            ...((msg.response_metadata?.chatluna as ChatLunaMessageMeta) ?? {}),
+            source: 'user'
+        }
+    }
+}
+
+export function isChatLunaUserMessage(msg: BaseMessage) {
+    const meta = msg.response_metadata?.chatluna as
+        | ChatLunaMessageMeta
+        | undefined
+
+    return meta?.source === 'user'
+}
 
 type MessageContentUrlPart =
     | MessageContentImageUrl

--- a/packages/core/tests/conversation-resolve.spec.ts
+++ b/packages/core/tests/conversation-resolve.spec.ts
@@ -1080,6 +1080,85 @@ it('message_delay uses the resolved conversation only', async () => {
     }
 })
 
+it('message_delay keeps collected messages in send order', async () => {
+    const { app, ctx } = await createMemoryService()
+
+    try {
+        let run:
+            | ((
+                  session: any,
+                  context: any
+              ) => Promise<ChainMiddlewareRunStatus>)
+            | undefined
+
+        applyMessageDelay(
+            ctx as never,
+            {
+                messageQueue: true,
+                messageQueueDelay: 0.01
+            } as never,
+            {
+                middleware: (_name, fn) => {
+                    run = fn as never
+                    return {
+                        after() {
+                            return this
+                        },
+                        before() {
+                            return this
+                        }
+                    }
+                }
+            } as never
+        )
+
+        const conversation = createConversation({
+            id: 'message-delay-order'
+        })
+        const contexts = [1, 2, 3].map((num) => ({
+            options: {
+                inputMessage: {
+                    content: String(num),
+                    name: 'tester'
+                },
+                conversation: {
+                    conversation
+                }
+            }
+        }))
+
+        const p3 = run!(
+            { ...createSession(), timestamp: 3 } as any,
+            contexts[2]
+        )
+        const p2 = run!(
+            { ...createSession(), timestamp: 2 } as any,
+            contexts[1]
+        )
+        const p1 = run!(
+            { ...createSession(), timestamp: 1 } as any,
+            contexts[0]
+        )
+        const statuses = await Promise.all([p1, p2, p3])
+        const content = contexts[0].options.inputMessage.content as {
+            text?: string
+        }[]
+
+        assert.deepEqual(statuses, [
+            ChainMiddlewareRunStatus.CONTINUE,
+            ChainMiddlewareRunStatus.STOP,
+            ChainMiddlewareRunStatus.STOP
+        ])
+        assert.equal(
+            content.map((part) => part.text ?? '').join(''),
+            '1\n2\n3'
+        )
+        ctx.emit('chatluna/after-chat', 'message-delay-order')
+    } finally {
+        await app.stop()
+    }
+})
+
 it('chat_time_limit_save uses the resolved conversation only', async () => {
     const { app, ctx } = await createMemoryService()
 

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -334,7 +334,11 @@ export async function createService(
         }
     } as never
 
-    const service = new ConversationService(ctx, createConfig(options.config))
+    const service = new ConversationService(
+        ctx,
+        createConfig(options.config),
+        ctx.chatluna.conversationRuntime
+    )
 
     return {
         service,

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -35,6 +35,7 @@ import {
     getMimeTypeFromSource,
     isMessageContentImageUrl
 } from 'koishi-plugin-chatluna/utils/string'
+import { isChatLunaUserMessage } from 'koishi-plugin-chatluna/utils/langchain'
 import { ToolCallChunk } from '@langchain/core/messages/tool'
 import { isZodSchemaV3 } from '@langchain/core/utils/types'
 import { normalizeOpenAIModelName, supportImageInput } from './client'
@@ -463,18 +464,26 @@ export function processInterleavedThinkMessages(
         return convertedMessages
     }
 
-    // Find the start of the last turn by locating the last user message
-    // According to DeepSeek docs: a turn starts with a user message
+    // Find the start of the last turn by locating the last ChatLuna user message.
     let lastTurnStartIndex = -1
     for (let i = originalMessages.length - 1; i >= 0; i--) {
         const message = originalMessages[i]
-        if (message.getType() === 'human') {
+        if (isChatLunaUserMessage(message)) {
             lastTurnStartIndex = i
             break
         }
     }
 
-    // If no user message found, treat all messages as the last turn
+    if (lastTurnStartIndex === -1) {
+        for (let i = originalMessages.length - 1; i >= 0; i--) {
+            const message = originalMessages[i]
+            if (message.getType() === 'human') {
+                lastTurnStartIndex = i
+                break
+            }
+        }
+    }
+
     if (lastTurnStartIndex === -1) {
         lastTurnStartIndex = 0
     }


### PR DESCRIPTION
This pr fixes conversation turn detection across ChatLuna and adapter flows, keeps delayed message batches merged in send order, and avoids the undefined `globalProxyAddress.length` access during encoder loading.

## New Features

None.

## Bug fixes

- Fixes #843 by marking ChatLuna user messages and reusing that marker when splitting chat rounds and processing DeepSeek interleaved think messages.
- Fixes #844 by guarding `globalProxyAddress` before reading `.length` in the tiktoken encoder loader.
- Fixes delayed message batching so queued messages are merged by session timestamp instead of middleware arrival order.

## Other Changes

- Pass `ConversationRuntime` into `ConversationService` directly instead of resolving it back through `ctx.chatluna`.
- Add a regression spec covering delayed message ordering.