### PR TITLE
[Fix] preserve agent context routing

### DIFF
--- a/packages/adapter-azure-openai/package.json
+++ b/packages/adapter-azure-openai/package.json
@@ -57,7 +57,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-claude/package.json
+++ b/packages/adapter-claude/package.json
@@ -59,7 +59,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-deepseek/package.json
+++ b/packages/adapter-deepseek/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-deepseek-adapter",
     "description": "deepseek adapter for chatluna",
-    "version": "1.4.0-alpha.2",
+    "version": "1.4.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "category": "ai",

--- a/packages/adapter-dify/package.json
+++ b/packages/adapter-dify/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-doubao/package.json
+++ b/packages/adapter-doubao/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-gemini/package.json
+++ b/packages/adapter-gemini/package.json
@@ -75,7 +75,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/adapter-hunyuan/package.json
+++ b/packages/adapter-hunyuan/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-ollama/package.json
+++ b/packages/adapter-ollama/package.json
@@ -54,7 +54,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/adapter-openai-like/package.json
+++ b/packages/adapter-openai-like/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-like-adapter",
     "description": "openai style api adapter for chatluna",
-    "version": "1.4.0-alpha.2",
+    "version": "1.4.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-openai/package.json
+++ b/packages/adapter-openai/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-openai-adapter",
     "description": "openai adapter for chatluna",
-    "version": "1.4.0-alpha.2",
+    "version": "1.4.0-alpha.3",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-qwen/package.json
+++ b/packages/adapter-qwen/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-rwkv/package.json
+++ b/packages/adapter-rwkv/package.json
@@ -69,7 +69,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-spark/package.json
+++ b/packages/adapter-spark/package.json
@@ -72,7 +72,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-wenxin/package.json
+++ b/packages/adapter-wenxin/package.json
@@ -71,7 +71,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/adapter-zhipu/package.json
+++ b/packages/adapter-zhipu/package.json
@@ -73,7 +73,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna",
     "description": "chatluna for koishi",
-    "version": "1.4.0-alpha.11",
+    "version": "1.4.0-alpha.12",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",

--- a/packages/core/src/llm-core/agent/openai/output_parser.ts
+++ b/packages/core/src/llm-core/agent/openai/output_parser.ts
@@ -179,7 +179,12 @@ export class OpenAIToolsAgentOutputParser extends BaseOutputParser<
                                 ? content
                                 : `Invoking "${toolCall.name}" with ${JSON.stringify(toolCall.args) ?? '{}'}`,
                         messageLog: i === 0 ? [message] : [],
-                        content: i === 0 ? message.content : undefined
+                        content: i === 0 ? message.content : undefined,
+                        reasoningContent:
+                            i === 0
+                                ? (message.additional_kwargs
+                                      ?.reasoning_content as string | undefined)
+                                : undefined
                     }
                 })
             } catch (error) {
@@ -205,7 +210,12 @@ export class OpenAIToolsAgentOutputParser extends BaseOutputParser<
                                 ? content
                                 : `Invoking "${toolCall.function.name}" with ${toolCall.function.arguments ?? '{}'}`,
                         messageLog: i === 0 ? [message] : [],
-                        content: i === 0 ? message.content : undefined
+                        content: i === 0 ? message.content : undefined,
+                        reasoningContent:
+                            i === 0
+                                ? (message.additional_kwargs
+                                      ?.reasoning_content as string | undefined)
+                                : undefined
                     }
                 })
             } catch (error) {

--- a/packages/core/src/llm-core/agent/types.ts
+++ b/packages/core/src/llm-core/agent/types.ts
@@ -179,6 +179,7 @@ export type AgentAction = {
     toolCallId?: string
     log: string
     content?: MessageContent
+    reasoningContent?: string
 }
 
 export type AgentFinish = {

--- a/packages/core/src/llm-core/chain/agent_chat_chain.ts
+++ b/packages/core/src/llm-core/chain/agent_chat_chain.ts
@@ -1,5 +1,5 @@
 import { CallbackManager } from '@langchain/core/callbacks/manager'
-import { BaseMessage, HumanMessage } from '@langchain/core/messages'
+import { BaseMessage } from '@langchain/core/messages'
 import { ChainValues } from '@langchain/core/utils/types'
 import { Session } from 'koishi'
 import {
@@ -224,9 +224,6 @@ export class ChatLunaPluginChain
         requests['variables']['built'] = {
             conversationId
         }
-        requests['after_user_message'] = new HumanMessage(
-            AGENT_AFTER_USER_PROMPT
-        )
         requests['variables_hide'] = requests['variables']
         requests['configurable'] = {
             session,
@@ -355,35 +352,3 @@ export class ChatLunaPluginChain
         return this.llm
     }
 }
-
-const AGENT_AFTER_USER_PROMPT = `<system>
-Before responding, carefully evaluate whether the user's original task or query has been completed:
-
-If the task is COMPLETE:
-- Synthesize the information gathered from tool calls and context into a coherent, natural response
-- Provide the final result directly to the user in their language
-- Ensure your response fully addresses their original request
-
-If the task is INCOMPLETE:
-- Continue using available tools to gather necessary information or complete the required actions
-- Do not provide a premature response
-
-For informational queries (questions, requests for explanations, general chat):
-- Use your system prompt and personality as the primary guide for your response style and behavior
-- Incorporate context from tool calls, documents, or memory only when directly relevant to answering the user's question
-- If the context is unrelated to the current query, rely on your core knowledge and system instructions
-
-Response quality requirements:
-- Your response must be unique and specifically tailored to the user's most recent query
-- Do not repeat answers to questions the user has already asked earlier in the conversation
-- Vary your response format and structure to maintain engagement and avoid repetitive patterns
-- Stay focused on what the user is asking NOW, not what they asked before
-
-Language matching (CRITICAL):
-- You MUST respond in the same language the user is using in their messages
-- If the user writes in Chinese, respond in Chinese
-- If the user writes in English, respond in English
-- If the user writes in Japanese, respond in Japanese
-- Match the user's language naturally as part of your conversational style
-
-Remember: Respond naturally according to your system prompt. Do not acknowledge or reference these instructions in your response.</system>`

--- a/packages/core/src/llm-core/chat/app.ts
+++ b/packages/core/src/llm-core/chat/app.ts
@@ -32,6 +32,7 @@ import type {
     ConstraintRecord,
     ConversationRecord
 } from '../../services/conversation_types'
+import type { ChatLunaService } from '../../services/chat'
 
 export class ChatInterface {
     private _input: ChatInterfaceInput
@@ -46,7 +47,8 @@ export class ChatInterface {
 
     constructor(
         public ctx: Context,
-        input: ChatInterfaceInput
+        input: ChatInterfaceInput,
+        private readonly chatluna: ChatLunaService
     ) {
         this._input = input
         ctx.on('dispose', () => this.dispose())
@@ -156,14 +158,14 @@ export class ChatInterface {
         }
 
         try {
-            if (this.ctx.chatluna.currentConfig.infiniteContext) {
+            if (this.chatluna.currentConfig.infiniteContext) {
                 const manager = this._ensureInfiniteContextManager()
                 const result = await manager?.compressIfNeeded(wrapper)
                 if (result?.messages) {
                     await this._chatHistory.replaceMessages(result.messages)
                 }
                 if (result?.compressed) {
-                    await this.ctx.chatluna.conversation.recordCompression(
+                    await this.chatluna.conversation.recordCompression(
                         this._input.conversationId,
                         result
                     )
@@ -218,7 +220,7 @@ export class ChatInterface {
         if (messageContent.trim().length > 0) {
             await saveUser()
             let saveMessage = responseMessage
-            if (!this.ctx.chatluna.currentConfig.rawOnCensor) {
+            if (!this.chatluna.currentConfig.rawOnCensor) {
                 saveMessage = displayResponse
             }
 
@@ -242,7 +244,7 @@ export class ChatInterface {
 
         if (this._input.autoTitle !== false) {
             autoSummarizeTitle(
-                this.ctx,
+                this.chatluna,
                 arg.conversationId,
                 wrapper,
                 arg.message,
@@ -282,12 +284,12 @@ export class ChatInterface {
             return
         }
 
-        const service = this.ctx.chatluna.platform
+        const service = this.chatluna.platform
         const [llmPlatform, llmModelName] = parseRawModelName(this._input.model)
 
         let llm: ComputedRef<ChatLunaChatModel>
 
-        let modelInfo: ComputedRef<ModelInfo>
+        let modelInfo: ComputedRef<ModelInfo | undefined>
         let historyMemory: BufferMemory
 
         try {
@@ -307,8 +309,7 @@ export class ChatInterface {
 
         try {
             ;[llm, modelInfo] = await initModel(
-                this.ctx,
-                service,
+                this.chatluna,
                 llmPlatform,
                 llmModelName
             )
@@ -399,7 +400,7 @@ export class ChatInterface {
             await this._chatHistory.replaceMessages(result.messages)
         }
         if (result.compressed) {
-            await this.ctx.chatluna.conversation.recordCompression(
+            await this.chatluna.conversation.recordCompression(
                 this._input.conversationId,
                 result
             )
@@ -415,7 +416,8 @@ export class ChatInterface {
         this._chatHistory = new KoishiChatMessageHistory(
             this.ctx,
             this._input.conversationId,
-            10000
+            10000,
+            this.chatluna
         )
 
         await this._chatHistory.loadConversation()
@@ -452,8 +454,7 @@ export class ChatInterface {
                 chatHistory: this._chatHistory,
                 conversationId: this._input.conversationId,
                 preset: this._input.preset,
-                threshold:
-                    this.ctx.chatluna.currentConfig.infiniteContextThreshold
+                threshold: this.chatluna.currentConfig.infiniteContextThreshold
             })
         }
 
@@ -462,14 +463,13 @@ export class ChatInterface {
 }
 
 async function autoSummarizeTitle(
-    ctx: Context,
+    chatluna: ChatLunaService,
     conversationId: string,
     wrapper: ChatLunaLLMChainWrapper,
     humanMsg: HumanMessage,
     aiMsg: AIMessage
 ) {
-    const claimed =
-        await ctx.chatluna.conversation.claimAutoTitle(conversationId)
+    const claimed = await chatluna.conversation.claimAutoTitle(conversationId)
     if (!claimed) {
         return
     }
@@ -490,12 +490,12 @@ async function autoSummarizeTitle(
         const result = await wrapper.model.invoke([new HumanMessage(prompt)])
         const title = getMessageContent(result.content).trim().slice(0, 20)
 
-        await ctx.chatluna.conversation.touchConversation(conversationId, {
+        await chatluna.conversation.touchConversation(conversationId, {
             title
         })
     } catch (error) {
         logger.error(error)
-        await ctx.chatluna.conversation.touchConversation(conversationId, {
+        await chatluna.conversation.touchConversation(conversationId, {
             autoTitle: true
         })
         throw error

--- a/packages/core/src/llm-core/chat/helper.ts
+++ b/packages/core/src/llm-core/chat/helper.ts
@@ -1,7 +1,6 @@
 import { Embeddings } from '@langchain/core/embeddings'
 import { AIMessage } from '@langchain/core/messages'
 import { computed, ComputedRef } from '@vue/reactivity'
-import { Context } from 'koishi'
 import { logger } from 'koishi-plugin-chatluna'
 import { emptyEmbeddings } from 'koishi-plugin-chatluna/llm-core/model/in_memory'
 import {
@@ -20,6 +19,7 @@ import {
     ChatLunaError,
     ChatLunaErrorCode
 } from 'koishi-plugin-chatluna/utils/error'
+import type { ChatLunaService } from '../../services/chat'
 
 export function createDisplayResponse(responseMessage: AIMessage) {
     const msg = new AIMessage({
@@ -84,19 +84,16 @@ export async function initEmbeddings(
 }
 
 export async function initModel(
-    ctx: Context,
-    service: PlatformService,
+    chatluna: ChatLunaService,
     llmPlatform: string,
     llmModelName: string
 ): Promise<
     [ComputedRef<ChatLunaChatModel>, ComputedRef<ModelInfo | undefined>]
 > {
+    const service = chatluna.platform
     const llmInfo = service.findModel(llmPlatform, llmModelName)
 
-    const llmModel = await ctx.chatluna.createChatModel(
-        llmPlatform,
-        llmModelName
-    )
+    const llmModel = await chatluna.createChatModel(llmPlatform, llmModelName)
 
     if (llmModel.value instanceof ChatLunaChatModel) {
         return [llmModel, llmInfo]

--- a/packages/core/src/llm-core/memory/message/database_history.ts
+++ b/packages/core/src/llm-core/memory/message/database_history.ts
@@ -21,6 +21,7 @@ import type {
     ChatLunaMessageMeta,
     MessageRecord
 } from '../../../services/conversation_types'
+import type { ChatLunaService } from '../../../services/chat'
 
 export class KoishiChatMessageHistory extends BaseChatMessageHistory {
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -38,7 +39,8 @@ export class KoishiChatMessageHistory extends BaseChatMessageHistory {
     constructor(
         ctx: Context,
         conversationId: string,
-        private _maxMessagesCount: number
+        private _maxMessagesCount: number,
+        private readonly chatluna: ChatLunaService
     ) {
         super()
 
@@ -382,9 +384,9 @@ export class KoishiChatMessageHistory extends BaseChatMessageHistory {
                 id: this.conversationId,
                 bindingKey: this.conversationId,
                 title: 'Conversation',
-                model: this._ctx.chatluna.config.defaultModel,
-                preset: this._ctx.chatluna.config.defaultPreset,
-                chatMode: this._ctx.chatluna.config.defaultChatMode,
+                model: this.chatluna.config.defaultModel,
+                preset: this.chatluna.config.defaultPreset,
+                chatMode: this.chatluna.config.defaultChatMode,
                 createdBy: 'system',
                 createdAt: new Date(),
                 updatedAt: new Date(),
@@ -532,9 +534,15 @@ async function serializeMessage(
 }
 
 function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
+    const reasoning = steps[0]?.action.reasoningContent
+
     return [
         new AIMessage({
             content: '',
+            additional_kwargs:
+                reasoning != null && reasoning.length > 0
+                    ? { reasoning_content: reasoning }
+                    : {},
             tool_calls: steps.map((step) => ({
                 id: step.action.toolCallId,
                 name: step.action.tool,

--- a/packages/core/src/services/chat.ts
+++ b/packages/core/src/services/chat.ts
@@ -260,23 +260,28 @@ export class ChatLunaService extends Service<Config> {
 
     async createChatInterface(conversation: ConversationRecord) {
         const config = this.currentConfig
-        const chatInterface = new ChatInterface(this.ctx.root, {
-            chatMode: conversation.chatMode,
-            autoTitle: conversation.autoTitle ?? true,
-            botName: config.botNames[0],
-            preset: this.preset.getPreset(conversation.preset),
-            model: conversation.model,
-            conversationId: conversation.id,
-            embeddings:
-                config.defaultEmbeddings && config.defaultEmbeddings.length > 0
-                    ? config.defaultEmbeddings
-                    : undefined,
-            vectorStoreName:
-                config.defaultVectorStore &&
-                config.defaultVectorStore.length > 0
-                    ? config.defaultVectorStore
-                    : undefined
-        })
+        const chatInterface = new ChatInterface(
+            this.ctx,
+            {
+                chatMode: conversation.chatMode,
+                autoTitle: conversation.autoTitle ?? true,
+                botName: config.botNames[0],
+                preset: this.preset.getPreset(conversation.preset),
+                model: conversation.model,
+                conversationId: conversation.id,
+                embeddings:
+                    config.defaultEmbeddings &&
+                    config.defaultEmbeddings.length > 0
+                        ? config.defaultEmbeddings
+                        : undefined,
+                vectorStoreName:
+                    config.defaultVectorStore &&
+                    config.defaultVectorStore.length > 0
+                        ? config.defaultVectorStore
+                        : undefined
+            },
+            this
+        )
 
         return chatInterface
     }

--- a/packages/extension-agent/package.json
+++ b/packages/extension-agent/package.json
@@ -1,7 +1,7 @@
 {
     "name": "koishi-plugin-chatluna-agent",
     "description": "Agent framework for ChatLuna",
-    "version": "1.0.23",
+    "version": "1.0.24",
     "main": "lib/index.cjs",
     "module": "lib/index.mjs",
     "typings": "lib/index.d.ts",
@@ -89,7 +89,7 @@
     "peerDependencies": {
         "@koishijs/plugin-console": "^5.30.11",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-agent/src/trigger/render.ts
+++ b/packages/extension-agent/src/trigger/render.ts
@@ -9,7 +9,7 @@ export function renderTriggerProviders(providers: TriggerProvider[]) {
 
     lines.push(
         '<trigger_tool>',
-        'Use the trigger tool to manage scheduled or passive trigger tasks for the current chat and current user.',
+        'Use the trigger tool to manage all scheduled or passive trigger tasks.',
         '',
         'Call it with one field: cmd = a single DSL statement.',
         'Syntax: verb(positional, ..., key=value, ...). Strings use double quotes.',
@@ -18,6 +18,7 @@ export function renderTriggerProviders(providers: TriggerProvider[]) {
         '  list()',
         '  get(42)',
         '  create(cron, message="Check updates", reply=channel, mode=chain, expression="*/10 8-9 * * *", missed=skip)',
+        '  create(cron, guild_id="123456", message="Check updates", scope=all, reply=channel, expression="0 9 * * *")',
         '  create(once, message="Good morning", reply=channel, fire_at="2026-04-25T08:00:00+08:00")',
         '  disable(42)',
         '  disable(42, 43)',
@@ -29,7 +30,10 @@ export function renderTriggerProviders(providers: TriggerProvider[]) {
         '',
         'Common create fields:',
         '  name=, message=, reply=channel|user|silent, mode=chain|direct,',
-        '  scope=current|all, new_conv=true|false.',
+        '  scope=all|personal, new_conv=true|false.',
+        'Target override fields for create:',
+        '  platform=, self_id=, user_id=, username=, guild_id=, channel_id=, direct=true|false.',
+        '  Omitted target fields default to the current chat. When guild_id or channel_id is set, direct defaults to false.',
         'Provider params are named args. Aliases: missed=skip|fire_once, fire_at=ISO.',
         '`message` is required when the chosen provider is marked "requires message" below.',
         '</trigger_tool>'

--- a/packages/extension-agent/src/trigger/tool.ts
+++ b/packages/extension-agent/src/trigger/tool.ts
@@ -1,12 +1,17 @@
 import { StructuredTool } from '@langchain/core/tools'
 import { z } from 'zod'
+import type { Session } from 'koishi'
 import {
     getBaseBindingKey,
     getPresetLane
 } from 'koishi-plugin-chatluna/services/chat'
 import type { ChatLunaToolRunnable } from 'koishi-plugin-chatluna/llm-core/platform/types'
 import type { ChatLunaAgentTriggerService } from '../service/trigger'
-import type { TriggerTask } from '../types'
+import {
+    bindingKeyFromRouting,
+    type TriggerTask,
+    type WakeupRouting
+} from '../types'
 import {
     type DslCall,
     type DslValue,
@@ -20,7 +25,7 @@ export class TriggerTool extends StructuredTool {
     name = 'trigger'
 
     description =
-        'Manage scheduled or passive trigger tasks for the current chat. ' +
+        'Manage scheduled or passive trigger tasks. ' +
         'Input is a single DSL statement in cmd. See <trigger_tool> and <trigger_providers>.'
 
     schema = z.object({
@@ -53,23 +58,11 @@ export class TriggerTool extends StructuredTool {
                 }
             ).agentContext?.requestId
             const runningTaskId = this.service.getRunningTaskId(requestId)
-            const resolved =
-                await this.service.ctx.chatluna.conversation.resolveConstraint(
-                    session
-                )
-            const baseKey = getBaseBindingKey(resolved.bindingKey)
-            const ownsTask = (task: {
-                bindingKey: string
-                createdBy: string
-            }) =>
-                (task.bindingKey === resolved.bindingKey ||
-                    task.bindingKey === baseKey) &&
-                task.createdBy === session.userId
 
             if (call.verb === 'list') {
-                const tasks = (await this.service.listTasks()).filter(ownsTask)
+                const tasks = await this.service.listTasks()
                 if (tasks.length < 1) {
-                    return 'No trigger tasks found for this chat.'
+                    return 'No trigger tasks found.'
                 }
 
                 return JSON.stringify(tasks.map(formatTask))
@@ -78,9 +71,8 @@ export class TriggerTool extends StructuredTool {
             if (call.verb === 'get') {
                 if (call.positional.length < 1)
                     return 'taskId is required for get.'
-                const tasks = await this._getOwnedTasks(
-                    call.positional.map(valueToNumber),
-                    ownsTask
+                const tasks = await this._getTasks(
+                    call.positional.map(valueToNumber)
                 )
                 if (typeof tasks === 'string') return tasks
                 const result = tasks.map(formatTask)
@@ -99,8 +91,7 @@ export class TriggerTool extends StructuredTool {
                 }
                 return await this._setEnabled(
                     call.positional.map(valueToNumber),
-                    true,
-                    ownsTask
+                    true
                 )
             }
 
@@ -120,22 +111,21 @@ export class TriggerTool extends StructuredTool {
                 if (ids.length < 1) {
                     return 'taskId is required for disable outside a trigger run.'
                 }
-                return await this._setEnabled(ids, false, ownsTask)
+                return await this._setEnabled(ids, false)
             }
 
             if (call.verb === 'fire') {
                 if (call.positional.length < 1) {
                     return 'taskId is required for fire.'
                 }
-                const tasks = await this._getOwnedTasks(
-                    call.positional.map(valueToNumber),
-                    ownsTask
+                const tasks = await this._getTasks(
+                    call.positional.map(valueToNumber)
                 )
                 if (typeof tasks === 'string') return tasks
 
                 const results = []
                 for (const task of tasks) {
-                    results.push(await this.service.fire(task.id, session))
+                    results.push(await this.service.fire(task.id))
                 }
                 return JSON.stringify(
                     results.length === 1 ? results[0] : results
@@ -147,7 +137,7 @@ export class TriggerTool extends StructuredTool {
                     return 'taskId is required for remove.'
                 }
                 const ids = call.positional.map(valueToNumber)
-                const tasks = await this._getOwnedTasks(ids, ownsTask)
+                const tasks = await this._getTasks(ids)
                 if (typeof tasks === 'string') return tasks
 
                 for (const id of ids) {
@@ -171,10 +161,7 @@ export class TriggerTool extends StructuredTool {
                         : runningTaskId == null
                           ? []
                           : [runningTaskId],
-                    new Date(
-                        Date.now() + valueToDurationMs(call.positional[0])
-                    ),
-                    ownsTask
+                    new Date(Date.now() + valueToDurationMs(call.positional[0]))
                 )
             }
 
@@ -194,8 +181,7 @@ export class TriggerTool extends StructuredTool {
                         : runningTaskId == null
                           ? []
                           : [runningTaskId],
-                    new Date(valueToString(call.positional[0])),
-                    ownsTask
+                    new Date(valueToString(call.positional[0]))
                 )
             }
 
@@ -207,6 +193,7 @@ export class TriggerTool extends StructuredTool {
                 return 'provider kind is required for create.'
             }
 
+            const named = call.named
             const providerKind = valueToString(call.positional[0])
             const provider = this.service
                 .getProviders()
@@ -216,9 +203,7 @@ export class TriggerTool extends StructuredTool {
             }
 
             const message =
-                call.named.message == null
-                    ? undefined
-                    : valueToString(call.named.message)
+                named.message == null ? undefined : valueToString(named.message)
             if (
                 provider.needsMessage &&
                 (message == null || message.trim().length < 1)
@@ -226,30 +211,50 @@ export class TriggerTool extends StructuredTool {
                 return `message is required for provider ${provider.kind}.`
             }
 
-            let useAllScope = false
-            if (call.named.scope != null) {
-                const value = valueToString(call.named.scope)
-                if (value !== 'all' && value !== 'personal') {
-                    return `Invalid scope: ${value}. Expected all or personal.`
-                }
-                useAllScope = value === 'all'
+            const scope =
+                named.scope == null ? 'personal' : valueToString(named.scope)
+            if (scope !== 'all' && scope !== 'personal') {
+                return `Invalid scope: ${scope}. Expected all or personal.`
             }
-            const bindingKey = useAllScope
-                ? getBaseBindingKey(resolved.bindingKey)
-                : resolved.bindingKey
-            const presetLane = useAllScope
-                ? null
-                : (resolved.activePresetLane ??
-                  getPresetLane(resolved.bindingKey))
+            const useAllScope = scope === 'all'
+            const direct =
+                typeof named.direct === 'boolean' ? named.direct : undefined
+            if (named.direct != null && direct == null) {
+                return 'Invalid direct: expected true or false.'
+            }
+            const target = buildRouting(session, named, direct)
+            const current =
+                await this.service.ctx.chatluna.conversation.resolveConstraint(
+                    session
+                )
+            const bindingKey = target.targetsOtherChat
+                ? bindingKeyFromRouting(
+                      target.routing,
+                      useAllScope ? 'shared' : 'personal'
+                  )
+                : useAllScope
+                  ? getBaseBindingKey(current.bindingKey)
+                  : current.bindingKey
+            const presetLane =
+                useAllScope || target.targetsOtherChat
+                    ? null
+                    : (current.activePresetLane ?? getPresetLane(bindingKey))
             const params: Record<string, unknown> = {}
-            for (const [key, value] of Object.entries(call.named)) {
+            for (const [key, value] of Object.entries(named)) {
                 if (
                     key === 'message' ||
                     key === 'reply' ||
                     key === 'mode' ||
                     key === 'name' ||
                     key === 'scope' ||
-                    key === 'new_conv'
+                    key === 'new_conv' ||
+                    key === 'platform' ||
+                    key === 'self_id' ||
+                    key === 'user_id' ||
+                    key === 'username' ||
+                    key === 'guild_id' ||
+                    key === 'channel_id' ||
+                    key === 'direct'
                 ) {
                     continue
                 }
@@ -263,8 +268,8 @@ export class TriggerTool extends StructuredTool {
             }
 
             let replyTo: 'channel' | 'user' | 'silent' | undefined
-            if (call.named.reply != null) {
-                const value = valueToString(call.named.reply)
+            if (named.reply != null) {
+                const value = valueToString(named.reply)
                 if (
                     value !== 'channel' &&
                     value !== 'user' &&
@@ -276,8 +281,8 @@ export class TriggerTool extends StructuredTool {
             }
 
             let execMode: 'chain' | 'direct' | undefined
-            if (call.named.mode != null) {
-                const value = valueToString(call.named.mode)
+            if (named.mode != null) {
+                const value = valueToString(named.mode)
                 if (value !== 'chain' && value !== 'direct') {
                     return `Invalid mode: ${value}. Expected chain or direct.`
                 }
@@ -285,19 +290,17 @@ export class TriggerTool extends StructuredTool {
             }
 
             let newConversation = true
-            if (call.named.new_conv != null) {
-                if (typeof call.named.new_conv !== 'boolean') {
+            if (named.new_conv != null) {
+                if (typeof named.new_conv !== 'boolean') {
                     return 'Invalid new_conv: expected true or false.'
                 }
-                newConversation = call.named.new_conv
+                newConversation = named.new_conv
             }
 
-            const task = await this.service.createTask(session, {
+            const task = await this.service.createTask(target.routing, {
                 providerKind,
                 name:
-                    call.named.name == null
-                        ? undefined
-                        : valueToString(call.named.name),
+                    named.name == null ? undefined : valueToString(named.name),
                 presetLane,
                 scope: useAllScope ? 'shared' : 'personal',
                 bindingKey,
@@ -318,12 +321,8 @@ export class TriggerTool extends StructuredTool {
         }
     }
 
-    private async _setEnabled(
-        ids: number[],
-        enabled: boolean,
-        ownsTask: (task: { bindingKey: string; createdBy: string }) => boolean
-    ) {
-        const tasks = await this._getOwnedTasks(ids, ownsTask)
+    private async _setEnabled(ids: number[], enabled: boolean) {
+        const tasks = await this._getTasks(ids)
         if (typeof tasks === 'string') return tasks
 
         for (const id of ids) {
@@ -332,17 +331,13 @@ export class TriggerTool extends StructuredTool {
         return `Trigger task ${ids.join(', ')} ${enabled ? 'enabled' : 'disabled'}.`
     }
 
-    private async _snooze(
-        ids: number[],
-        after: Date,
-        ownsTask: (task: { bindingKey: string; createdBy: string }) => boolean
-    ) {
+    private async _snooze(ids: number[], after: Date) {
         if (ids.length < 1) {
             return 'taskId is required for snooze outside a trigger run.'
         }
         if (Number.isNaN(after.valueOf())) return 'Invalid snooze date.'
 
-        const tasks = await this._getOwnedTasks(ids, ownsTask)
+        const tasks = await this._getTasks(ids)
         if (typeof tasks === 'string') return tasks
 
         const result = []
@@ -352,14 +347,11 @@ export class TriggerTool extends StructuredTool {
         return JSON.stringify(result.length === 1 ? result[0] : result)
     }
 
-    private async _getOwnedTasks(
-        ids: number[],
-        ownsTask: (task: { bindingKey: string; createdBy: string }) => boolean
-    ) {
+    private async _getTasks(ids: number[]) {
         const tasks: TriggerTask[] = []
         for (const id of ids) {
             const task = await this.service.getTask(id)
-            if (task == null || !ownsTask(task)) {
+            if (task == null) {
                 return `Trigger task ${id} not found.`
             }
             tasks.push(task)
@@ -368,21 +360,75 @@ export class TriggerTool extends StructuredTool {
     }
 }
 
-function formatTask(task: {
-    id: number
-    name?: string | null
-    providerKind: string | null
-    enabled: boolean
-    nextFireAt?: Date | null
-    params?: Record<string, unknown> | null
-}) {
+function buildRouting(
+    session: Session,
+    named: Record<string, DslValue>,
+    direct?: boolean
+) {
+    const targetsOtherChat =
+        named.platform != null ||
+        named.self_id != null ||
+        named.user_id != null ||
+        named.username != null ||
+        named.guild_id != null ||
+        named.channel_id != null ||
+        named.direct != null
+    const isDirect =
+        direct ??
+        (session.isDirect && named.guild_id == null && named.channel_id == null)
+    const guildId =
+        named.guild_id == null
+            ? (session.guildId ?? undefined)
+            : valueToString(named.guild_id)
+    const channelId =
+        named.channel_id == null
+            ? named.guild_id == null
+                ? (session.channelId ?? guildId)
+                : guildId
+            : valueToString(named.channel_id)
+
+    return {
+        targetsOtherChat,
+        routing: {
+            platform:
+                named.platform == null
+                    ? session.platform
+                    : valueToString(named.platform),
+            selfId:
+                named.self_id == null
+                    ? session.selfId
+                    : valueToString(named.self_id),
+            userId:
+                named.user_id == null
+                    ? session.userId
+                    : valueToString(named.user_id),
+            username:
+                named.username == null
+                    ? session.username
+                    : valueToString(named.username),
+            guildId: isDirect ? undefined : guildId,
+            channelId: isDirect ? undefined : channelId,
+            isDirect
+        } satisfies WakeupRouting
+    }
+}
+
+function formatTask(task: TriggerTask) {
     return {
         id: task.id,
         name: task.name,
         providerKind: task.providerKind,
         enabled: task.enabled,
+        bindingKey: task.bindingKey,
+        platform: task.platform,
+        selfId: task.selfId,
+        userId: task.userId,
+        guildId: task.guildId,
+        channelId: task.channelId,
+        isDirect: task.isDirect,
         nextFireAt: task.nextFireAt,
-        params: task.params
+        params: task.params,
+        createdBy: task.createdBy
     }
 }
 

--- a/packages/extension-long-memory/package.json
+++ b/packages/extension-long-memory/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/extension-tools/package.json
+++ b/packages/extension-tools/package.json
@@ -66,13 +66,13 @@
         "@types/turndown": "^5.0.6",
         "atsc": "^2.1.0",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna-agent": "^1.0.23",
+        "koishi-plugin-chatluna-agent": "^1.0.24",
         "koishi-plugin-adapter-onebot": "^6.8.0"
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11",
-        "koishi-plugin-chatluna-agent": "^1.0.23",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12",
+        "koishi-plugin-chatluna-agent": "^1.0.24",
         "koishi-plugin-chatluna-storage-service": "^1.0.6"
     },
     "peerDependenciesMeta": {

--- a/packages/extension-variable/package.json
+++ b/packages/extension-variable/package.json
@@ -58,7 +58,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "resolutions": {
         "@langchain/core": "^0.3.80",

--- a/packages/renderer-image/package.json
+++ b/packages/renderer-image/package.json
@@ -62,7 +62,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/service-embeddings/package.json
+++ b/packages/service-embeddings/package.json
@@ -63,7 +63,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/service-multimodal/package.json
+++ b/packages/service-multimodal/package.json
@@ -61,7 +61,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11",
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12",
         "koishi-plugin-ffmpeg-path": "^2.0.0"
     },
     "peerDependenciesMeta": {

--- a/packages/service-search/package.json
+++ b/packages/service-search/package.json
@@ -74,7 +74,7 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "koishi": {
         "description": {

--- a/packages/service-vector-store/package.json
+++ b/packages/service-vector-store/package.json
@@ -58,7 +58,7 @@
         "@zilliz/milvus2-sdk-node": "^2.6.2",
         "faiss-node": "^0.5.1",
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     },
     "peerDependenciesMeta": {
         "@zilliz/milvus2-sdk-node": {

--- a/packages/shared-adapter/package.json
+++ b/packages/shared-adapter/package.json
@@ -70,6 +70,6 @@
     },
     "peerDependencies": {
         "koishi": "^4.18.9",
-        "koishi-plugin-chatluna": "^1.4.0-alpha.11"
+        "koishi-plugin-chatluna": "^1.4.0-alpha.12"
     }
 }

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -464,6 +464,12 @@ export function processInterleavedThinkMessages(
         return convertedMessages
     }
 
+    const hasToolCallRound = convertedMessages.some(
+        (message) =>
+            message.role === 'assistant' &&
+            (message.tool_calls?.length ?? 0) > 0
+    )
+
     // Find the start of the last turn by locating the last ChatLuna user message.
     let lastTurnStartIndex = -1
     for (let i = originalMessages.length - 1; i >= 0; i--) {
@@ -490,8 +496,7 @@ export function processInterleavedThinkMessages(
 
     // For messages in the last turn, add reasoning_content from additional_kwargs
     return convertedMessages.map((message, index) => {
-        // Only process messages in the last turn (from lastTurnStartIndex onwards)
-        if (index >= lastTurnStartIndex) {
+        if (hasToolCallRound || index >= lastTurnStartIndex) {
             const originalMessage = originalMessages[index]
             const reasoningContent = originalMessage?.additional_kwargs
                 ?.reasoning_content as string | undefined


### PR DESCRIPTION
This pr fixes adapter, agent, conversation, trigger, and workflow issues while adding reranker platform support and bundled agentcli integration.

## New Features

- Add first-class reranker model support across platform APIs and shared adapter requester helpers.
- Bundle agentcli as a skill and add config sync support for local and sandbox agentcli working copies.
- Allow trigger tasks to target explicit routing fields such as platform, self_id, user_id, guild_id, channel_id, and direct.

## Bug fixes

See the list of fixed issues below

- Preserve mixed chat history turn boundaries and message ordering.
- Preserve reasoning content through tool-call parsing and serialized agent tool messages.
- Route chat interfaces through the active ChatLuna service instead of relying on root context lookup.
- Tolerate tokenizer encode failures.
- Update build workflow tooling.

## Other Changes

- Refresh alpha package versions and peer dependency ranges.
- Move runtime sync utilities under extension-agent utils.
- Update trigger tool documentation and returned task metadata.