### PR TITLE
[Fix] preserve agent reasoning and runtime sync state

### DIFF
--- a/packages/core/src/llm-core/agent/sub-agent.ts
+++ b/packages/core/src/llm-core/agent/sub-agent.ts
@@ -862,9 +862,15 @@ function appendTaskToolBatch(task: AgentTaskSession, steps: AgentStep[]) {
 }
 
 function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
+    const reasoning = steps[0]?.action.reasoningContent
+
     return [
         new AIMessage({
             content: '',
+            // DeepSeek-V4 thinking mode requires reasoning_content (possibly
+            // empty string) to be echoed back on every tool_call turn.
+            additional_kwargs:
+                reasoning != null ? { reasoning_content: reasoning } : {},
             tool_calls: steps.map((step) => ({
                 id: step.action.toolCallId,
                 name: step.action.tool,

--- a/packages/core/src/llm-core/memory/message/database_history.ts
+++ b/packages/core/src/llm-core/memory/message/database_history.ts
@@ -539,10 +539,10 @@ function createAgentToolMessages(steps: AgentStep[]): BaseMessage[] {
     return [
         new AIMessage({
             content: '',
+            // DeepSeek-V4 thinking mode requires reasoning_content (possibly
+            // empty string) to be echoed back on every tool_call turn.
             additional_kwargs:
-                reasoning != null && reasoning.length > 0
-                    ? { reasoning_content: reasoning }
-                    : {},
+                reasoning != null ? { reasoning_content: reasoning } : {},
             tool_calls: steps.map((step) => ({
                 id: step.action.toolCallId,
                 name: step.action.tool,

--- a/packages/extension-agent/src/skills/builtin.ts
+++ b/packages/extension-agent/src/skills/builtin.ts
@@ -62,7 +62,7 @@ export async function syncBundledSkills(ctx: Context) {
             }
         }
 
-        ctx.logger.info(
+        ctx.logger[force && current?.isFile() ? 'debug' : 'info'](
             `${force && current?.isFile() ? 'Refreshed' : 'Copied'} bundled skill '${entry.name}' to ${to}${preservedConfig ? ' (preserved config.json)' : ''}`
         )
     }

--- a/packages/extension-agent/src/utils/runtime_sync.ts
+++ b/packages/extension-agent/src/utils/runtime_sync.ts
@@ -119,6 +119,7 @@ export class ChatLunaAgentRuntimeSyncService {
         const current = this._states.get(key)
         if (current) {
             current.count += 1
+            current.context = context
             return
         }
 
@@ -158,20 +159,20 @@ export class ChatLunaAgentRuntimeSyncService {
             return
         }
 
-        this._states.delete(key)
         if (!state.dirty) {
+            this._states.delete(key)
             return
         }
 
         const agent = this.getAgent()
 
         try {
-            const session = await agent.computer
-                .getAgentSession(state.context)
-                .catch(() => undefined)
+            const session = await agent.computer.getAgentSession(state.context)
             if (session && session.backend !== 'local') {
                 await syncRuntimeSession(agent, session)
             }
+
+            this._states.delete(key)
         } catch (err) {
             this.ctx.logger.warn('Failed to flush runtime sync files', err)
         }

--- a/packages/extension-agent/src/utils/runtime_sync.ts
+++ b/packages/extension-agent/src/utils/runtime_sync.ts
@@ -3,7 +3,11 @@
 import { mkdir, readFile, writeFile } from 'fs/promises'
 import { dirname, join, posix } from 'path'
 import { CallbackManager } from '@langchain/core/callbacks/manager'
-import { type AgentRunContext } from 'koishi-plugin-chatluna/llm-core/agent'
+import {
+    type AgentCallbackEvent,
+    type AgentRunContext,
+    CHATLUNA_AGENT_EVENT
+} from 'koishi-plugin-chatluna/llm-core/agent'
 import type { ChatCallbacksProvider } from 'koishi-plugin-chatluna/services/chat'
 import { Context } from 'koishi'
 import { logger } from '..'
@@ -23,11 +27,6 @@ interface RuntimeSyncFile {
     kind: 'skill' | 'subagent'
     targetPath: string
     content: string
-}
-
-interface RuntimeSyncState {
-    count: number
-    context: AgentRunContext
 }
 
 export class ChatLunaAgentRuntimeSyncService {
@@ -92,6 +91,19 @@ export class ChatLunaAgentRuntimeSyncService {
                     }
 
                     await this.finishRun(String(runId))
+                },
+                handleCustomEvent: async (name, data, runId) => {
+                    if (name !== CHATLUNA_AGENT_EVENT || !runId) {
+                        return
+                    }
+
+                    if (
+                        isRuntimeSyncToolCall(
+                            (data as AgentCallbackEvent).event
+                        )
+                    ) {
+                        this.markDirty(String(runId))
+                    }
                 }
             })
         }
@@ -112,8 +124,21 @@ export class ChatLunaAgentRuntimeSyncService {
 
         this._states.set(key, {
             count: 1,
-            context
+            context,
+            dirty: false
         })
+    }
+
+    private markDirty(runId: string) {
+        const key = this._runs.get(runId)
+        if (!key) {
+            return
+        }
+
+        const state = this._states.get(key)
+        if (state) {
+            state.dirty = true
+        }
     }
 
     private async finishRun(runId: string) {
@@ -134,6 +159,10 @@ export class ChatLunaAgentRuntimeSyncService {
         }
 
         this._states.delete(key)
+        if (!state.dirty) {
+            return
+        }
+
         const agent = this.getAgent()
 
         try {
@@ -147,6 +176,21 @@ export class ChatLunaAgentRuntimeSyncService {
             this.ctx.logger.warn('Failed to flush runtime sync files', err)
         }
     }
+}
+
+interface RuntimeSyncState {
+    count: number
+    context: AgentRunContext
+    dirty: boolean
+}
+
+function isRuntimeSyncToolCall(event: AgentCallbackEvent['event']) {
+    return (
+        event.type === 'tool-call' &&
+        event.actions.some((item) =>
+            ['bash', 'file_write', 'file_edit'].includes(item.tool)
+        )
+    )
 }
 
 async function syncRuntimeSession(

--- a/packages/shared-adapter/src/requester.ts
+++ b/packages/shared-adapter/src/requester.ts
@@ -195,6 +195,7 @@ export async function* processStreamResponse<
     let errorCount = 0
     const reasoningState = {
         content: '',
+        seen: false,
         startedAt: Date.now(),
         endedAt: undefined as number | undefined
     }
@@ -274,12 +275,17 @@ export async function* processStreamResponse<
                 reasoningState.endedAt = Date.now()
             }
 
-            if (
-                reasoningState.endedAt == null &&
-                !hasResult &&
-                delta.reasoning_content
-            ) {
-                reasoningState.content += delta.reasoning_content
+            // DeepSeek-V4 thinking mode may emit reasoning_content === "".
+            // Track field presence so we can echo it back verbatim later.
+            if (Object.hasOwn(delta, 'reasoning_content')) {
+                reasoningState.seen = true
+                if (
+                    reasoningState.endedAt == null &&
+                    !hasResult &&
+                    typeof delta.reasoning_content === 'string'
+                ) {
+                    reasoningState.content += delta.reasoning_content
+                }
             }
 
             const messageChunk = convertDeltaToMessageChunk(
@@ -338,7 +344,7 @@ export async function* processStreamResponse<
         }
     }
 
-    if (reasoningState.content.length > 0) {
+    if (reasoningState.seen || reasoningState.content.length > 0) {
         const reasoningTime =
             (reasoningState.endedAt ?? Date.now()) - reasoningState.startedAt
 
@@ -346,6 +352,8 @@ export async function* processStreamResponse<
             message: new AIMessageChunk({
                 content: '',
                 additional_kwargs: {
+                    // Always emit the field (possibly "") so DeepSeek-V4
+                    // thinking mode receives reasoning_content back verbatim.
                     reasoning_content: reasoningState.content,
                     ...(reasoningTime != null
                         ? { reasoning_time: reasoningTime }

--- a/packages/shared-adapter/src/utils.ts
+++ b/packages/shared-adapter/src/utils.ts
@@ -501,7 +501,9 @@ export function processInterleavedThinkMessages(
             const reasoningContent = originalMessage?.additional_kwargs
                 ?.reasoning_content as string | undefined
 
-            if (reasoningContent) {
+            // DeepSeek-V4 thinking mode requires the original reasoning_content
+            // (including empty string) to be passed back. Keep "" as-is.
+            if (reasoningContent != null) {
                 return {
                     ...message,
                     reasoning_content: reasoningContent
@@ -784,7 +786,7 @@ export function convertMessageToMessageChunk(
     message: ChatCompletionResponseMessage
 ) {
     const content = message.content ?? ''
-    const reasoningContent = message.reasoning_content ?? ''
+    const reasoningContent = message.reasoning_content
 
     const role = (
         (message.role?.length ?? 0) > 0 ? message.role : 'assistant'
@@ -798,7 +800,8 @@ export function convertMessageToMessageChunk(
         reasoning_content?: string
     } = {}
 
-    if (reasoningContent.length > 0) {
+    // Preserve empty reasoning_content for DeepSeek-V4 thinking mode.
+    if (reasoningContent != null) {
         additionalKwargs.reasoning_content = reasoningContent
     }
 
@@ -853,7 +856,7 @@ export function convertDeltaToMessageChunk(
         (delta.role?.length ?? 0) > 0 ? delta.role : defaultRole
     ).toLowerCase()
     const content = delta.content ?? ''
-    const reasoningContent = delta.reasoning_content ?? ''
+    const reasoningContent = delta.reasoning_content as string | undefined
 
     let additionalKwargs: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/naming-convention
@@ -868,7 +871,8 @@ export function convertDeltaToMessageChunk(
         additionalKwargs = {}
     }
 
-    if (reasoningContent.length > 0) {
+    // Preserve empty reasoning_content for DeepSeek-V4 thinking mode.
+    if (reasoningContent != null) {
         additionalKwargs.reasoning_content = reasoningContent
     }
 


### PR DESCRIPTION
This pr preserves DeepSeek-V4 reasoning content across agent tool-call turns and avoids unnecessary runtime session sync when no mutable tool ran.

## New Features

None

## Bug fixes

- Preserve empty `reasoning_content` values in streamed and non-streamed OpenAI-compatible message conversion.
- Echo agent tool-call `reasoning_content` back through core history and sub-agent tool batches so DeepSeek-V4 thinking mode does not reject follow-up requests.
- Sync agent runtime session files only after mutating runtime tools run, avoiding stale or unnecessary writes.

## Other Changes

- Lower repeated bundled skill refresh logs from info to debug.
- Add `.chatluna/deepseek-v4-empty-reasoning-fix.md` documenting the DeepSeek-V4 empty reasoning compatibility fix.