### PR TITLE
[fix]:修复消息队列格式化后的文本顺序

### DIFF
--- a/packages/core/src/middlewares/conversation/request_conversation.ts
+++ b/packages/core/src/middlewares/conversation/request_conversation.ts
@@ -333,15 +333,12 @@ async function processUserPrompt(
 }
 
 function sortContentByType(content: MessageContentComplex[]) {
-    return content.sort((a, b) =>
-        a.type === 'text'
-            ? -1
-            : b.type === 'text'
-              ? 1
-              : a.type < b.type
-                ? -1
-                : 1
-    )
+    return content.sort((a, b) => {
+        if (a.type === b.type) return 0
+        if (a.type === 'text') return -1
+        if (b.type === 'text') return 1
+        return a.type < b.type ? -1 : 1
+    })
 }
 
 async function setupRegularMessageStream(

--- a/packages/core/src/middlewares/conversation/request_conversation.ts
+++ b/packages/core/src/middlewares/conversation/request_conversation.ts
@@ -333,7 +333,7 @@ async function processUserPrompt(
 }
 
 function sortContentByType(content: MessageContentComplex[]) {
-    return content.sort((a, b) => {
+    return [...content].sort((a, b) => {
         if (a.type === b.type) return 0
         if (a.type === 'text') return -1
         if (b.type === 'text') return 1


### PR DESCRIPTION
修正用户提示格式化时复杂消息排序比较器，在同类型内容之间保持原有顺序，避免消息队列合并后的多段文本被反向发送。