### PR TITLE
[Fix] tolerate tokenizer encode failures

### DIFF
--- a/packages/core/src/llm-core/platform/model.ts
+++ b/packages/core/src/llm-core/platform/model.ts
@@ -840,7 +840,14 @@ export class ChatLunaChatModel extends BaseChatModel<ChatLunaModelCallOptions> {
         }
 
         if (this.__encoding) {
-            numTokens = this.__encoding.encode(text)?.length ?? numTokens
+            try {
+                numTokens = this.__encoding.encode(text)?.length ?? numTokens
+            } catch (error) {
+                /* logger.warn(
+                    'Failed to calculate number of tokens, falling back to approximate count',
+                    error
+                ) */
+            }
         }
         return numTokens
     }


### PR DESCRIPTION
This pr prevents tokenizer encode failures from breaking token counting by keeping the existing approximate token count fallback.

## New Features

None

## Bug fixes

Tokenizer encoding errors are now caught during token counting so chat model calls can continue using the approximate token count.

## Other Changes

Ran `yarn lint-fix` before committing.